### PR TITLE
`gravatar-ui`- UI Component -> LargeSummaryProfile

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -58,6 +58,7 @@ import com.gravatar.services.GravatarListener
 import com.gravatar.services.ProfileService
 import com.gravatar.types.Email
 import com.gravatar.ui.components.LargeProfile
+import com.gravatar.ui.components.LargeProfileSummary
 import com.gravatar.ui.components.MiniProfileCard
 import com.gravatar.ui.components.ProfileCard
 import kotlinx.coroutines.CoroutineScope
@@ -232,6 +233,15 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                         .background(MaterialTheme.colorScheme.surfaceContainer)
                         .fillMaxWidth()
                         .padding(24.dp),
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                LargeProfileSummary(
+                    profiles.entry.first(),
+                    Modifier
+                        .padding(8.dp)
+                        .background(MaterialTheme.colorScheme.surfaceContainer)
+                        .padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 8.dp)
+                        .fillMaxWidth(),
                 )
             } else {
                 if (error.isNotEmpty()) {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
@@ -1,0 +1,90 @@
+package com.gravatar.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.gravatar.api.models.Account
+import com.gravatar.api.models.Email
+import com.gravatar.api.models.UserProfile
+import com.gravatar.ui.components.atomic.Avatar
+import com.gravatar.ui.components.atomic.DisplayName
+import com.gravatar.ui.components.atomic.UserInfo
+import com.gravatar.ui.components.atomic.ViewProfileButton
+
+/**
+ * [LargeProfileSummary] is a composable that displays a user's profile in a resumed way.
+ * Given a [UserProfile], it displays a [LargeProfileSummary] using the other atomic components provided within the SDK.
+ *
+ * @param profile The user's profile information
+ * @param modifier Composable modifier
+ */
+@Composable
+public fun LargeProfileSummary(profile: UserProfile, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Avatar(
+            profile = profile,
+            size = 132.dp,
+            modifier = Modifier.clip(CircleShape),
+        )
+        ProvideTextStyle(TextStyle(fontSize = 24.sp, fontWeight = FontWeight.Bold, lineHeight = 24.sp)) {
+            DisplayName(profile, modifier = Modifier.padding(top = 16.dp))
+        }
+        ProvideTextStyle(
+            TextStyle(
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                color = MaterialTheme.colorScheme.outline,
+                textAlign = TextAlign.Center,
+            ),
+        ) {
+            UserInfo(profile)
+        }
+        ProvideTextStyle(
+            MaterialTheme.typography.bodyMedium.merge(color = MaterialTheme.colorScheme.onBackground),
+        ) {
+            ViewProfileButton(profile, Modifier.padding(0.dp), inlineContent = null)
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LargeProfileSummaryPreview() {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+        LargeProfileSummary(
+            UserProfile(
+                hash = "1234567890",
+                displayName = "Dominique Doe",
+                preferredUsername = "ddoe",
+                jobTitle = "Farmer",
+                company = "Farmers United",
+                currentLocation = "Crac'h, France",
+                pronouns = "They/Them",
+                accounts = listOf(
+                    Account(name = "Mastodon", url = "https://mastodon.social/@ddoe"),
+                    Account(name = "Tumblr", url = "https://ddoe.tumblr.com"),
+                    Account(name = "WordPress", url = "https://ddoe.wordpress.com"),
+                ),
+                aboutMe = "I'm a farmer, I love to code. I ride my bicycle to work. One apple a day keeps the " +
+                    "doctor away. This about me description is quite long, this is good for testing.",
+                emails = listOf(Email(primary = true, value = "john@doe.com")),
+            ),
+        )
+    }
+}

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
@@ -32,21 +33,29 @@ import com.gravatar.ui.R
  *
  * @param profile The user's profile information
  * @param modifier Composable modifier
+ * @param inlineContent The content to display inline with the text, by default it is an arrow icon.
+ * It can be null if no content is needed.
  */
 @Composable
-public fun ViewProfileButton(profile: UserProfile, modifier: Modifier = Modifier) {
+public fun ViewProfileButton(
+    profile: UserProfile,
+    modifier: Modifier = Modifier,
+    inlineContent: @Composable ((String) -> Unit)? = { DefaultInlineContent() },
+) {
     val uriHandler = LocalUriHandler.current
-    val arrowString = "->"
+    val iconInlineId = "->"
     val text = buildAnnotatedString {
         append(stringResource(R.string.view_profile_button))
-        append(" ")
-        // Append a placeholder string "[myBox]" and attach an annotation "inlineContent" on it.
-        appendInlineContent(arrowString, "[arrow]")
+        if (inlineContent != null) {
+            append(" ")
+            // Append a placeholder string "[myBox]" and attach an annotation "inlineContent" on it.
+            appendInlineContent(iconInlineId, "[icon]")
+        }
     }
 
-    val inlineContent = mapOf(
+    val inlineContentMap = mapOf(
         Pair(
-            arrowString,
+            iconInlineId,
             InlineTextContent(
                 Placeholder(
                     width = 16.sp,
@@ -54,12 +63,7 @@ public fun ViewProfileButton(profile: UserProfile, modifier: Modifier = Modifier
                     placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
                 ),
             ) {
-                // In RTL mode the Arrow will be mirrored
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                    tint = LocalTextStyle.current.color,
-                    contentDescription = "",
-                )
+                inlineContent?.invoke(it)
             },
         ),
     )
@@ -71,8 +75,18 @@ public fun ViewProfileButton(profile: UserProfile, modifier: Modifier = Modifier
         contentPadding = PaddingValues(start = 0.dp, end = 0.dp),
         modifier = modifier,
     ) {
-        Text(text, inlineContent = inlineContent)
+        Text(text, inlineContent = inlineContentMap)
     }
+}
+
+@Composable
+private fun DefaultInlineContent() {
+    // In RTL mode the Arrow will be mirrored
+    Icon(
+        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+        tint = LocalTextStyle.current.color,
+        contentDescription = "",
+    )
 }
 
 @Preview(showBackground = true)
@@ -85,5 +99,27 @@ private fun ViewProfileButtonPreview() {
         }
         // Preview in LTR mode
         ViewProfileButton(UserProfile("4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a"))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ViewProfileButtonWithCustomizedInlineContentPreview() {
+    ViewProfileButton(UserProfile("4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a"), inlineContent = {
+        Icon(
+            painter = painterResource(R.drawable.gravatar_icon),
+            contentDescription = "",
+        )
+    })
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ViewProfileButtonWithoutInlineContentPreview() {
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+        ViewProfileButton(
+            UserProfile("4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a"),
+            inlineContent = null,
+        )
     }
 }


### PR DESCRIPTION
Closes #100 

### Description

Implementing the `LargeSummaryProfile` component using atomic components.

<img width="325" alt="image" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/02ede573-6185-4c78-9f8f-d76041c5c27a">

This component includes the `ViewProfile` atomic component but with a small change. As you can see in the design, in this case, we don't want to show the arrow. For that reason, I've modified the `ViewProfileButton.kt` to accept via param the `@Composable` we want to show using the arrow by default.

<img width="139" alt="image" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/b010472e-ebfa-4aab-937d-2aa344dc474d">

### Testing Steps

Check that the new component looks as per designs.
