### PR TITLE
Forcing a concrete version of "jackson-core"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,11 @@ plugins {
 buildscript {
     dependencies {
         classpath("org.jetbrains.dokka:dokka-base:1.9.20")
+
+        /**
+         * Forcing the use of Jackson Core to avoid a conflict between the version used by Dokka and the one used by OpenAPI Generator.
+         */
+        classpath("com.fasterxml.jackson.core:jackson-core:2.15.3")
     }
 }
 


### PR DESCRIPTION
Closes #85 

### Description

There is a conflict between the Jackson Core versions used by Dokka and the OpenAPI Generator. Forcing the last version to avoid that issue.

> Note: we should run OpenAPI generation in CI just to check generation works fine.

I'm not completely sure which is the best place to add. Buildkite? GitHub Actions? 
Maybe we can wait until we improve the REST API part and think about the best approach for the code generation. Wdyt?

### Testing Steps

- Clone the branch
- Execute and verify that works: `./gradlew :gravatar:openApiGenerate`
- Execute and verify that works: `./gradlew dokkaHtmlMultiModule`

