### PR TITLE
Replace Uri by java.net.URL in the core module

### DIFF
--- a/app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -268,7 +268,7 @@ private fun AvatarTab(
                                     forceDefaultAvatar = if (settingsState.forceDefaultAvatar) true else null,
                                     rating = if (settingsState.imageRatingEnabled) settingsState.imageRating else null,
                                 ),
-                            ).uri().toString(),
+                            ).url().toString(),
                         )
                     } catch (e: Exception) {
                         onError(null, e.fillInStackTrace())

--- a/app/src/main/java/com/gravatar/demoapp/ui/components/ProfileCard.kt
+++ b/app/src/main/java/com/gravatar/demoapp/ui/components/ProfileCard.kt
@@ -45,7 +45,7 @@ fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier, avatarImage
                         avatarImageSize.toPx().toInt()
                     },
                 ),
-            ).uri().toString(),
+            ).url().toString(),
             contentDescription = "User profile image",
             modifier = Modifier
                 .clip(CircleShape)

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -92,11 +92,14 @@ public class AvatarUrl {
         } ?: false
     }
 
-    public fun url(): URL {
-        return URL(
-            canonicalUrl.protocol,
-            canonicalUrl.host,
-            canonicalUrl.path.plus(queryParameters(avatarQueryOptions)),
-        )
-    }
+    /**
+     * Get the Avatar URL including query parameters.
+     *
+     * @return URL
+     */
+    public fun url(): URL = URL(
+        canonicalUrl.protocol,
+        canonicalUrl.host,
+        canonicalUrl.path.plus(queryParameters(avatarQueryOptions)),
+    )
 }

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -1,48 +1,48 @@
 package com.gravatar
 
-import android.net.Uri
 import com.gravatar.GravatarConstants.GRAVATAR_WWW_BASE_HOST
 import com.gravatar.types.Email
 import com.gravatar.types.Hash
+import java.net.URL
+import java.net.URLEncoder
 import java.util.Locale
 
 /**
  * Gravatar avatar URL.
  */
 public class AvatarUrl {
-    public val canonicalUrl: Uri
+    public val canonicalUrl: URL
     public val hash: Hash
     public var avatarQueryOptions: AvatarQueryOptions? = null
 
     public companion object {
-        internal fun hashFromUrl(url: Uri): Hash {
-            return Hash(url.pathSegments.last())
+        internal fun hashFromUrl(url: URL): Hash {
+            val hashPart = url.path?.substringAfterLast('/')
+            require(!hashPart.isNullOrEmpty()) { "Invalid Gravatar URL: $url" }
+            return Hash(hashPart)
         }
 
-        internal fun dropQueryParams(uri: Uri): Uri {
-            return Uri.Builder()
-                .scheme(uri.scheme)
-                .authority(uri.host)
-                .appendEncodedPath(uri.pathSegments.joinToString("/"))
-                .build()
+        internal fun dropQueryParams(url: URL): URL {
+            // Only keep the protocol, host and path
+            return URL(url.protocol, url.host, url.path)
         }
     }
 
-    private fun Uri.Builder.appendGravatarQueryParameters(avatarQueryOptions: AvatarQueryOptions?): Uri.Builder {
-        return this.apply {
-            avatarQueryOptions?.defaultAvatarOption?.let {
-                appendQueryParameter("d", it.queryParam())
-            } // eg. default monster, "d=monsterid"
-            avatarQueryOptions?.preferredSize?.let {
-                appendQueryParameter("s", it.toString())
-            } // eg. size 42, "s=42"
-            avatarQueryOptions?.rating?.let {
-                appendQueryParameter("r", it.rating)
-            } // eg. rated pg, "r=pg"
-            avatarQueryOptions?.forceDefaultAvatar?.let {
-                appendQueryParameter("f", if (it) "y" else "n")
-            } // eg. force yes, "f=y"
-        }
+    private fun queryParameters(avatarQueryOptions: AvatarQueryOptions?): String {
+        var queryList = mutableListOf<String>()
+        avatarQueryOptions?.defaultAvatarOption?.let {
+            queryList.add("d=${URLEncoder.encode(it.queryParam(), "UTF-8")}")
+        } // eg. default monster, "d=monsterid"
+        avatarQueryOptions?.preferredSize?.let {
+            queryList.add("s=$it")
+        } // eg. size 42, "s=42"
+        avatarQueryOptions?.rating?.let {
+            queryList.add("r=${it.rating}")
+        } // eg. rated pg, "r=pg"
+        avatarQueryOptions?.forceDefaultAvatar?.let {
+            queryList.add("f=${if (it) "y" else "n"}")
+        } // eg. force yes, "f=y"
+        return if (queryList.isEmpty()) "" else queryList.joinToString("&", "?")
     }
 
     /**
@@ -53,12 +53,7 @@ public class AvatarUrl {
     public constructor(hash: Hash, avatarQueryOptions: AvatarQueryOptions? = null) {
         this.hash = hash
         this.avatarQueryOptions = avatarQueryOptions
-        this.canonicalUrl = Uri.Builder()
-            .scheme("https")
-            .authority(GRAVATAR_WWW_BASE_HOST)
-            .appendPath("avatar")
-            .appendPath(hash.toString())
-            .build()
+        this.canonicalUrl = URL("https", GRAVATAR_WWW_BASE_HOST, "/avatar/$hash")
     }
 
     /**
@@ -74,13 +69,14 @@ public class AvatarUrl {
     /**
      * Create an avatar URL from an existing Gravatar URL.
      *
-     * @param uri Gravatar URL
+     * @param url Gravatar URL
+     * @param avatarQueryOptions Avatar query options
      */
-    public constructor(uri: Uri, avatarQueryOptions: AvatarQueryOptions? = null) {
-        this.hash = hashFromUrl(uri)
+    public constructor(url: URL, avatarQueryOptions: AvatarQueryOptions? = null) {
+        this.hash = hashFromUrl(url)
         // Force the removal of query parameters as we can't be sure they are valid and won't interfere with
         // the new query parameters
-        this.canonicalUrl = dropQueryParams(uri)
+        this.canonicalUrl = dropQueryParams(url)
         this.avatarQueryOptions = avatarQueryOptions
         require(isAvatarUrl())
     }
@@ -96,7 +92,11 @@ public class AvatarUrl {
         } ?: false
     }
 
-    public fun uri(): Uri {
-        return canonicalUrl.buildUpon().appendGravatarQueryParameters(avatarQueryOptions).build()
+    public fun url(): URL {
+        return URL(
+            canonicalUrl.protocol,
+            canonicalUrl.host,
+            canonicalUrl.path.plus(queryParameters(avatarQueryOptions)),
+        )
     }
 }

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -29,7 +29,7 @@ public class AvatarUrl {
     }
 
     private fun queryParameters(avatarQueryOptions: AvatarQueryOptions?): String {
-        var queryList = mutableListOf<String>()
+        val queryList = mutableListOf<String>()
         avatarQueryOptions?.defaultAvatarOption?.let {
             queryList.add("d=${URLEncoder.encode(it.queryParam(), "UTF-8")}")
         } // eg. default monster, "d=monsterid"

--- a/gravatar/src/main/java/com/gravatar/ProfileUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/ProfileUrl.kt
@@ -1,15 +1,11 @@
 package com.gravatar
 
-import android.net.Uri
 import com.gravatar.types.Email
 import com.gravatar.types.Hash
+import java.net.URL
 
 public class ProfileUrl(public val hash: Hash) {
-    public val url: Uri = Uri.Builder()
-        .scheme("https")
-        .authority(GravatarConstants.GRAVATAR_BASE_HOST)
-        .appendPath(hash.toString())
-        .build()
+    public val url: URL = URL("https", GravatarConstants.GRAVATAR_BASE_HOST, hash.toString())
 
     public constructor(email: Email) : this(email.hash())
 

--- a/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
+++ b/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
@@ -250,7 +250,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `Force default avatar false must generate f=n`() {
+    fun `force default avatar false must generate f=n`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?f=n",

--- a/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
+++ b/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
@@ -18,7 +18,7 @@ import java.net.URL
 @RunWith(RobolectricTestRunner::class)
 class AvatarUrlTest {
     @Test
-    fun `emailAddressToGravatarUrl must not add any query param if not set`() {
+    fun `AvatarUrl created via an email address must not add any query param if not set`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66",
             AvatarUrl(Email("example@example.com")).url().toString(),
@@ -26,7 +26,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `emailAddressToGravatarUrl must set the size but no other query param if not set`() {
+    fun `AvatarUrl created via an email address must set the size but no other query param if not set`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?s=1000",
@@ -35,7 +35,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `emailAddressToGravatarUrl must add default avatar but no other query param if not set`() {
+    fun `AvatarUrl created via an email address must add default avatar but no other query param if not set`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?d=monsterid",
@@ -47,7 +47,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `emailAddressToGravatarUri must add size and default avatar query params`() {
+    fun `AvatarUrl created via an email address must add size and default avatar query params`() {
         assertEquals(
             URL(
                 "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
@@ -58,7 +58,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `emailAddressToGravatarUrl must add all supported parameters`() {
+    fun `AvatarUrl created via an email address must add all supported parameters`() {
         assertEquals(
             URL(
                 "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
@@ -69,7 +69,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `rewrite gravatar url must replace size and default`() {
+    fun `AvatarUrl created via an URL must replace size and default`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66",
             AvatarUrl(
@@ -82,7 +82,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `rewrite gravatar url must add all supported parameters`() {
+    fun `AvatarUrl created via an URL must add all supported parameters`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?d=identicon&s=42&r=pg&f=y",
@@ -102,7 +102,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `rewrite gravatar url must remove size and default if no parameter given`() {
+    fun `AvatarUrl created via an URL must remove size and default if no parameter given`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66",
             AvatarUrl(
@@ -115,7 +115,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `keep url scheme on gravatar urls and drop parameters`() {
+    fun `AvatarUrl created via an URL must keep gravatar host and path but drop parameters`() {
         assertEquals(
             "http://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66",
             AvatarUrl(
@@ -143,7 +143,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `keep host on 1 dot gravatar dot com urls and set parameters`() {
+    fun `AvatarUrl created via an URL must keep gravatar host and set parameters`() {
         assertEquals(
             "https://1.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?d=identicon&s=42",
@@ -158,7 +158,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `rewrite gravatar url fails on a non gravatar URL`() {
+    fun `AvatarUrl created via an URL fails on a non gravatar URL`() {
         assertThrows(IllegalArgumentException::class.java) {
             AvatarUrl(
                 URL(
@@ -169,7 +169,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `rewrite gravatar url fails on a non gravatar hash URL`() {
+    fun `AvatarUrl created via an URL fails on a non gravatar hash URL`() {
         assertThrows(IllegalArgumentException::class.java) {
             AvatarUrl(
                 URL(
@@ -236,7 +236,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `emailAddressToGravatarUrl supports custom url and encode them`() {
+    fun `AvatarUrl created via an email address supports custom url and encode them`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?d=https%3A%2F%2Fexample.com%2F%3Fencoded%3Dtrue%26please%3Dyes",
@@ -250,7 +250,7 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `Force default avatar false generate f=n`() {
+    fun `Force default avatar false must generate f=n`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?f=n",

--- a/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
+++ b/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
@@ -1,6 +1,5 @@
 package com.gravatar
 
-import android.net.Uri
 import com.gravatar.DefaultAvatarOption.CustomUrl
 import com.gravatar.DefaultAvatarOption.Identicon
 import com.gravatar.DefaultAvatarOption.MonsterId
@@ -14,6 +13,7 @@ import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.net.URL
 
 @RunWith(RobolectricTestRunner::class)
 class AvatarUrlTest {
@@ -21,7 +21,7 @@ class AvatarUrlTest {
     fun `emailAddressToGravatarUrl must not add any query param if not set`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66",
-            AvatarUrl(Email("example@example.com")).uri().toString(),
+            AvatarUrl(Email("example@example.com")).url().toString(),
         )
     }
 
@@ -30,7 +30,7 @@ class AvatarUrlTest {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?s=1000",
-            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(preferredSize = 1000)).uri().toString(),
+            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(preferredSize = 1000)).url().toString(),
         )
     }
 
@@ -42,29 +42,29 @@ class AvatarUrlTest {
             AvatarUrl(
                 Email("example@example.com"),
                 AvatarQueryOptions(defaultAvatarOption = MonsterId),
-            ).uri().toString(),
+            ).url().toString(),
         )
     }
 
     @Test
     fun `emailAddressToGravatarUri must add size and default avatar query params`() {
         assertEquals(
-            Uri.parse(
+            URL(
                 "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                     "970a1e66?d=identicon&s=42",
             ),
-            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(42, Identicon)).uri(),
+            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(42, Identicon)).url(),
         )
     }
 
     @Test
     fun `emailAddressToGravatarUrl must add all supported parameters`() {
         assertEquals(
-            Uri.parse(
+            URL(
                 "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                     "970a1e66?d=robohash&s=42&r=x&f=y",
             ),
-            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(42, RoboHash, X, true)).uri(),
+            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(42, RoboHash, X, true)).url(),
         )
     }
 
@@ -73,11 +73,11 @@ class AvatarUrlTest {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66",
             AvatarUrl(
-                Uri.parse(
+                URL(
                     "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66?d=identicon&s=42",
                 ),
-            ).uri().toString(),
+            ).url().toString(),
         )
     }
 
@@ -87,7 +87,7 @@ class AvatarUrlTest {
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?d=identicon&s=42&r=pg&f=y",
             AvatarUrl(
-                Uri.parse(
+                URL(
                     "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66",
                 ),
@@ -97,7 +97,7 @@ class AvatarUrlTest {
                     ParentalGuidance,
                     true,
                 ),
-            ).uri().toString(),
+            ).url().toString(),
         )
     }
 
@@ -106,11 +106,11 @@ class AvatarUrlTest {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66",
             AvatarUrl(
-                Uri.parse(
+                URL(
                     "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66?d=identicon&s=42",
                 ),
-            ).uri().toString(),
+            ).url().toString(),
         )
     }
 
@@ -119,11 +119,11 @@ class AvatarUrlTest {
         assertEquals(
             "http://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66",
             AvatarUrl(
-                Uri.parse(
+                URL(
                     "http://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66?d=identicon",
                 ),
-            ).uri().toString(),
+            ).url().toString(),
         )
     }
 
@@ -133,12 +133,12 @@ class AvatarUrlTest {
             "https://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?d=identicon&s=42",
             AvatarUrl(
-                Uri.parse(
+                URL(
                     "https://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66?d=identicon&s=42",
                 ),
                 AvatarQueryOptions(42, Identicon),
-            ).uri().toString(),
+            ).url().toString(),
         )
     }
 
@@ -148,12 +148,12 @@ class AvatarUrlTest {
             "https://1.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?d=identicon&s=42",
             AvatarUrl(
-                Uri.parse(
+                URL(
                     "https://1.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66?d=identicon&s=42",
                 ),
                 AvatarQueryOptions(42, Identicon),
-            ).uri().toString(),
+            ).url().toString(),
         )
     }
 
@@ -161,8 +161,19 @@ class AvatarUrlTest {
     fun `rewrite gravatar url fails on a non gravatar URL`() {
         assertThrows(IllegalArgumentException::class.java) {
             AvatarUrl(
-                Uri.parse(
+                URL(
                     "https://example.com/avatar/oiresntioes",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `rewrite gravatar url fails on a non gravatar hash URL`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            AvatarUrl(
+                URL(
+                    "https://gravatar.com/",
                 ),
             )
         }
@@ -234,7 +245,19 @@ class AvatarUrlTest {
                 AvatarQueryOptions(
                     defaultAvatarOption = CustomUrl("https://example.com/?encoded=true&please=yes"),
                 ),
-            ).uri().toString(),
+            ).url().toString(),
+        )
+    }
+
+    @Test
+    fun `Force default avatar false generate f=n`() {
+        assertEquals(
+            "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
+                "?f=n",
+            AvatarUrl(
+                Email("example@example.com"),
+                AvatarQueryOptions(forceDefaultAvatar = false),
+            ).url().toString(),
         )
     }
 }


### PR DESCRIPTION
Closes #73 

### Description

- I removed all references to `android.net.Uri` and replaced them by `java.net.URL`.
- I updated the tests and added a couple more (one to check for the `f=n` query parameter and another one to check that the AvatarUrl created with an URL has a non-empty hash path).
- Note: I only URL encoded the default avatar, as this is the only one to have user generated inputs

### Testing Steps

- [ ] Check that the updated tests are correct and run them
- [ ] Run the demo app
