### PR TITLE
Publish the documentation on tags

### DIFF
--- a/.github/workflows/dokka-github-pages.yml
+++ b/.github/workflows/dokka-github-pages.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - trunk
       - release/*
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Closes #72

### Description

Add a filter to run dokka action on tags push. Match semver version numbers: `[0-9]+.[0-9]+.[0-9]+`, so we can use tags without publishing docs for other stuff.

> Use the tags filter when you want to include tag name patterns or when you want to both include and exclude tag names patterns. 

from the [GitHub documentation
](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore)

### Testing Steps

I think we need to publish a test tag (0.0.1 maybe?) to test it, or just wait for the next release.