### PR TITLE
Check that OpenAPI generation works as expected in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,3 +49,10 @@ steps:
     notify:
       - github_commit_status:
           context: "Publish :gravatar"
+
+  # Run it after building step so the generated files are not bundled with the release
+  - label: "OpenAPI generation"
+    command: |
+      echo "--- ⚒️ Generating OpenAPI code"
+      ./gradlew :gravatar:openApiGenerate
+


### PR DESCRIPTION
Closes #90

### Description

Check that OpenAPI generation works as expected in CI

### Testing Steps

Wait for CI and check openapi generation ran correctly