### PR TITLE
Let dev pass a default email to the local.properties file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,8 @@ buildscript {
         classpath("org.jetbrains.dokka:dokka-base:1.9.20")
 
         /**
-         * Forcing the use of Jackson Core to avoid a conflict between the version used by Dokka and the one used by OpenAPI Generator.
+         * Forcing the use of Jackson Core to avoid a conflict between the version used by
+         * Dokka and the one used by OpenAPI Generator.
          */
         classpath("com.fasterxml.jackson.core:jackson-core:2.15.3")
     }

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -9,9 +12,19 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
 }
 
+fun localProperties(): Properties {
+    val localProperties = Properties()
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localProperties.load(FileInputStream(localPropertiesFile))
+    }
+    return localProperties
+}
+
 android {
     namespace = "com.gravatar"
     compileSdk = 34
+    buildFeatures.buildConfig = true
 
     defaultConfig {
         applicationId = "com.gravatar.demoapp"
@@ -21,6 +34,14 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        localProperties().let { properties ->
+            buildConfigField(
+                "String",
+                "DEMO_EMAIL",
+                "\"${properties["demo-app.email"]?.toString() ?: "gravatar@automattic.com"}\"",
+            )
+        }
     }
 
     buildTypes {

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.gravatar.BuildConfig
 import com.gravatar.R
 import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.demoapp.ui.components.GravatarPasswordInput
@@ -33,7 +34,7 @@ import com.gravatar.ui.GravatarImagePickerWrapperListener
 
 @Composable
 fun AvatarUpdateTab(showSnackBar: (String?, Throwable?) -> Unit, modifier: Modifier = Modifier) {
-    var email by remember { mutableStateOf("gravatar@automattic.com") }
+    var email by remember { mutableStateOf(BuildConfig.DEMO_EMAIL) }
     var accessToken by remember { mutableStateOf("") }
     var accessTokenVisible by rememberSaveable { mutableStateOf(false) }
     var isUploading by remember { mutableStateOf(false) }

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -43,6 +43,7 @@ import coil.request.ImageRequest
 import coil.size.Size
 import com.gravatar.AvatarQueryOptions
 import com.gravatar.AvatarUrl
+import com.gravatar.BuildConfig
 import com.gravatar.DefaultAvatarOption
 import com.gravatar.ImageRating
 import com.gravatar.R
@@ -147,7 +148,7 @@ private fun GravatarTabs(
 
 @Composable
 private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwable?) -> Unit) {
-    var email by remember { mutableStateOf("maxime.biais@automattic.com", neverEqualPolicy()) }
+    var email by remember { mutableStateOf(BuildConfig.DEMO_EMAIL, neverEqualPolicy()) }
     var hash by remember { mutableStateOf("", neverEqualPolicy()) }
     var profiles by remember { mutableStateOf(UserProfiles(emptyList()), neverEqualPolicy()) }
     var loading by remember { mutableStateOf(false) }
@@ -229,7 +230,7 @@ private fun AvatarTab(
     var settingsState by remember {
         mutableStateOf(
             SettingsState(
-                email = "maxime.biais@automattic.com",
+                email = BuildConfig.DEMO_EMAIL,
                 size = null,
                 defaultAvatarImageEnabled = false,
                 selectedDefaultAvatar = DefaultAvatarOption.MonsterId,


### PR DESCRIPTION
### Description

Let devs configure their own default email in the demo app

### Testing Steps

- Build and run the demo app, check the default email address is: "gravatar@automattic.com"
- Add a new property to your `local.properties` file: `demo-app.email=test@example.com`, then build and run the demo app, make sure the default email address is "test@example.com"