### PR TITLE
`gravatar-ui`- First iteration of the Ghost UI

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -156,7 +156,7 @@ private fun GravatarTabs(
 private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwable?) -> Unit) {
     var email by remember { mutableStateOf(BuildConfig.DEMO_EMAIL, neverEqualPolicy()) }
     var hash by remember { mutableStateOf("", neverEqualPolicy()) }
-    var profile: UserProfileState? by remember { mutableStateOf(null, neverEqualPolicy()) }
+    var profileState: UserProfileState? by remember { mutableStateOf(null, neverEqualPolicy()) }
     var error by remember { mutableStateOf("") }
     val profileService = ProfileService()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -179,13 +179,13 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
             Button(
                 onClick = {
                     keyboardController?.hide()
-                    profile = UserProfileState.Loading
+                    profileState = UserProfileState.Loading
                     error = ""
                     profileService.fetch(
                         Email(email),
                         object : GravatarListener<UserProfiles> {
                             override fun onSuccess(response: UserProfiles) {
-                                profile = response.entry.firstOrNull()?.let { UserProfileState.Loaded(it) }
+                                profileState = response.entry.firstOrNull()?.let { UserProfileState.Loaded(it) }
                             }
 
                             override fun onError(errorType: ErrorType) {
@@ -201,14 +201,14 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                 GravatarDivider()
                 LabelledText(R.string.gravatar_generated_hash_label, text = hash)
                 GravatarDivider()
-                if ((profile is UserProfileState.Loading)) {
+                if ((profileState is UserProfileState.Loading)) {
                     CircularProgressIndicator()
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
             // Show the profile card if we got a result and there is no error and it's not loading
-            if ((profile is UserProfileState.Loaded) && error.isEmpty() && profile != null) {
-                (profile as? UserProfileState.Loaded)?.let {
+            if ((profileState is UserProfileState.Loaded) && error.isEmpty() && profileState != null) {
+                (profileState as? UserProfileState.Loaded)?.let {
                     ProfileCard(
                         it.userProfile,
                         Modifier
@@ -220,7 +220,7 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                 }
             }
             if (error.isEmpty()) {
-                profile?.let {
+                profileState?.let {
                     MiniProfileCard(
                         it,
                         Modifier
@@ -232,8 +232,8 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                     Spacer(modifier = Modifier.height(16.dp))
                 }
             }
-            if ((profile is UserProfileState.Loaded) && error.isEmpty() && profile != null) {
-                (profile as? UserProfileState.Loaded)?.let {
+            if ((profileState is UserProfileState.Loaded) && error.isEmpty() && profileState != null) {
+                (profileState as? UserProfileState.Loaded)?.let {
                     LargeProfile(
                         it.userProfile,
                         Modifier

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -61,6 +61,7 @@ import com.gravatar.ui.components.LargeProfile
 import com.gravatar.ui.components.LargeProfileSummary
 import com.gravatar.ui.components.MiniProfileCard
 import com.gravatar.ui.components.ProfileCard
+import com.gravatar.ui.components.UserProfileLoadingState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -155,8 +156,7 @@ private fun GravatarTabs(
 private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwable?) -> Unit) {
     var email by remember { mutableStateOf(BuildConfig.DEMO_EMAIL, neverEqualPolicy()) }
     var hash by remember { mutableStateOf("", neverEqualPolicy()) }
-    var profiles by remember { mutableStateOf(UserProfiles(emptyList()), neverEqualPolicy()) }
-    var loading by remember { mutableStateOf(false) }
+    var profile: UserProfileLoadingState? by remember { mutableStateOf(null, neverEqualPolicy()) }
     var error by remember { mutableStateOf("") }
     val profileService = ProfileService()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -179,20 +179,18 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
             Button(
                 onClick = {
                     keyboardController?.hide()
-                    loading = true
+                    profile = UserProfileLoadingState.Loading
                     error = ""
                     profileService.fetch(
                         Email(email),
                         object : GravatarListener<UserProfiles> {
                             override fun onSuccess(response: UserProfiles) {
-                                profiles = response
-                                loading = false
+                                profile = response.entry.firstOrNull()?.let { UserProfileLoadingState.Loaded(it) }
                             }
 
                             override fun onError(errorType: ErrorType) {
                                 onError(errorType.name, null)
                                 error = errorType.name
-                                loading = false
                             }
                         },
                     )
@@ -203,46 +201,56 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                 GravatarDivider()
                 LabelledText(R.string.gravatar_generated_hash_label, text = hash)
                 GravatarDivider()
-                if (loading) {
+                if ((profile is UserProfileLoadingState.Loading)) {
                     CircularProgressIndicator()
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
             // Show the profile card if we got a result and there is no error and it's not loading
-            if (!loading && error.isEmpty() && profiles.entry.isNotEmpty()) {
-                ProfileCard(
-                    profiles.entry.first(),
-                    Modifier
-                        .background(MaterialTheme.colorScheme.surfaceContainer)
-                        .fillMaxWidth()
-                        .padding(24.dp),
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                MiniProfileCard(
-                    profiles.entry.first(),
-                    Modifier
-                        .background(MaterialTheme.colorScheme.surfaceContainer)
-                        .align(Alignment.Start)
-                        .fillMaxWidth()
-                        .padding(24.dp),
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                LargeProfile(
-                    profiles.entry.first(),
-                    Modifier
-                        .background(MaterialTheme.colorScheme.surfaceContainer)
-                        .fillMaxWidth()
-                        .padding(24.dp),
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                LargeProfileSummary(
-                    profiles.entry.first(),
-                    Modifier
-                        .padding(8.dp)
-                        .background(MaterialTheme.colorScheme.surfaceContainer)
-                        .padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 8.dp)
-                        .fillMaxWidth(),
-                )
+            if ((profile is UserProfileLoadingState.Loaded) && error.isEmpty() && profile != null) {
+                (profile as? UserProfileLoadingState.Loaded)?.let {
+                    ProfileCard(
+                        it.userProfile,
+                        Modifier
+                            .background(MaterialTheme.colorScheme.surfaceContainer)
+                            .fillMaxWidth()
+                            .padding(24.dp),
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+            }
+            if (error.isEmpty()) {
+                profile?.let {
+                    MiniProfileCard(
+                        it,
+                        Modifier
+                            .background(MaterialTheme.colorScheme.surfaceContainer)
+                            .align(Alignment.Start)
+                            .fillMaxWidth()
+                            .padding(24.dp),
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+            }
+            if ((profile is UserProfileLoadingState.Loaded) && error.isEmpty() && profile != null) {
+                (profile as? UserProfileLoadingState.Loaded)?.let {
+                    LargeProfile(
+                        it.userProfile,
+                        Modifier
+                            .background(MaterialTheme.colorScheme.surfaceContainer)
+                            .fillMaxWidth()
+                            .padding(24.dp),
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    LargeProfileSummary(
+                        it.userProfile,
+                        Modifier
+                            .padding(8.dp)
+                            .background(MaterialTheme.colorScheme.surfaceContainer)
+                            .padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 8.dp)
+                            .fillMaxWidth(),
+                    )
+                }
             } else {
                 if (error.isNotEmpty()) {
                     Text(text = error)

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -61,7 +61,7 @@ import com.gravatar.ui.components.LargeProfile
 import com.gravatar.ui.components.LargeProfileSummary
 import com.gravatar.ui.components.MiniProfileCard
 import com.gravatar.ui.components.ProfileCard
-import com.gravatar.ui.components.UserProfileLoadingState
+import com.gravatar.ui.components.UserProfileState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -156,7 +156,7 @@ private fun GravatarTabs(
 private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwable?) -> Unit) {
     var email by remember { mutableStateOf(BuildConfig.DEMO_EMAIL, neverEqualPolicy()) }
     var hash by remember { mutableStateOf("", neverEqualPolicy()) }
-    var profile: UserProfileLoadingState? by remember { mutableStateOf(null, neverEqualPolicy()) }
+    var profile: UserProfileState? by remember { mutableStateOf(null, neverEqualPolicy()) }
     var error by remember { mutableStateOf("") }
     val profileService = ProfileService()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -179,13 +179,13 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
             Button(
                 onClick = {
                     keyboardController?.hide()
-                    profile = UserProfileLoadingState.Loading
+                    profile = UserProfileState.Loading
                     error = ""
                     profileService.fetch(
                         Email(email),
                         object : GravatarListener<UserProfiles> {
                             override fun onSuccess(response: UserProfiles) {
-                                profile = response.entry.firstOrNull()?.let { UserProfileLoadingState.Loaded(it) }
+                                profile = response.entry.firstOrNull()?.let { UserProfileState.Loaded(it) }
                             }
 
                             override fun onError(errorType: ErrorType) {
@@ -201,14 +201,14 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                 GravatarDivider()
                 LabelledText(R.string.gravatar_generated_hash_label, text = hash)
                 GravatarDivider()
-                if ((profile is UserProfileLoadingState.Loading)) {
+                if ((profile is UserProfileState.Loading)) {
                     CircularProgressIndicator()
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
             // Show the profile card if we got a result and there is no error and it's not loading
-            if ((profile is UserProfileLoadingState.Loaded) && error.isEmpty() && profile != null) {
-                (profile as? UserProfileLoadingState.Loaded)?.let {
+            if ((profile is UserProfileState.Loaded) && error.isEmpty() && profile != null) {
+                (profile as? UserProfileState.Loaded)?.let {
                     ProfileCard(
                         it.userProfile,
                         Modifier
@@ -232,8 +232,8 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                     Spacer(modifier = Modifier.height(16.dp))
                 }
             }
-            if ((profile is UserProfileLoadingState.Loaded) && error.isEmpty() && profile != null) {
-                (profile as? UserProfileLoadingState.Loaded)?.let {
+            if ((profile is UserProfileState.Loaded) && error.isEmpty() && profile != null) {
+                (profile as? UserProfileState.Loaded)?.let {
                     LargeProfile(
                         it.userProfile,
                         Modifier

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -21,6 +21,8 @@ android {
 
     defaultConfig {
         minSdk = 21
+        // targetSdkVersion has no effect for libraries. This is only used for the test APK
+        targetSdk = 34
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/GravatarTheme.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/GravatarTheme.kt
@@ -1,12 +1,19 @@
 package com.gravatar.ui
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
+
+private val DarkColorScheme = darkColorScheme()
+
+private val LightColorScheme = lightColorScheme()
 
 /**
  * [GravatarTheme] is a composable that wraps the content of the application with the Gravatar theme.
@@ -49,7 +56,13 @@ public interface GravatarTheme {
  * [LocalGravatarTheme] is a CompositionLocal that provides the current [GravatarTheme].
  */
 public val LocalGravatarTheme: ProvidableCompositionLocal<GravatarTheme> =
-    staticCompositionLocalOf { object : GravatarTheme {} }
+    staticCompositionLocalOf {
+        object : GravatarTheme {
+            override val colorScheme: ColorScheme
+                @Composable
+                get() = if (isSystemInDarkTheme()) DarkColorScheme else LightColorScheme
+        }
+    }
 
 /** The current [GravatarTheme]. */
 public val gravatarTheme: GravatarTheme

--- a/gravatar-ui/src/main/java/com/gravatar/ui/SkeletonEffect.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/SkeletonEffect.kt
@@ -1,0 +1,71 @@
+package com.gravatar.ui
+
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun Modifier.skeletonEffect(): Modifier {
+    val infiniteTransition = rememberInfiniteTransition(label = "skeletonTransition")
+    val backgroundColor = infiniteTransition.animateColor(
+        // ⚠️ We should add the colors to the theme and use them here.
+        if (isSystemInDarkTheme()) Color(0xFF6B6B6B) else Color(0xFFE5E7E9),
+        if (isSystemInDarkTheme()) Color(0xFF979797) else Color(0xFFF2F2F2),
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                durationMillis = 800
+            },
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "backgroundColorAnimation",
+    ).value
+
+    return this.background(backgroundColor)
+}
+
+@Composable
+internal fun TextSkeletonEffect(
+    textStyle: TextStyle,
+    modifier: Modifier = Modifier,
+    text: String = "",
+    skeletonVerticalPadding: Dp = 2.dp,
+    skeletonShape: Shape = RoundedCornerShape(10.dp),
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val measure = textMeasurer.measure(
+        text,
+        textStyle,
+    )
+    val height = with(LocalDensity.current) { measure.size.height.toDp() }
+    Box(
+        modifier
+            .height(height),
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(skeletonVerticalPadding)
+                .fillMaxSize()
+                .clip(skeletonShape)
+                .skeletonEffect(),
+        )
+    }
+}

--- a/gravatar-ui/src/main/java/com/gravatar/ui/SkeletonEffect.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/SkeletonEffect.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.integerResource
@@ -23,6 +22,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.gravatar.ui.theme.skeleton_dark_end_color
+import com.gravatar.ui.theme.skeleton_dark_start_color
+import com.gravatar.ui.theme.skeleton_light_end_color
+import com.gravatar.ui.theme.skeleton_light_start_color
 
 @Composable
 internal fun Modifier.skeletonEffect(): Modifier {
@@ -30,8 +33,8 @@ internal fun Modifier.skeletonEffect(): Modifier {
     val infiniteTransition = rememberInfiniteTransition(label = "skeletonTransition")
     val backgroundColor = infiniteTransition.animateColor(
         // ⚠️ We should add the colors to the theme and use them here.
-        if (isSystemInDarkTheme()) Color(0xFF6B6B6B) else Color(0xFFE5E7E9),
-        if (isSystemInDarkTheme()) Color(0xFF979797) else Color(0xFFF2F2F2),
+        if (isSystemInDarkTheme()) skeleton_dark_start_color else skeleton_light_start_color,
+        if (isSystemInDarkTheme()) skeleton_dark_end_color else skeleton_light_end_color,
         animationSpec = infiniteRepeatable(
             animation = keyframes {
                 durationMillis = animationDuration

--- a/gravatar-ui/src/main/java/com/gravatar/ui/SkeletonEffect.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/SkeletonEffect.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.integerResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
@@ -25,6 +26,7 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 internal fun Modifier.skeletonEffect(): Modifier {
+    val animationDuration = integerResource(id = R.integer.gravatar_skeleton_animation_duration)
     val infiniteTransition = rememberInfiniteTransition(label = "skeletonTransition")
     val backgroundColor = infiniteTransition.animateColor(
         // ⚠️ We should add the colors to the theme and use them here.
@@ -32,7 +34,7 @@ internal fun Modifier.skeletonEffect(): Modifier {
         if (isSystemInDarkTheme()) Color(0xFF979797) else Color(0xFFF2F2F2),
         animationSpec = infiniteRepeatable(
             animation = keyframes {
-                durationMillis = 800
+                durationMillis = animationDuration
             },
             repeatMode = RepeatMode.Reverse,
         ),

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.delay
  */
 @Composable
 public fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
-    MiniProfileCard(state = UserProfileLoadingState.Loaded(profile), modifier = modifier)
+    MiniProfileCard(state = UserProfileState.Loaded(profile), modifier = modifier)
 }
 
 /**
@@ -50,7 +50,7 @@ public fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) 
  * @param modifier Composable modifier
  */
 @Composable
-public fun MiniProfileCard(state: UserProfileLoadingState, modifier: Modifier = Modifier) {
+public fun MiniProfileCard(state: UserProfileState, modifier: Modifier = Modifier) {
     GravatarTheme {
         Row(modifier = modifier) {
             Avatar(
@@ -64,13 +64,13 @@ public fun MiniProfileCard(state: UserProfileLoadingState, modifier: Modifier = 
                     textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                 )
                 when (state) {
-                    is UserProfileLoadingState.Loaded -> {
+                    is UserProfileState.Loaded -> {
                         if (!state.userProfile.currentLocation.isNullOrBlank()) {
                             Location(state)
                         }
                     }
 
-                    UserProfileLoadingState.Loading -> {
+                    UserProfileState.Loading -> {
                         Location(state, modifier.width(120.dp))
                     }
                 }
@@ -99,10 +99,10 @@ private fun MiniProfileCardPreview() {
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun MiniProfileCardLoadingPreview() {
-    var state: UserProfileLoadingState by remember { mutableStateOf(UserProfileLoadingState.Loading) }
+    var state: UserProfileState by remember { mutableStateOf(UserProfileState.Loading) }
     LaunchedEffect(key1 = state) {
         delay(5000)
-        state = UserProfileLoadingState.Loaded(
+        state = UserProfileState.Loaded(
             UserProfile(
                 "4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a",
                 displayName = "John Doe",

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/MiniProfileCard.kt
@@ -1,12 +1,22 @@
 package com.gravatar.ui.components
 
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
@@ -18,6 +28,7 @@ import com.gravatar.ui.components.atomic.Avatar
 import com.gravatar.ui.components.atomic.DisplayName
 import com.gravatar.ui.components.atomic.Location
 import com.gravatar.ui.components.atomic.ViewProfileButton
+import kotlinx.coroutines.delay
 
 /**
  * [MiniProfileCard] is a composable that displays a mini profile card.
@@ -28,23 +39,43 @@ import com.gravatar.ui.components.atomic.ViewProfileButton
  */
 @Composable
 public fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
+    MiniProfileCard(state = UserProfileLoadingState.Loaded(profile), modifier = modifier)
+}
+
+/**
+ * [MiniProfileCard] is a composable that displays a mini profile card.
+ * Given a [UserProfile], it displays a mini profile card using the other atomic components provided within the SDK.
+ *
+ * @param state The user's profile loading state
+ * @param modifier Composable modifier
+ */
+@Composable
+public fun MiniProfileCard(state: UserProfileLoadingState, modifier: Modifier = Modifier) {
     GravatarTheme {
         Row(modifier = modifier) {
             Avatar(
-                profile = profile,
+                state = state,
                 size = 72.dp,
                 modifier = Modifier.clip(CircleShape),
             )
             Column(modifier = Modifier.padding(start = 14.dp)) {
                 DisplayName(
-                    profile,
+                    state,
                     textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                 )
-                if (!profile.currentLocation.isNullOrBlank()) {
-                    Location(profile)
+                when (state) {
+                    is UserProfileLoadingState.Loaded -> {
+                        if (!state.userProfile.currentLocation.isNullOrBlank()) {
+                            Location(state)
+                        }
+                    }
+
+                    UserProfileLoadingState.Loading -> {
+                        Location(state, modifier.width(120.dp))
+                    }
                 }
                 ViewProfileButton(
-                    profile,
+                    state,
                     modifier = Modifier.height(32.dp),
                 )
             }
@@ -57,9 +88,31 @@ public fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) 
 private fun MiniProfileCardPreview() {
     MiniProfileCard(
         UserProfile(
-            "1234",
+            "4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a",
             displayName = "John Doe",
             currentLocation = "Crac'h, France",
         ),
     )
+}
+
+@Preview(uiMode = UI_MODE_NIGHT_NO)
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun MiniProfileCardLoadingPreview() {
+    var state: UserProfileLoadingState by remember { mutableStateOf(UserProfileLoadingState.Loading) }
+    LaunchedEffect(key1 = state) {
+        delay(5000)
+        state = UserProfileLoadingState.Loaded(
+            UserProfile(
+                "4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a",
+                displayName = "John Doe",
+                currentLocation = "Crac'h, France",
+            ),
+        )
+    }
+    GravatarTheme {
+        Surface(Modifier.fillMaxWidth()) {
+            MiniProfileCard(state)
+        }
+    }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/UserProfileLoadingState.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/UserProfileLoadingState.kt
@@ -1,0 +1,56 @@
+package com.gravatar.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.gravatar.api.models.UserProfile
+import com.gravatar.ui.GravatarTheme
+import com.gravatar.ui.components.UserProfileLoadingState.Loaded
+import com.gravatar.ui.components.UserProfileLoadingState.Loading
+import kotlinx.coroutines.delay
+
+/**
+ * [UserProfileLoadingState] represents the state of a user profile loading.
+ * It can be in a [Loading] state or a [Loaded] state.
+ */
+public sealed class UserProfileLoadingState {
+    /**
+     * [Loading] represents the state where the user profile is still loading.
+     */
+    public data object Loading : UserProfileLoadingState()
+
+    /**
+     * [Loaded] represents the state where the user profile has been loaded.
+     *
+     * @property userProfile The user's profile information
+     */
+    public data class Loaded(val userProfile: UserProfile) : UserProfileLoadingState()
+}
+
+@Preview
+@Composable
+public fun LoadingToLoadedStatePreview(composable: @Composable (state: UserProfileLoadingState) -> Unit = {}) {
+    var state: UserProfileLoadingState by remember { mutableStateOf(Loading) }
+    LaunchedEffect(key1 = state) {
+        delay(5000)
+        state = Loaded(
+            UserProfile(
+                "4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a",
+                displayName = "John Doe",
+                currentLocation = "Crac'h, France",
+            ),
+        )
+    }
+    GravatarTheme {
+        Surface(Modifier.fillMaxWidth()) {
+            composable.invoke(state)
+        }
+    }
+}

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/UserProfileState.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/UserProfileState.kt
@@ -12,32 +12,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.UserProfile
 import com.gravatar.ui.GravatarTheme
-import com.gravatar.ui.components.UserProfileLoadingState.Loaded
-import com.gravatar.ui.components.UserProfileLoadingState.Loading
+import com.gravatar.ui.components.UserProfileState.Loaded
+import com.gravatar.ui.components.UserProfileState.Loading
 import kotlinx.coroutines.delay
 
 /**
- * [UserProfileLoadingState] represents the state of a user profile loading.
+ * [UserProfileState] represents the state of a user profile loading.
  * It can be in a [Loading] state or a [Loaded] state.
  */
-public sealed class UserProfileLoadingState {
+public sealed class UserProfileState {
     /**
      * [Loading] represents the state where the user profile is still loading.
      */
-    public data object Loading : UserProfileLoadingState()
+    public data object Loading : UserProfileState()
 
     /**
      * [Loaded] represents the state where the user profile has been loaded.
      *
      * @property userProfile The user's profile information
      */
-    public data class Loaded(val userProfile: UserProfile) : UserProfileLoadingState()
+    public data class Loaded(val userProfile: UserProfile) : UserProfileState()
 }
 
 @Preview
 @Composable
-public fun LoadingToLoadedStatePreview(composable: @Composable (state: UserProfileLoadingState) -> Unit = {}) {
-    var state: UserProfileLoadingState by remember { mutableStateOf(Loading) }
+public fun LoadingToLoadedStatePreview(composable: @Composable (state: UserProfileState) -> Unit = {}) {
+    var state: UserProfileState by remember { mutableStateOf(Loading) }
     LaunchedEffect(key1 = state) {
         delay(5000)
         state = Loaded(

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -14,7 +14,7 @@ import com.gravatar.AvatarQueryOptions
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.avatarUrl
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileLoadingState
+import com.gravatar.ui.components.UserProfileState
 import com.gravatar.ui.skeletonEffect
 
 /**
@@ -55,13 +55,13 @@ public fun Avatar(
  */
 @Composable
 public fun Avatar(
-    state: UserProfileLoadingState,
+    state: UserProfileState,
     size: Dp,
     modifier: Modifier = Modifier,
     avatarQueryOptions: AvatarQueryOptions? = null,
 ) {
     when (state) {
-        is UserProfileLoadingState.Loading -> {
+        is UserProfileState.Loading -> {
             Box(
                 modifier = modifier
                     .size(size)
@@ -69,7 +69,7 @@ public fun Avatar(
             )
         }
 
-        is UserProfileLoadingState.Loaded -> {
+        is UserProfileState.Loaded -> {
             Avatar(
                 profile = state.userProfile,
                 size = size,

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -1,5 +1,7 @@
 package com.gravatar.ui.components.atomic
 
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -11,6 +13,9 @@ import coil.compose.AsyncImage
 import com.gravatar.AvatarQueryOptions
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.avatarUrl
+import com.gravatar.ui.components.LoadingToLoadedStatePreview
+import com.gravatar.ui.components.UserProfileLoadingState
+import com.gravatar.ui.skeletonEffect
 
 /**
  * [Avatar] is a composable that displays a user's avatar.
@@ -40,8 +45,50 @@ public fun Avatar(
     )
 }
 
+/**
+ * [Avatar] is a composable that displays a user's avatar.
+ *
+ * @param state
+ * @param size The size of the avatar
+ * @param modifier Composable modifier
+ * @param avatarQueryOptions Options to customize the avatar query
+ */
+@Composable
+public fun Avatar(
+    state: UserProfileLoadingState,
+    size: Dp,
+    modifier: Modifier = Modifier,
+    avatarQueryOptions: AvatarQueryOptions? = null,
+) {
+    when (state) {
+        is UserProfileLoadingState.Loading -> {
+            Box(
+                modifier = modifier
+                    .size(size)
+                    .skeletonEffect(),
+            )
+        }
+
+        is UserProfileLoadingState.Loaded -> {
+            Avatar(
+                profile = state.userProfile,
+                size = size,
+                modifier = modifier,
+                avatarQueryOptions = avatarQueryOptions,
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 private fun AvatarPreview() {
     Avatar(UserProfile("4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a"), 256.dp)
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun AvatarStatePreview() {
+    LoadingToLoadedStatePreview { Avatar(it, 256.dp) }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.UserProfile
 import com.gravatar.ui.TextSkeletonEffect
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileLoadingState
+import com.gravatar.ui.components.UserProfileState
 
 /**
  * [DisplayName] is a composable that displays the user's display name.
@@ -38,16 +38,16 @@ public fun DisplayName(
  */
 @Composable
 public fun DisplayName(
-    state: UserProfileLoadingState,
+    state: UserProfileState,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
 ) {
     when (state) {
-        is UserProfileLoadingState.Loading -> {
+        is UserProfileState.Loading -> {
             TextSkeletonEffect(textStyle = textStyle)
         }
 
-        is UserProfileLoadingState.Loaded -> {
+        is UserProfileState.Loaded -> {
             DisplayName(state.userProfile, modifier, textStyle)
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
@@ -1,12 +1,17 @@
 package com.gravatar.ui.components.atomic
 
+import android.content.res.Configuration
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.UserProfile
+import com.gravatar.ui.TextSkeletonEffect
+import com.gravatar.ui.components.LoadingToLoadedStatePreview
+import com.gravatar.ui.components.UserProfileLoadingState
 
 /**
  * [DisplayName] is a composable that displays the user's display name.
@@ -21,5 +26,45 @@ public fun DisplayName(
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
 ) {
-    Text(text = profile.displayName.orEmpty(), modifier = modifier, style = textStyle)
+    DisplayName(displayName = profile.displayName.orEmpty(), modifier = modifier, textStyle = textStyle)
+}
+
+/**
+ * [DisplayName] is a composable that displays the user's display name or a loading skeleton.
+ *
+ * @param state The user's profile loading state
+ * @param modifier Composable modifier
+ * @param textStyle The style to apply to the text
+ */
+@Composable
+public fun DisplayName(
+    state: UserProfileLoadingState,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+) {
+    when (state) {
+        is UserProfileLoadingState.Loading -> {
+            TextSkeletonEffect(textStyle = textStyle)
+        }
+
+        is UserProfileLoadingState.Loaded -> {
+            DisplayName(state.userProfile, modifier, textStyle)
+        }
+    }
+}
+
+@Composable
+private fun DisplayName(
+    displayName: String,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+) {
+    Text(text = displayName, modifier = modifier, style = textStyle)
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+public fun DisplayNamePreview() {
+    LoadingToLoadedStatePreview { DisplayName(it) }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
@@ -1,5 +1,7 @@
 package com.gravatar.ui.components.atomic
 
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -7,7 +9,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.gravatar.api.models.UserProfile
+import com.gravatar.ui.TextSkeletonEffect
+import com.gravatar.ui.components.LoadingToLoadedStatePreview
+import com.gravatar.ui.components.UserProfileLoadingState
 
 /**
  * [Location] is a composable that displays a user's location in text format.
@@ -30,6 +36,35 @@ public fun Location(
     content(profile.currentLocation.orEmpty(), modifier)
 }
 
+/**
+ * [Location] is a composable that displays a user's location in text format or a loading skeleton.
+ * The user's location is displayed in a text format. If the location is too long, it will be truncated
+ *
+ * @param state The user's profile loading state
+ * @param modifier Composable modifier
+ * @param textStyle The style to apply to the default text content
+ * @param content Composable to display the user location
+ */
+@Composable
+public fun Location(
+    state: UserProfileLoadingState,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.outline),
+    content: @Composable ((String, Modifier) -> Unit) = { location, contentModifier ->
+        LocationDefaultContent(location, textStyle, contentModifier)
+    },
+) {
+    when (state) {
+        is UserProfileLoadingState.Loading -> {
+            TextSkeletonEffect(textStyle = textStyle, modifier = Modifier.width(120.dp))
+        }
+
+        is UserProfileLoadingState.Loaded -> {
+            Location(state.userProfile, modifier, textStyle, content)
+        }
+    }
+}
+
 @Composable
 private fun LocationDefaultContent(location: String, textStyle: TextStyle, modifier: Modifier) = Text(
     location,
@@ -43,4 +78,11 @@ private fun LocationDefaultContent(location: String, textStyle: TextStyle, modif
 @Composable
 private fun LocationPreview() {
     Location(UserProfile("", currentLocation = "Crac'h, France"))
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LocationStatePreview() {
+    LoadingToLoadedStatePreview { Location(it) }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.gravatar.api.models.UserProfile
 import com.gravatar.ui.TextSkeletonEffect
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileLoadingState
+import com.gravatar.ui.components.UserProfileState
 
 /**
  * [Location] is a composable that displays a user's location in text format.
@@ -47,7 +47,7 @@ public fun Location(
  */
 @Composable
 public fun Location(
-    state: UserProfileLoadingState,
+    state: UserProfileState,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.outline),
     content: @Composable ((String, Modifier) -> Unit) = { location, contentModifier ->
@@ -55,11 +55,11 @@ public fun Location(
     },
 ) {
     when (state) {
-        is UserProfileLoadingState.Loading -> {
+        is UserProfileState.Loading -> {
             TextSkeletonEffect(textStyle = textStyle, modifier = Modifier.width(120.dp))
         }
 
-        is UserProfileLoadingState.Loaded -> {
+        is UserProfileState.Loaded -> {
             Location(state.userProfile, modifier, textStyle, content)
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
@@ -1,7 +1,9 @@
 package com.gravatar.ui.components.atomic
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.icons.Icons
@@ -29,6 +31,9 @@ import androidx.compose.ui.unit.sp
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.profileUrl
 import com.gravatar.ui.R
+import com.gravatar.ui.TextSkeletonEffect
+import com.gravatar.ui.components.LoadingToLoadedStatePreview
+import com.gravatar.ui.components.UserProfileLoadingState
 
 /**
  * ViewProfileButton is a composable that displays a button to view a user's profile.
@@ -83,6 +88,39 @@ public fun ViewProfileButton(
     }
 }
 
+/**
+ * [ViewProfileButton] is a composable that displays a button to view a user's profile or it's loading state.
+ *
+ * @param state The user's profile loading state
+ * @param modifier Composable modifier
+ * @param textStyle The style to apply to the text
+ * @param inlineContent The content to display inline with the text, by default it is an arrow icon.
+ * It can be null if no content is needed.
+ */
+@Composable
+public fun ViewProfileButton(
+    state: UserProfileLoadingState,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = MaterialTheme.typography.titleSmall.copy(color = MaterialTheme.colorScheme.onBackground),
+    inlineContent: @Composable ((String) -> Unit)? = { DefaultInlineContent(textStyle.color) },
+) {
+    when (state) {
+        is UserProfileLoadingState.Loading -> {
+            TextButton(
+                onClick = {},
+                contentPadding = PaddingValues(start = 0.dp, end = 0.dp),
+                modifier = modifier,
+            ) {
+                TextSkeletonEffect(textStyle = textStyle, modifier = Modifier.width(88.dp))
+            }
+        }
+
+        is UserProfileLoadingState.Loaded -> {
+            ViewProfileButton(state.userProfile, modifier, textStyle, inlineContent)
+        }
+    }
+}
+
 @Composable
 private fun DefaultInlineContent(tintColor: Color) {
     // In RTL mode the Arrow will be mirrored
@@ -126,4 +164,11 @@ private fun ViewProfileButtonWithoutInlineContentPreview() {
             inlineContent = null,
         )
     }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ViewProfileButtonStatePreview() {
+    LoadingToLoadedStatePreview { ViewProfileButton(it) }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
@@ -33,7 +33,7 @@ import com.gravatar.extensions.profileUrl
 import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileLoadingState
+import com.gravatar.ui.components.UserProfileState
 
 /**
  * ViewProfileButton is a composable that displays a button to view a user's profile.
@@ -99,13 +99,13 @@ public fun ViewProfileButton(
  */
 @Composable
 public fun ViewProfileButton(
-    state: UserProfileLoadingState,
+    state: UserProfileState,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.titleSmall.copy(color = MaterialTheme.colorScheme.onBackground),
     inlineContent: @Composable ((String) -> Unit)? = { DefaultInlineContent(textStyle.color) },
 ) {
     when (state) {
-        is UserProfileLoadingState.Loading -> {
+        is UserProfileState.Loading -> {
             TextButton(
                 onClick = {},
                 contentPadding = PaddingValues(start = 0.dp, end = 0.dp),
@@ -115,7 +115,7 @@ public fun ViewProfileButton(
             }
         }
 
-        is UserProfileLoadingState.Loaded -> {
+        is UserProfileState.Loaded -> {
             ViewProfileButton(state.userProfile, modifier, textStyle, inlineContent)
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/theme/Color.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/theme/Color.kt
@@ -1,0 +1,8 @@
+package com.gravatar.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+internal val skeleton_dark_start_color: Color = Color(0xFF6B6B6B)
+internal val skeleton_dark_end_color: Color = Color(0xFF979797)
+internal val skeleton_light_start_color: Color = Color(0xFFE5E7E9)
+internal val skeleton_light_end_color: Color = Color(0xFFF2F2F2)

--- a/gravatar-ui/src/main/res/values/values.xml
+++ b/gravatar-ui/src/main/res/values/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="gravatar_skeleton_animation_duration">800</integer>
+</resources>


### PR DESCRIPTION
Closes #109 

### Description

We want the Gravatar UI components to have a "loading" state. That state should have a skeleton animation of 800ms.

SkeletonEffect contains the base code to be used along the different components to create their "loading" state.

All modified components can be used in two different ways:

- Passing a profile as a parameter (Previous way of working)
- Passing a UserProfileLoadingState. This way, we'll show a skeleton to indicate when the profile is loading. When the state changes to "Loaded", the composable will be updated to show the already loaded state.

<img width="433" alt="image" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/5f347b45-f662-47b9-aeef-29a5f67286c4">


I'll apply the same pattern to the other components in the next PR.

### Testing Steps
- Run the different previews in a device
- Run the demo app and verify how the skeleton looks for the MiniProfileCard

https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/9bc63de8-523b-4ad7-9e06-26d4b5ecc3a7
