### PR TITLE
Demo - use coroutines instead of callbacks

### DIFF
--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -68,7 +68,6 @@ android {
 }
 
 dependencies {
-
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -75,7 +75,7 @@ android {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    api("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")


### PR DESCRIPTION
### Description

I'm tempted to keep both version of the "suspend" functions and the classic methods with the callbacks. If we just write the suspend versions, it's a huge pain for Java devs to integrate the library.

We could rename the callback versions `fun fetchWithListener(Email, Listenerer)` and set the suspend version as the default, eg. `suspend fun fetch(Email) : UserProfiles`

### Testing Steps

Run the demo app, make sure you can fetch profiles (and check the loading indicator and error works as expected)