### PR TITLE
Adding internet permission to both library modules `gravatar-ui` and `gravatar`

### DIFF
--- a/gravatar-ui/src/main/AndroidManifest.xml
+++ b/gravatar-ui/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application>
         <!-- Lib activities-->
         <activity

--- a/gravatar/src/main/AndroidManifest.xml
+++ b/gravatar/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
Closes #96 

### Description

Both modules uses internet, `gravatar` core to launch the network request and `gravatar-ui` to load the avatars.

### Testing Steps

Open a `@Composable` on `gravatar-ui` that load an avatar. For example, [ProfileCardView](https://github.com/Automattic/Gravatar-SDK-Android/blob/2f7d61d65d67b6e199057d81e6c07474d68b3a58/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileCard.kt#L86) and run the preview in a device.

<img width="315" alt="image" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/f62000c0-5d8d-4836-b3d8-44f94e328298">

Verify you can see the default avatar:

<img width="250" alt="Alt Text" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/331c26c5-2c72-46be-9bd8-3968de19b96d">
