### PR TITLE
Fix #117: lower minsdkversion

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 
     defaultConfig {
         applicationId = "com.gravatar.demoapp"
-        minSdk = 24
+        minSdk = 21
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -22,7 +22,7 @@ fun localProperties(): Properties {
 }
 
 android {
-    namespace = "com.gravatar"
+    namespace = "com.gravatar.demoapp"
     compileSdk = 34
     buildFeatures.buildConfig = true
 

--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         tools:targetApi="31">
 
         <activity
-            android:name=".demoapp.MainActivity"
+            android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Gravatar">

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.gravatar.BuildConfig
-import com.gravatar.R
+import com.gravatar.demoapp.BuildConfig
+import com.gravatar.demoapp.R
 import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.demoapp.ui.components.GravatarPasswordInput
 import com.gravatar.services.ErrorType

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -45,11 +45,11 @@ import coil.request.ImageRequest
 import coil.size.Size
 import com.gravatar.AvatarQueryOptions
 import com.gravatar.AvatarUrl
-import com.gravatar.BuildConfig
 import com.gravatar.DefaultAvatarOption
 import com.gravatar.ImageRating
-import com.gravatar.R
 import com.gravatar.api.models.UserProfiles
+import com.gravatar.demoapp.BuildConfig
+import com.gravatar.demoapp.R
 import com.gravatar.demoapp.theme.GravatarDemoAppTheme
 import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.demoapp.ui.model.SettingsState

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/GravatarImageSettings.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/GravatarImageSettings.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.DefaultAvatarOption
 import com.gravatar.ImageRating
-import com.gravatar.R
+import com.gravatar.demoapp.R
 import com.gravatar.demoapp.theme.GravatarDemoAppTheme
 import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.demoapp.ui.model.SettingsState

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/components/GravatarEmailInput.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/components/GravatarEmailInput.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.gravatar.R
+import com.gravatar.demoapp.R
 
 @Composable
 fun GravatarEmailInput(email: String, onValueChange: (String) -> Unit, modifier: Modifier = Modifier) {

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -20,8 +20,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-
+        minSdk = 21
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 21
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }


### PR DESCRIPTION
Closes #117

### Description

I picked 21 as minSdk for `gravatar-ui` because the maximum minSdk on our dependencies is 21 (`coil` minSdk is 21).

I wanted to set 14 as minimum to the `gravatar` module, but it's creating build errors with `mockk`. We could override the manifest merger (especially since it's only for test builds) but for now I think 21 as minSdk is fine.

I also updated the minSdk version of the demo-app as it was easier to test build limits.

Note: I also updated the demo app namespace in this PR as it was causing build warnings.


