### PR TITLE
SDK - Keep parity with iOS docs

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -19,7 +19,7 @@ By adopting this Code of Conduct, project maintainers commit themselves to fairl
 
 This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing a project maintainer via support@gravatar.com, with a subject (the field labeled `Your Question`) that includes `Code of Conduct`. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing a project maintainer via support@gravatar.com, with a subject that includes `Code of Conduct`. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/][version]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,4 +42,4 @@ Note: If you are part of the org, and have the necessary permissions for the rep
 
 ### Development Practices
 
-Have look at the [Coding Style Guide](README.md#coding-style) to learn how to format your code so it passes the convention and quality checks like the rest of the project.
+Have look at the [Coding Style](README.md#coding-style) guide to learn how to format your code so it passes the convention and quality checks like the rest of the project.


### PR DESCRIPTION
Fixes: #61 

We don't have a form to report abusive behaviours, so removing the part that mentions "(the field labeled `Your Question`)"