### PR TITLE
ProfileService is taking an optional OkHttpClient parameter so we need to make okhttp an _api_ dependency

### DIFF
--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -75,7 +75,7 @@ android {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    api("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")


### PR DESCRIPTION
I noticed the issue when testing the library in an empty app.