### PR TITLE
Submit Gradle dependencies to GH dependency graph

### DIFF
--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -1,0 +1,23 @@
+name: Submit dependencies to GitHub Dependency Graph
+on:
+  push:
+    branches:
+      - trunk
+      - release/*
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Setup Gradle to generate and submit dependency graphs
+        uses: gradle/gradle-build-action@v2
+        with:
+          dependency-graph: generate-and-submit
+      - name: Generate the dependency graph which will be submitted post-job
+        run: ./gradlew :gravatar:dependencies


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions job to send Gradle/Maven dependencies to Github Dependency Graph for each push to `trunk` or `release/*` branch.

By sending those dependencies, we allow Dependabot to scan whether dependencies we use are affected by known vulnerabilities.

Soon, those metrics will be available to visualize on Apps Metrics ([link](https://metrics.a8c-ci.services/grafana/d/f2131a73-89a3-48b9-8d3b-ecc1456347ac/dependabot-security-alerts?orgId=1)).

More about this project can be found internally at paaHJt-5Tn-p2

I know `Gravatar-SDK-Android` is a small repository with not many dependencies at this point, but nevertheless I think it's worth collecting data and being informed about any security vulnerabilities as soon as possible.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
This can't really be tested without forking, and forks are disabled for this repository.

This job is used in all other Android projects in Automattic, so it should be safe to merge without testing.
