### PR TITLE
Enable Detekt rules to detect undocumented public classes, methods or properties

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -57,3 +57,8 @@ comments:
       - 'Preview'
     excludes: [ '**/test/**', '**/androidTest/**', '**/demoapp/**' ]
     searchProtectedFunction: false
+  UndocumentedPublicProperty:
+    active: true
+    # TODO - Remove the explicit exclusion of Email.kt once we implement the new REST API
+    excludes: [ '**/test/**', '**/androidTest/**', '**/demoapp/**', '**/models/Email.kt' ]
+    searchProtectedProperty: false

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -50,3 +50,10 @@ comments:
     searchInInnerObject: true
     searchInInnerInterface: true
     searchInProtectedClass: false
+  UndocumentedPublicFunction:
+    active: true
+    # Ignore Jetpack Compose functions annotated with @Preview
+    ignoreAnnotated:
+      - 'Preview'
+    excludes: [ '**/test/**', '**/androidTest/**', '**/demoapp/**' ]
+    searchProtectedFunction: false

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -40,3 +40,13 @@ style:
   WildcardImport:
     active: true
     excludeImports: []
+
+comments:
+  UndocumentedPublicClass:
+    active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/demoapp/**' ]
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+    searchInProtectedClass: false

--- a/gravatar-ui/src/main/java/com/gravatar/ui/GravatarImagePickerWrapper.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/GravatarImagePickerWrapper.kt
@@ -106,6 +106,13 @@ public interface GravatarImagePickerWrapperListener : GravatarListener<Unit> {
     public fun onAvatarUploadStarted()
 }
 
+/**
+ * Options to customize the image edition screen.
+ *
+ * @param statusBarColor The color of the status bar.
+ * @param toolbarColor The color of the toolbar.
+ * @param toolbarWidgetColor The color of the toolbar widgets.
+ */
 public data class ImageEditionStyling(
     val statusBarColor: Int? = null,
     val toolbarColor: Int? = null,

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileCard.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileCard.kt
@@ -29,6 +29,10 @@ import com.gravatar.ui.components.atomic.SocialIconRow
 import com.gravatar.ui.components.atomic.UserInfo
 import com.gravatar.ui.components.atomic.ViewProfileButton
 
+/**
+ * [ProfileCard] is a composable that displays a user's profile card.
+ * Given a [UserProfile], it displays a [ProfileCard] using the other atomic components provided within the SDK.
+ */
 @Composable
 fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
     Column(

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
@@ -5,6 +5,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.UserProfile
 
+/**
+ * [AboutMe] is a composable that displays a user's about me description.
+ */
 @Composable
 public fun AboutMe(profile: UserProfile, modifier: Modifier = Modifier, maxLines: Int = 2) {
     ExpandableText(profile.aboutMe.orEmpty(), modifier, maxLines)

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -12,6 +12,9 @@ import com.gravatar.AvatarQueryOptions
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.avatarUrl
 
+/**
+ * [Avatar] is a composable that displays a user's avatar.
+ */
 @Composable
 public fun Avatar(
     profile: UserProfile,

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
@@ -5,6 +5,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.gravatar.api.models.UserProfile
 
+/**
+ * [DisplayName] is a composable that displays the user's display name.
+ */
 @Composable
 public fun DisplayName(profile: UserProfile, modifier: Modifier = Modifier) {
     Text(text = profile.displayName.orEmpty(), modifier = modifier)

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -23,6 +23,9 @@ import com.gravatar.ui.R
 import java.net.MalformedURLException
 import java.net.URL
 
+/**
+ * LocalIcon is a predefined list of social media icons that can be used in the SocialIcon composable.
+ */
 public enum class LocalIcon(val shortname: String, val imageResource: Int) {
     Gravatar("gravatar", R.drawable.gravatar_icon),
     Calendly("calendly", R.drawable.calendly_icon),
@@ -50,6 +53,9 @@ public enum class LocalIcon(val shortname: String, val imageResource: Int) {
     }
 }
 
+/**
+ * SocialMedia is a data class that represents a social media account that Gravatar users can add to their profiles.
+ */
 public class SocialMedia(val url: URL, val name: String, val iconUrl: URL? = null, val icon: LocalIcon? = null)
 
 public fun mediaList(profile: UserProfile): List<SocialMedia> {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -1,5 +1,6 @@
 package com.gravatar.ui.components.atomic
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -25,8 +26,14 @@ import java.net.URL
 
 /**
  * LocalIcon is a predefined list of social media icons that can be used in the SocialIcon composable.
+ *
+ * @property shortname The shortname of the social media platform.
+ * @property imageResource The drawable resource ID of the icon.
  */
-public enum class LocalIcon(val shortname: String, val imageResource: Int) {
+public enum class LocalIcon(
+    val shortname: String,
+    @DrawableRes val imageResource: Int,
+) {
     Gravatar("gravatar", R.drawable.gravatar_icon),
     Calendly("calendly", R.drawable.calendly_icon),
     Fediverse("fediverse", R.drawable.fediverse_icon),
@@ -58,6 +65,11 @@ public enum class LocalIcon(val shortname: String, val imageResource: Int) {
 
 /**
  * SocialMedia is a data class that represents a social media account that Gravatar users can add to their profiles.
+ *
+ * @property url The [URL] of the social media account.
+ * @property name The name of the social media platform.
+ * @property iconUrl The [URL] of the icon for the social media platform.
+ * @property icon The [LocalIcon] for the social media platform.
  */
 public class SocialMedia(val url: URL, val name: String, val iconUrl: URL? = null, val icon: LocalIcon? = null)
 

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -47,6 +47,9 @@ public enum class LocalIcon(val shortname: String, val imageResource: Int) {
     companion object {
         private val shortnames = entries.associateBy { it.shortname }
 
+        /**
+         * Returns the LocalIcon enum value for the given shortname.
+         */
         public fun valueOf(shortname: String?): LocalIcon? {
             return shortnames[shortname]
         }
@@ -58,7 +61,7 @@ public enum class LocalIcon(val shortname: String, val imageResource: Int) {
  */
 public class SocialMedia(val url: URL, val name: String, val iconUrl: URL? = null, val icon: LocalIcon? = null)
 
-public fun mediaList(profile: UserProfile): List<SocialMedia> {
+private fun mediaList(profile: UserProfile): List<SocialMedia> {
     val mediaList = mutableListOf<SocialMedia>()
     // Force the Gravatar icon
     mediaList.add(SocialMedia(profile.profileUrl().url, LocalIcon.Gravatar.name, icon = LocalIcon.Gravatar))
@@ -79,6 +82,10 @@ public fun mediaList(profile: UserProfile): List<SocialMedia> {
     return mediaList
 }
 
+/**
+ * [SocialIcon] is a composable that displays a clickable icon for a social media account.
+ * The link will navigate to the Gravatar user's profile on the social media platform.
+ */
 @Composable
 fun SocialIcon(media: SocialMedia, modifier: Modifier = Modifier) {
     val uriHandler = LocalUriHandler.current
@@ -108,6 +115,9 @@ fun SocialIcon(media: SocialMedia, modifier: Modifier = Modifier) {
     }
 }
 
+/**
+ * [SocialIconRow] is a composable that displays a row of clickable [SocialIcon].
+ */
 @Composable
 fun SocialIconRow(socialMedia: List<SocialMedia>, modifier: Modifier = Modifier, maxIcons: Int = 4) {
     Row(modifier = modifier) {
@@ -117,6 +127,9 @@ fun SocialIconRow(socialMedia: List<SocialMedia>, modifier: Modifier = Modifier,
     }
 }
 
+/**
+ * [SocialIconRow] is a composable that displays a row of clickable [SocialIcon].
+ */
 @Composable
 fun SocialIconRow(profile: UserProfile, modifier: Modifier = Modifier, maxIcons: Int = 4) {
     SocialIconRow(mediaList(profile), modifier, maxIcons)

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
@@ -6,6 +6,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.formattedUserInfo
 
+/**
+ * [UserInfo] is a composable that displays a user's information in a formatted way.
+ * The user's information includes their company, job title, pronunciation, pronouns, and current
+ * location when available.
+ */
 @Composable
 public fun UserInfo(profile: UserProfile, modifier: Modifier = Modifier, maxLines: Int = 2) {
     // TODO this doesn't work with one Text field due. If the job_title and the company line is too long,

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
@@ -27,6 +27,9 @@ import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.profileUrl
 import com.gravatar.ui.R
 
+/**
+ * ViewProfileButton is a composable that displays a button to view a user's profile.
+ */
 @Composable
 public fun ViewProfileButton(profile: UserProfile, modifier: Modifier = Modifier) {
     val uriHandler = LocalUriHandler.current

--- a/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
@@ -3,10 +3,10 @@ package com.gravatar
 /**
  * Data class that represents the query options for an avatar.
  *
- * @param size Size of the avatar, must be between 1 and 2048. Optional: default to 80
+ * @param preferredSize Size of the avatar, must be between 1 and 2048. Optional: default to 80
  * @param defaultAvatarOption Default avatar image. Optional: default to Gravatar logo
  * @param rating Image rating. Optional: default to General, suitable for display on all websites with any audience
- * @param forceDefaultAvatarImage Force default avatar image. Optional: default to false
+ * @param forceDefaultAvatar Force default avatar image. Optional: default to false
  */
 public data class AvatarQueryOptions(
     public val preferredSize: Int? = null,

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -92,6 +92,11 @@ public class AvatarUrl {
         } ?: false
     }
 
+    /**
+     * Get the [URL] for the avatar.
+     *
+     * @return [URL] for the avatar
+     */
     public fun url(): URL {
         return URL(
             canonicalUrl.protocol,

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -9,6 +9,10 @@ import java.util.Locale
 
 /**
  * Gravatar avatar URL.
+ *
+ * @property canonicalUrl Canonical URL of the avatar
+ * @property hash Gravatar hash
+ * @property avatarQueryOptions Avatar query options
  */
 public class AvatarUrl {
     public val canonicalUrl: URL

--- a/gravatar/src/main/java/com/gravatar/DefaultAvatarOption.kt
+++ b/gravatar/src/main/java/com/gravatar/DefaultAvatarOption.kt
@@ -6,6 +6,7 @@ package com.gravatar
 public sealed class DefaultAvatarOption {
     /**
      * @suppress
+     * @property style the style of the default avatar image
      */
     public abstract class Predefined(public val style: String) : DefaultAvatarOption()
 

--- a/gravatar/src/main/java/com/gravatar/ImageRating.kt
+++ b/gravatar/src/main/java/com/gravatar/ImageRating.kt
@@ -4,6 +4,8 @@ package com.gravatar
  * Gravatar allows users to self-rate their images so that they can indicate if an image is appropriate
  * for a certain audience. By default, only ‘General’ rated images are displayed unless you indicate that
  * you would like to see higher ratings.
+ *
+ * @property rating The rating to be used in the Gravatar URL.
  */
 public enum class ImageRating(public val rating: String) {
     /** Suitable for display on all websites with any audience type. */

--- a/gravatar/src/main/java/com/gravatar/ProfileUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/ProfileUrl.kt
@@ -4,6 +4,11 @@ import com.gravatar.types.Email
 import com.gravatar.types.Hash
 import java.net.URL
 
+/**
+ * Represents a Gravatar profile URL.
+ *
+ * @property hash The hash of the email address.
+ */
 public class ProfileUrl(public val hash: Hash) {
     public val url: URL = URL("https", GravatarConstants.GRAVATAR_BASE_HOST, hash.toString())
 

--- a/gravatar/src/main/java/com/gravatar/ProfileUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/ProfileUrl.kt
@@ -14,6 +14,11 @@ public class ProfileUrl(public val hash: Hash) {
 
     public constructor(email: Email) : this(email.hash())
 
+    /**
+     * Get the [AvatarUrl] for the represented profile.
+     *
+     * @return the [AvatarUrl] of the avatar image
+     */
     public fun avatarUrl(): AvatarUrl {
         return AvatarUrl(hash)
     }

--- a/gravatar/src/main/java/com/gravatar/ProfileUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/ProfileUrl.kt
@@ -10,6 +10,9 @@ import java.net.URL
  * @property hash The hash of the email address.
  */
 public class ProfileUrl(public val hash: Hash) {
+    /**
+     * The URL of the profile.
+     */
     public val url: URL = URL("https", GravatarConstants.GRAVATAR_BASE_HOST, hash.toString())
 
     public constructor(email: Email) : this(email.hash())

--- a/gravatar/src/main/java/com/gravatar/types/Email.kt
+++ b/gravatar/src/main/java/com/gravatar/types/Email.kt
@@ -1,5 +1,10 @@
 package com.gravatar.types
 
+/**
+ * Email address representation.
+ *
+ * @property address the email address
+ */
 public class Email(private val address: String) {
     /**
      * Get a Gravatar hash for a given email address.


### PR DESCRIPTION
Closes #67 

### Description

To ensure that the libraries are properly documented, we can enable some Detekt rules like:

[UndocumentedPublicClass](https://detekt.dev/docs/rules/comments/#undocumentedpublicclass)
[UndocumentedPublicFunction](https://detekt.dev/docs/rules/comments/#undocumentedpublicfunction)
[UndocumentedPublicProperty](https://detekt.dev/docs/rules/comments/#undocumentedpublicproperty)

We don't need to apply those rules to the demo-app.

### Testing Steps

**UndocumentedPublicClass**: Remove the documentation for a public class in the library ([Example](https://github.com/Automattic/Gravatar-SDK-Android/blob/dc7fae55000f3e412f219f228c1c585d1c222646/gravatar-ui/src/main/java/com/gravatar/ui/GravatarImagePickerWrapper.kt)) and execute `./gradlew detekt`. 
- [ ] Verify you receive an error

**UndocumentedPublicFunction**: Remove the documentation from a public method ([Example](https://github.com/Automattic/Gravatar-SDK-Android/blob/dc7fae55000f3e412f219f228c1c585d1c222646/gravatar/src/main/java/com/gravatar/ProfileUrl.kt#L20)) and execute `./gradlew detekt`. 
- [ ] Verify you receive an error

**UndocumentedPublicProperty**: Remove the documentation from a public property ([Example](https://github.com/Automattic/Gravatar-SDK-Android/blob/dc7fae55000f3e412f219f228c1c585d1c222646/gravatar/src/main/java/com/gravatar/ProfileUrl.kt#L10) and execute `./gradlew detekt`. 
- [ ] Verify you receive an error