### PR TITLE
Fix #80: add extension methods to userprofile

### DIFF
--- a/app/src/main/java/com/gravatar/demoapp/ui/components/ProfileCard.kt
+++ b/app/src/main/java/com/gravatar/demoapp/ui/components/ProfileCard.kt
@@ -29,7 +29,7 @@ import com.gravatar.AvatarQueryOptions
 import com.gravatar.AvatarUrl
 import com.gravatar.api.models.Email
 import com.gravatar.api.models.UserProfile
-import com.gravatar.types.Hash
+import com.gravatar.extensions.hash
 
 @Composable
 fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier, avatarImageSize: Dp = 128.dp) {
@@ -39,7 +39,7 @@ fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier, avatarImage
     ) {
         AsyncImage(
             AvatarUrl(
-                Hash(profile.hash),
+                profile.hash(),
                 AvatarQueryOptions(
                     preferredSize = with(LocalDensity.current) {
                         avatarImageSize.toPx().toInt()

--- a/gravatar/src/main/java/com/gravatar/extensions/UserProfileExtensions.kt
+++ b/gravatar/src/main/java/com/gravatar/extensions/UserProfileExtensions.kt
@@ -1,5 +1,6 @@
 package com.gravatar.extensions
 
+import com.gravatar.AvatarQueryOptions
 import com.gravatar.AvatarUrl
 import com.gravatar.ProfileUrl
 import com.gravatar.api.models.UserProfile
@@ -15,8 +16,8 @@ public fun UserProfile.hash(): Hash {
 /**
  * Get the avatar URL for a user profile.
  */
-public fun UserProfile.avatarUrl(): AvatarUrl {
-    return AvatarUrl(this.hash())
+public fun UserProfile.avatarUrl(avatarQueryOptions: AvatarQueryOptions? = null): AvatarUrl {
+    return AvatarUrl(this.hash(), avatarQueryOptions)
 }
 
 /**

--- a/gravatar/src/main/java/com/gravatar/extensions/UserProfileExtensions.kt
+++ b/gravatar/src/main/java/com/gravatar/extensions/UserProfileExtensions.kt
@@ -1,0 +1,27 @@
+package com.gravatar.extensions
+
+import com.gravatar.AvatarUrl
+import com.gravatar.ProfileUrl
+import com.gravatar.api.models.UserProfile
+import com.gravatar.types.Hash
+
+/**
+ * Get the hash for a user profile.
+ */
+public fun UserProfile.hash(): Hash {
+    return Hash(this.hash)
+}
+
+/**
+ * Get the avatar URL for a user profile.
+ */
+public fun UserProfile.avatarUrl(): AvatarUrl {
+    return AvatarUrl(this.hash())
+}
+
+/**
+ * Get the profile URL for a user profile.
+ */
+public fun UserProfile.profileUrl(): ProfileUrl {
+    return ProfileUrl(this.hash())
+}


### PR DESCRIPTION
Closes #80

### Description

- Add extension methods to UserProfile models: let users get the Hash, AvatarUrl, ProfileUrl
- Update the demo app to use the `.hash()` method

We will add more methods later when we add more details to the OpenAPI specs.
