### PR TITLE
Don't show Location if it's empty

### DIFF
--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
@@ -40,13 +40,15 @@ public fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) 
             ProvideTextStyle(TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Bold, lineHeight = 24.sp)) {
                 DisplayName(profile)
             }
-            ProvideTextStyle(
-                TextStyle(
-                    fontSize = 14.sp,
-                    color = MaterialTheme.colorScheme.outline,
-                ),
-            ) {
-                Location(profile)
+            if (!profile.currentLocation.isNullOrBlank()) {
+                ProvideTextStyle(
+                    TextStyle(
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.outline,
+                    ),
+                ) {
+                    Location(profile)
+                }
             }
             ProvideTextStyle(
                 MaterialTheme.typography.bodyMedium.merge(color = MaterialTheme.colorScheme.onBackground),


### PR DESCRIPTION
Closes #107 

### Description

Don't show the Location component when the currentLocation is null or blank. I was thinking about moving the check in Location or ExpandableText components directly, but that might be unsettling for a third party developers to see the component disappear if it's empty.

Before | After
-|-
<img width="569" alt="Screenshot 2024-04-16 at 08 34 50" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/40213/ed685d54-1960-4880-b6f4-3b24e041c9c5">|<img width="566" alt="Screenshot 2024-04-16 at 08 46 27" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/40213/0478dc18-089d-4b8f-b331-e58f1cb06c88">

### Testing Steps

Run the demo app, go to the profile tab, check that a profile with current location unset shows the 

