### PR TITLE
Enable strict mode in `gravatar-ui`module 

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -62,3 +62,9 @@ comments:
     # TODO - Remove the explicit exclusion of Email.kt once we implement the new REST API
     excludes: [ '**/test/**', '**/androidTest/**', '**/demoapp/**', '**/models/Email.kt' ]
     searchProtectedProperty: false
+  OutdatedDocumentation:
+    active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/demoapp/**', '**/models/**' ]
+    matchTypeParameters: true
+    matchDeclarationsOrder: true
+    allowParamOnConstructorProperties: false

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -60,6 +60,11 @@ android {
             }
         }
     }
+
+    // Explicit API mode
+    kotlin {
+        explicitApi()
+    }
 }
 
 dependencies {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/GravatarImagePickerWrapper.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/GravatarImagePickerWrapper.kt
@@ -109,9 +109,9 @@ public interface GravatarImagePickerWrapperListener : GravatarListener<Unit> {
 /**
  * Options to customize the image edition screen.
  *
- * @param statusBarColor The color of the status bar.
- * @param toolbarColor The color of the toolbar.
- * @param toolbarWidgetColor The color of the toolbar widgets.
+ * @property statusBarColor The color of the status bar.
+ * @property toolbarColor The color of the toolbar.
+ * @property toolbarWidgetColor The color of the toolbar widgets.
  */
 public data class ImageEditionStyling(
     val statusBarColor: Int? = null,

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
@@ -29,7 +29,7 @@ import com.gravatar.ui.components.atomic.ViewProfileButton
  * @param modifier Composable modifier
  */
 @Composable
-fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
+public fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
     Row(modifier = modifier) {
         Avatar(
             profile = profile,
@@ -62,7 +62,7 @@ fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-fun MiniProfileCardPreview() {
+private fun MiniProfileCardPreview() {
     MiniProfileCard(
         UserProfile(
             "1234",

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileCard.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileCard.kt
@@ -34,7 +34,7 @@ import com.gravatar.ui.components.atomic.ViewProfileButton
  * Given a [UserProfile], it displays a [ProfileCard] using the other atomic components provided within the SDK.
  */
 @Composable
-fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
+public fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.Start,
@@ -83,7 +83,7 @@ fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-fun ProfileCardPreview() {
+private fun ProfileCardPreview() {
     ProfileCard(
         UserProfile(
             hash = "1234567890",

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileCard.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileCard.kt
@@ -32,6 +32,9 @@ import com.gravatar.ui.components.atomic.ViewProfileButton
 /**
  * [ProfileCard] is a composable that displays a user's profile card.
  * Given a [UserProfile], it displays a [ProfileCard] using the other atomic components provided within the SDK.
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
  */
 @Composable
 public fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
@@ -7,6 +7,11 @@ import com.gravatar.api.models.UserProfile
 
 /**
  * [AboutMe] is a composable that displays a user's about me description.
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
+ * @param maxLines The maximum number of lines to display before truncating the text
+ * @param dialogContent The content to display in a dialog when the truncated text is clicked
  */
 @Composable
 public fun AboutMe(

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -14,6 +14,11 @@ import com.gravatar.extensions.avatarUrl
 
 /**
  * [Avatar] is a composable that displays a user's avatar.
+ *
+ * @param profile The user's profile information
+ * @param size The size of the avatar
+ * @param modifier Composable modifier
+ * @param avatarQueryOptions Options to customize the avatar query
  */
 @Composable
 public fun Avatar(

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
@@ -7,6 +7,9 @@ import com.gravatar.api.models.UserProfile
 
 /**
  * [DisplayName] is a composable that displays the user's display name.
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
  */
 @Composable
 public fun DisplayName(profile: UserProfile, modifier: Modifier = Modifier) {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -102,6 +102,9 @@ private fun mediaList(profile: UserProfile): List<SocialMedia> {
 /**
  * [SocialIcon] is a composable that displays a clickable icon for a social media account.
  * The link will navigate to the Gravatar user's profile on the social media platform.
+ *
+ * @param media The social media account to display
+ * @param modifier Composable modifier
  */
 @Composable
 public fun SocialIcon(media: SocialMedia, modifier: Modifier = Modifier) {
@@ -134,6 +137,10 @@ public fun SocialIcon(media: SocialMedia, modifier: Modifier = Modifier) {
 
 /**
  * [SocialIconRow] is a composable that displays a row of clickable [SocialIcon].
+ *
+ * @param socialMedia The list of social media accounts to display
+ * @param modifier Composable modifier
+ * @param maxIcons The maximum number of icons to display
  */
 @Composable
 public fun SocialIconRow(socialMedia: List<SocialMedia>, modifier: Modifier = Modifier, maxIcons: Int = 4) {
@@ -146,6 +153,10 @@ public fun SocialIconRow(socialMedia: List<SocialMedia>, modifier: Modifier = Mo
 
 /**
  * [SocialIconRow] is a composable that displays a row of clickable [SocialIcon].
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
+ * @param maxIcons The maximum number of icons to display
  */
 @Composable
 public fun SocialIconRow(profile: UserProfile, modifier: Modifier = Modifier, maxIcons: Int = 4) {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -31,8 +31,8 @@ import java.net.URL
  * @property imageResource The drawable resource ID of the icon.
  */
 public enum class LocalIcon(
-    val shortname: String,
-    @DrawableRes val imageResource: Int,
+    public val shortname: String,
+    @DrawableRes public val imageResource: Int,
 ) {
     Gravatar("gravatar", R.drawable.gravatar_icon),
     Calendly("calendly", R.drawable.calendly_icon),
@@ -51,7 +51,7 @@ public enum class LocalIcon(
     WordPress("wordpress", R.drawable.wordpress_icon),
     ;
 
-    companion object {
+    public companion object {
         private val shortnames = entries.associateBy { it.shortname }
 
         /**
@@ -71,7 +71,12 @@ public enum class LocalIcon(
  * @property iconUrl The [URL] of the icon for the social media platform.
  * @property icon The [LocalIcon] for the social media platform.
  */
-public class SocialMedia(val url: URL, val name: String, val iconUrl: URL? = null, val icon: LocalIcon? = null)
+public class SocialMedia(
+    public val url: URL,
+    public val name: String,
+    public val iconUrl: URL? = null,
+    public val icon: LocalIcon? = null,
+)
 
 private fun mediaList(profile: UserProfile): List<SocialMedia> {
     val mediaList = mutableListOf<SocialMedia>()
@@ -99,7 +104,7 @@ private fun mediaList(profile: UserProfile): List<SocialMedia> {
  * The link will navigate to the Gravatar user's profile on the social media platform.
  */
 @Composable
-fun SocialIcon(media: SocialMedia, modifier: Modifier = Modifier) {
+public fun SocialIcon(media: SocialMedia, modifier: Modifier = Modifier) {
     val uriHandler = LocalUriHandler.current
     IconButton(
         onClick = {
@@ -131,7 +136,7 @@ fun SocialIcon(media: SocialMedia, modifier: Modifier = Modifier) {
  * [SocialIconRow] is a composable that displays a row of clickable [SocialIcon].
  */
 @Composable
-fun SocialIconRow(socialMedia: List<SocialMedia>, modifier: Modifier = Modifier, maxIcons: Int = 4) {
+public fun SocialIconRow(socialMedia: List<SocialMedia>, modifier: Modifier = Modifier, maxIcons: Int = 4) {
     Row(modifier = modifier) {
         socialMedia.take(maxIcons).forEach { media ->
             SocialIcon(media = media, modifier = Modifier.size(32.dp))
@@ -143,13 +148,13 @@ fun SocialIconRow(socialMedia: List<SocialMedia>, modifier: Modifier = Modifier,
  * [SocialIconRow] is a composable that displays a row of clickable [SocialIcon].
  */
 @Composable
-fun SocialIconRow(profile: UserProfile, modifier: Modifier = Modifier, maxIcons: Int = 4) {
+public fun SocialIconRow(profile: UserProfile, modifier: Modifier = Modifier, maxIcons: Int = 4) {
     SocialIconRow(mediaList(profile), modifier, maxIcons)
 }
 
 @Preview(showBackground = true)
 @Composable
-fun SocialIconRowPreview() {
+private fun SocialIconRowPreview() {
     val userProfile = UserProfile(
         hash = "",
         accounts = listOf(

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
@@ -10,6 +10,11 @@ import com.gravatar.extensions.formattedUserInfo
  * [UserInfo] is a composable that displays a user's information in a formatted way.
  * The user's information includes their company, job title, pronunciation, pronouns, and current
  * location when available.
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
+ * @param maxLines The maximum number of lines to display before truncating the text
+ * @param dialogContent The content to display in a dialog when the truncated text is clicked
  */
 @Composable
 public fun UserInfo(

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
@@ -29,6 +29,9 @@ import com.gravatar.ui.R
 
 /**
  * ViewProfileButton is a composable that displays a button to view a user's profile.
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
  */
 @Composable
 public fun ViewProfileButton(profile: UserProfile, modifier: Modifier = Modifier) {

--- a/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
@@ -3,10 +3,10 @@ package com.gravatar
 /**
  * Data class that represents the query options for an avatar.
  *
- * @param preferredSize Size of the avatar, must be between 1 and 2048. Optional: default to 80
- * @param defaultAvatarOption Default avatar image. Optional: default to Gravatar logo
- * @param rating Image rating. Optional: default to General, suitable for display on all websites with any audience
- * @param forceDefaultAvatar Force default avatar image. Optional: default to false
+ * @property preferredSize Size of the avatar, must be between 1 and 2048. Optional: default to 80
+ * @property defaultAvatarOption Default avatar image. Optional: default to Gravatar logo
+ * @property rating Image rating. Optional: default to General, suitable for display on all websites with any audience
+ * @property forceDefaultAvatar Force default avatar image. Optional: default to false
  */
 public data class AvatarQueryOptions(
     public val preferredSize: Int? = null,

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -10,9 +10,9 @@ import java.util.Locale
 /**
  * Gravatar avatar URL.
  *
- * @property canonicalUrl Canonical URL of the avatar
- * @property hash Gravatar hash
- * @property avatarQueryOptions Avatar query options
+ * [canonicalUrl] Canonical URL of the avatar
+ * [hash] Gravatar hash
+ * [avatarQueryOptions] Avatar query options
  */
 public class AvatarUrl {
     public val canonicalUrl: URL
@@ -53,6 +53,7 @@ public class AvatarUrl {
      * Create an avatar URL from a Gravatar hash.
      *
      * @param hash Gravatar hash
+     * @param avatarQueryOptions Avatar query options
      */
     public constructor(hash: Hash, avatarQueryOptions: AvatarQueryOptions? = null) {
         this.hash = hash
@@ -64,6 +65,7 @@ public class AvatarUrl {
      * Create an avatar URL from an email address.
      *
      * @param email Email address
+     * @param avatarQueryOptions Avatar query options
      */
     public constructor(
         email: Email,

--- a/gravatar/src/main/java/com/gravatar/DefaultAvatarOption.kt
+++ b/gravatar/src/main/java/com/gravatar/DefaultAvatarOption.kt
@@ -64,7 +64,7 @@ public sealed class DefaultAvatarOption {
      *   - MUST have a recognizable image extension (jpg, jpeg, gif, png, heic)
      *   - MUST NOT include a querystring (if it does, it will be ignored)
      *
-     * @param defaultImageUrl the custom url to use as the default avatar image.
+     * @property defaultImageUrl the custom url to use as the default avatar image.
      */
     public data class CustomUrl(val defaultImageUrl: String) : DefaultAvatarOption()
 

--- a/gravatar/src/main/java/com/gravatar/types/Email.kt
+++ b/gravatar/src/main/java/com/gravatar/types/Email.kt
@@ -3,7 +3,7 @@ package com.gravatar.types
 /**
  * Email address representation.
  *
- * @property address the email address
+ * @param address the email address
  */
 public class Email(private val address: String) {
     /**


### PR DESCRIPTION
Closes #101 

### Description

When we created the `gravatar-ui` module, we forgot to set up the strict mode that forces us to specify the visibility in classes and methods. Similar to what we did in #57, we want to enable the strictApiMode in the UI module. 

In addition, I'm enabling the [OutdatedDocumentation](https://detekt.dev/docs/rules/comments/#outdateddocumentation) rule in Detekt in order to simplify the process of keeping the code documentation up-to-date.

### Testing Steps

- Remove a visibility identifier from a class and verify you receive an error when building the project ([Example](https://github.com/Automattic/Gravatar-SDK-Android/blob/5a229e61a056fb93c54fe9b7f2618326c4e11038/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt#L32))

- Remove or modify any comment to make the documentation don't fit with the actual method signature ([Example](https://github.com/Automattic/Gravatar-SDK-Android/blob/5a229e61a056fb93c54fe9b7f2618326c4e11038/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt#L19)). Execute Detetk and verify you receive an error.
