### PR TITLE
Trigger documentation generation on GitHub release publishing

### DIFF
--- a/.github/workflows/dokka-github-pages.yml
+++ b/.github/workflows/dokka-github-pages.yml
@@ -7,6 +7,8 @@ on:
       - release/*
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+  release:
+    types: [published]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
### Description

We noticed an issue on documentation generation for tags, `github.ref_name` is sometimes set to `trunk` on tags, eg. documentation for 0.2.0 was generated under `/trunk/` instead of `/0.2.0/`.

### Testing Steps

We'll need to merge this and then create and publish a test release (eg. 0.2.1) to check if the `github.ref_name` is correctly set.