### PR TITLE
Let ExpandableText to accept a custom dialog content

### DIFF
--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
@@ -21,6 +21,13 @@ import com.gravatar.ui.components.atomic.DisplayName
 import com.gravatar.ui.components.atomic.Location
 import com.gravatar.ui.components.atomic.ViewProfileButton
 
+/**
+ * [MiniProfileCard] is a composable that displays a mini profile card.
+ * Given a [UserProfile], it displays a mini profile card using the other atomic components provided within the SDK.
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
+ */
 @Composable
 fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
     Row(modifier = modifier) {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
@@ -9,8 +9,13 @@ import com.gravatar.api.models.UserProfile
  * [AboutMe] is a composable that displays a user's about me description.
  */
 @Composable
-public fun AboutMe(profile: UserProfile, modifier: Modifier = Modifier, maxLines: Int = 2) {
-    ExpandableText(profile.aboutMe.orEmpty(), modifier, maxLines)
+public fun AboutMe(
+    profile: UserProfile,
+    modifier: Modifier = Modifier,
+    maxLines: Int = 2,
+    dialogContent: @Composable (() -> Unit)? = null,
+) {
+    ExpandableText(profile.aboutMe.orEmpty(), modifier, maxLines, dialogContent)
 }
 
 @Preview

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
@@ -13,7 +13,7 @@ public fun AboutMe(
     profile: UserProfile,
     modifier: Modifier = Modifier,
     maxLines: Int = 2,
-    dialogContent: @Composable (() -> Unit)? = null,
+    dialogContent: @Composable ((String) -> Unit)? = { DefaultDialogContent(text = it) },
 ) {
     ExpandableText(profile.aboutMe.orEmpty(), modifier, maxLines, dialogContent)
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ExpandableText.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ExpandableText.kt
@@ -1,11 +1,13 @@
 package com.gravatar.ui.components.atomic
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -13,14 +15,21 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.gravatar.ui.R
 
 @Composable
-internal fun ExpandableText(text: String, modifier: Modifier = Modifier, maxLines: Int = 2) {
+internal fun ExpandableText(
+    text: String,
+    modifier: Modifier = Modifier,
+    maxLines: Int = 2,
+    dialogContent: @Composable (() -> Unit)? = null,
+) {
     var showDialog by remember { mutableStateOf(false) }
     var clickableText by remember { mutableStateOf(false) }
 
@@ -37,20 +46,29 @@ internal fun ExpandableText(text: String, modifier: Modifier = Modifier, maxLine
     )
     if (showDialog) {
         Dialog(onDismissRequest = { showDialog = false }) {
-            Card(
-                modifier = Modifier.wrapContentSize(),
-                shape = RoundedCornerShape(16.dp),
-            ) {
-                Text(
-                    text = text,
-                    modifier = Modifier
-                        .padding(16.dp)
-                        .fillMaxWidth()
-                        .wrapContentSize(),
-                    textAlign = TextAlign.Start,
-                )
+            if (dialogContent != null) {
+                dialogContent()
+            } else {
+                DefaultDialogContent(text)
             }
         }
+    }
+}
+
+@Composable
+private fun DefaultDialogContent(text: String) {
+    Card(
+        modifier = Modifier.wrapContentSize(),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth()
+                .wrapContentSize(),
+            textAlign = TextAlign.Start,
+        )
     }
 }
 
@@ -58,4 +76,23 @@ internal fun ExpandableText(text: String, modifier: Modifier = Modifier, maxLine
 @Composable
 private fun ExpandableTextPreview() {
     ExpandableText("Text that \ncan be expanded \nby clicking on it.")
+}
+
+@Preview
+@Composable
+private fun ExpandableTextPreviewWithDialogContent() {
+    ExpandableText("Text that \ncan be expanded \nby clicking on it.") {
+        Card(
+            modifier = Modifier.wrapContentSize(),
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            Row(modifier = Modifier.padding(8.dp)) {
+                Icon(
+                    painter = painterResource(R.drawable.gravatar_icon),
+                    contentDescription = "",
+                )
+                Text("This demonstrates how to pass a custom dialog content to the ExpandableText.")
+            }
+        }
+    }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ExpandableText.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ExpandableText.kt
@@ -28,7 +28,7 @@ internal fun ExpandableText(
     text: String,
     modifier: Modifier = Modifier,
     maxLines: Int = 2,
-    dialogContent: @Composable (() -> Unit)? = null,
+    dialogContent: @Composable ((String) -> Unit)? = { DefaultDialogContent(it) },
 ) {
     var showDialog by remember { mutableStateOf(false) }
     var clickableText by remember { mutableStateOf(false) }
@@ -46,17 +46,18 @@ internal fun ExpandableText(
     )
     if (showDialog) {
         Dialog(onDismissRequest = { showDialog = false }) {
-            if (dialogContent != null) {
-                dialogContent()
-            } else {
-                DefaultDialogContent(text)
-            }
+            dialogContent?.invoke(text)
         }
     }
 }
 
+/**
+ * Default dialog content for the [ExpandableText] composable.
+ *
+ * @param text The original text to be expanded in the dialog
+ */
 @Composable
-private fun DefaultDialogContent(text: String) {
+public fun DefaultDialogContent(text: String) {
     Card(
         modifier = Modifier.wrapContentSize(),
         shape = RoundedCornerShape(16.dp),
@@ -81,7 +82,7 @@ private fun ExpandableTextPreview() {
 @Preview
 @Composable
 private fun ExpandableTextPreviewWithDialogContent() {
-    ExpandableText("Text that \ncan be expanded \nby clicking on it.") {
+    ExpandableText("Text that \ncan be expanded \nby clicking on it.") { text ->
         Card(
             modifier = Modifier.wrapContentSize(),
             shape = RoundedCornerShape(16.dp),
@@ -91,7 +92,7 @@ private fun ExpandableTextPreviewWithDialogContent() {
                     painter = painterResource(R.drawable.gravatar_icon),
                     contentDescription = "",
                 )
-                Text("This demonstrates how to pass a custom dialog content to the ExpandableText.")
+                Text("$text\n\nThis demonstrates how to pass a custom dialog content to the ExpandableText.")
             }
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
@@ -5,6 +5,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.UserProfile
 
+/**
+ * [Location] is a composable that displays a user's location in text format.
+ * The user's location is displayed in a text format. If the location is too long, it will be truncated
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
+ * @param maxLines Maximum number of lines to display
+ * @param dialogContent Content to display in a dialog when the text is clicked
+ */
 @Composable
 public fun Location(
     profile: UserProfile,

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
@@ -19,7 +19,7 @@ public fun Location(
     profile: UserProfile,
     modifier: Modifier = Modifier,
     maxLines: Int = 1,
-    dialogContent: @Composable (() -> Unit)? = null,
+    dialogContent: @Composable ((String) -> Unit)? = { DefaultDialogContent(text = it) },
 ) {
     ExpandableText(profile.currentLocation.orEmpty(), modifier, maxLines, dialogContent)
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
@@ -6,8 +6,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.UserProfile
 
 @Composable
-public fun Location(profile: UserProfile, modifier: Modifier = Modifier, maxLines: Int = 1) {
-    ExpandableText(profile.currentLocation.orEmpty(), modifier, maxLines)
+public fun Location(
+    profile: UserProfile,
+    modifier: Modifier = Modifier,
+    maxLines: Int = 1,
+    dialogContent: @Composable (() -> Unit)? = null,
+) {
+    ExpandableText(profile.currentLocation.orEmpty(), modifier, maxLines, dialogContent)
 }
 
 @Preview

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
@@ -12,10 +12,15 @@ import com.gravatar.extensions.formattedUserInfo
  * location when available.
  */
 @Composable
-public fun UserInfo(profile: UserProfile, modifier: Modifier = Modifier, maxLines: Int = 2) {
+public fun UserInfo(
+    profile: UserProfile,
+    modifier: Modifier = Modifier,
+    maxLines: Int = 2,
+    dialogContent: @Composable (() -> Unit)? = null,
+) {
     // TODO this doesn't work with one Text field due. If the job_title and the company line is too long,
     // it will to break the layout
-    ExpandableText(profile.formattedUserInfo(), modifier, maxLines)
+    ExpandableText(profile.formattedUserInfo(), modifier, maxLines, dialogContent)
 }
 
 @Preview

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
@@ -16,7 +16,7 @@ public fun UserInfo(
     profile: UserProfile,
     modifier: Modifier = Modifier,
     maxLines: Int = 2,
-    dialogContent: @Composable (() -> Unit)? = null,
+    dialogContent: @Composable ((String) -> Unit)? = { DefaultDialogContent(text = it) },
 ) {
     // TODO this doesn't work with one Text field due. If the job_title and the company line is too long,
     // it will to break the layout


### PR DESCRIPTION
Closes #92 

### Description

Let the `ExpandableText` composable to accept custom dialog content. That way, the content that should be shown when the `ExpandableText` is clicked can be customized. 

Also, it allows the SDK client to not show anything if they want to prevent the dialog.

<img width="250" alt="Alt Text" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/6de98215-d1bf-42b4-967d-5965ac10b76e">

**Open discussion**
With the actual changes, it will only be useful if someone uses the atomic components. If we decide to work on the customization of the components, adding some parameters to the ProfileCards could be interesting to let the dialogs customizations. 

### Testing Steps

- Code review
- Play with `ExpandableTextPreviewWithDialogContent`
