### PR TITLE
Publish UI module to s3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,6 +42,8 @@ steps:
       ./gradlew \
       :gravatar:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
       :gravatar:publish \
+      :gravatar-ui:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
+      :gravatar-ui:publish \
       --no-configuration-cache
     plugins: [$CI_TOOLKIT]
     notify:

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           dependency-graph: generate-and-submit
       - name: Generate the dependency graph which will be submitted post-job
-        run: ./gradlew :gravatar:dependencies
+        run: ./gradlew :gravatar:dependencies :gravatar-ui:dependencies

--- a/README.md
+++ b/README.md
@@ -110,10 +110,19 @@ repositories {
     maven {
         url "https://a8c-libs.s3.amazonaws.com/android"
     }
+    // Jitpack is used to fetch the uCrop library. Required only for gravatar-ui module.
+    maven {
+        url "https://jitpack.io"
+        content {
+            includeModule("com.github.yalantis", "ucrop")
+        }
+    }
 }
 
 dependencies {
     implementation ("com.gravatar:gravatar:<version>")
+    // OR
+    implementation ("com.gravatar:gravatar-ui:<version>")
 }
 ```
 

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("com.automattic.android.publish-to-s3")
 
     // Ktlint
     id("org.jlleitschuh.gradle.ktlint")
@@ -81,4 +82,18 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.2")
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("maven") {
+                from(components["release"])
+
+                groupId = "com.gravatar"
+                artifactId = "gravatar-ui"
+                // version is set by `publish-to-s3` plugin
+            }
+        }
+    }
 }


### PR DESCRIPTION
Addresses internal request: pdnsEh-1zk-p2

### Description
This PR adds support for publishing `gravatar-ui` module to A8c S3 instance.

### Testing Steps
Please add the dependency like

```groovy
implementation "com.gravatar:gravatar-ui:publish_ui_module_to_s3-99776fa2138c98c46ce5b61f2157192a1b9bbb08`
```

in an external Gradle build and verify that UI classes are available.