### PR TITLE
`gravatar-ui` - Unify profile component names

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -56,7 +56,7 @@ import com.gravatar.services.Result
 import com.gravatar.types.Email
 import com.gravatar.ui.components.LargeProfile
 import com.gravatar.ui.components.LargeProfileSummary
-import com.gravatar.ui.components.ProfileCard
+import com.gravatar.ui.components.Profile
 import com.gravatar.ui.components.ProfileSummary
 import com.gravatar.ui.components.UserProfileState
 import kotlinx.coroutines.CoroutineScope
@@ -158,7 +158,7 @@ private fun ProfileCards(profileState: UserProfileState?, error: String) {
     // Show the profile card if we got a result and there is no error and it's not loading
     if (error.isEmpty()) {
         profileState?.let {
-            ProfileCard(it, defaultModifier)
+            Profile(it, defaultModifier)
             Spacer(modifier = Modifier.height(16.dp))
             ProfileSummary(it, defaultModifier)
             Spacer(modifier = Modifier.height(16.dp))

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -150,7 +150,7 @@ private fun GravatarTabs(
 }
 
 @Composable
-private fun ProfileCards(profileState: UserProfileState?, error: String) {
+private fun ProfileComponents(profileState: UserProfileState?, error: String) {
     val defaultModifier = Modifier
         .background(MaterialTheme.colorScheme.surfaceContainer)
         .fillMaxWidth()
@@ -226,7 +226,7 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                 },
             ) { Text(text = stringResource(R.string.button_get_profile)) }
             Spacer(modifier = Modifier.height(16.dp))
-            ProfileCards(profileState, error)
+            ProfileComponents(profileState, error)
         }
     }
 }

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -56,8 +56,8 @@ import com.gravatar.services.Result
 import com.gravatar.types.Email
 import com.gravatar.ui.components.LargeProfile
 import com.gravatar.ui.components.LargeProfileSummary
-import com.gravatar.ui.components.MiniProfileCard
 import com.gravatar.ui.components.ProfileCard
+import com.gravatar.ui.components.ProfileSummary
 import com.gravatar.ui.components.UserProfileState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -160,7 +160,7 @@ private fun ProfileCards(profileState: UserProfileState?, error: String) {
         profileState?.let {
             ProfileCard(it, defaultModifier)
             Spacer(modifier = Modifier.height(16.dp))
-            MiniProfileCard(it, defaultModifier)
+            ProfileSummary(it, defaultModifier)
             Spacer(modifier = Modifier.height(16.dp))
             LargeProfile(it, defaultModifier)
             Spacer(modifier = Modifier.height(16.dp))
@@ -216,6 +216,7 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                                     profileState = UserProfileState.Loaded(it)
                                 }
                             }
+
                             is Result.Failure -> {
                                 onError(result.error.name, null)
                                 error = result.error.name

--- a/demo-app/src/main/res/values/strings.xml
+++ b/demo-app/src/main/res/values/strings.xml
@@ -12,10 +12,12 @@
     <string name="tab_label_avatar">Avatar</string>
     <string name="tab_label_avatar_update">Avatar Update</string>
     <string name="button_get_profile">Get Profile</string>
+    <string name="button_enable_loading_state">Skeleton</string>
     <string name="text_display_name">Display Name: %1$s</string>
     <string name="text_url">Url: %1$s</string>
     <string name="button_load_gravatar">Load Gravatar</string>
     <string name="access_token_label">Access Token</string>
+    <string name="theme_label">Theme</string>
     <string name="update_avatar_button_label">Update Avatar</string>
     <string name="avatar_update_upload_success_toast">Upload success</string>
     <string name="avatar_update_upload_failed_toast">Upload error: %1$s</string>

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
@@ -29,26 +29,26 @@ import com.gravatar.ui.components.atomic.UserInfo
 import com.gravatar.ui.components.atomic.ViewProfileButton
 
 /**
- * [ProfileCard] is a composable that displays a user's profile card.
- * Given a [UserProfile], it displays a [ProfileCard] using the other atomic components provided within the SDK.
+ * [Profile] is a composable that displays a user's profile card.
+ * Given a [UserProfile], it displays a [Profile] using the other atomic components provided within the SDK.
  *
  * @param profile The user's profile information
  * @param modifier Composable modifier
  */
 @Composable
-public fun ProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
-    ProfileCard(state = UserProfileState.Loaded(profile), modifier = modifier)
+public fun Profile(profile: UserProfile, modifier: Modifier = Modifier) {
+    Profile(state = UserProfileState.Loaded(profile), modifier = modifier)
 }
 
 /**
- * [ProfileCard] is a composable that displays a user's profile card.
- * Given a [UserProfileState], it displays a [ProfileCard] or the skeleton if it's in a loading state.
+ * [Profile] is a composable that displays a user's profile card.
+ * Given a [UserProfileState], it displays a [Profile] or the skeleton if it's in a loading state.
  *
  * @param state The user's profile state
  * @param modifier Composable modifier
  */
 @Composable
-public fun ProfileCard(state: UserProfileState, modifier: Modifier = Modifier) {
+public fun Profile(state: UserProfileState, modifier: Modifier = Modifier) {
     GravatarTheme {
         Column(
             modifier = modifier,
@@ -86,8 +86,8 @@ public fun ProfileCard(state: UserProfileState, modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-private fun ProfileCardPreview() {
-    ProfileCard(
+private fun ProfilePreview() {
+    Profile(
         UserProfile(
             hash = "1234567890",
             displayName = "Dominique Doe",
@@ -111,6 +111,6 @@ private fun ProfileCardPreview() {
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-private fun ProfileCardLoadingPreview() {
-    LoadingToLoadedStatePreview { ProfileCard(it) }
+private fun ProfileLoadingPreview() {
+    LoadingToLoadedStatePreview { Profile(it) }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
@@ -23,26 +23,26 @@ import com.gravatar.ui.components.atomic.Location
 import com.gravatar.ui.components.atomic.ViewProfileButton
 
 /**
- * [MiniProfileCard] is a composable that displays a mini profile card.
+ * [ProfileSummary] is a composable that displays a mini profile card.
  * Given a [UserProfile], it displays a mini profile card using the other atomic components provided within the SDK.
  *
  * @param profile The user's profile information
  * @param modifier Composable modifier
  */
 @Composable
-public fun MiniProfileCard(profile: UserProfile, modifier: Modifier = Modifier) {
-    MiniProfileCard(state = UserProfileState.Loaded(profile), modifier = modifier)
+public fun ProfileSummary(profile: UserProfile, modifier: Modifier = Modifier) {
+    ProfileSummary(state = UserProfileState.Loaded(profile), modifier = modifier)
 }
 
 /**
- * [MiniProfileCard] is a composable that displays a mini profile card.
+ * [ProfileSummary] is a composable that displays a mini profile card.
  * Given a [UserProfile], it displays a mini profile card using the other atomic components provided within the SDK.
  *
  * @param state The user's profile state
  * @param modifier Composable modifier
  */
 @Composable
-public fun MiniProfileCard(state: UserProfileState, modifier: Modifier = Modifier) {
+public fun ProfileSummary(state: UserProfileState, modifier: Modifier = Modifier) {
     GravatarTheme {
         Row(modifier = modifier) {
             Avatar(
@@ -77,8 +77,8 @@ public fun MiniProfileCard(state: UserProfileState, modifier: Modifier = Modifie
 
 @Preview
 @Composable
-private fun MiniProfileCardPreview() {
-    MiniProfileCard(
+private fun ProfileSummaryPreview() {
+    ProfileSummary(
         UserProfile(
             "4539566a0223b11d28fc47c864336fa27b8fe49b5f85180178c9e3813e910d6a",
             displayName = "John Doe",
@@ -90,6 +90,6 @@ private fun MiniProfileCardPreview() {
 @Preview(uiMode = UI_MODE_NIGHT_NO)
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
-private fun MiniProfileCardLoadingPreview() {
-    LoadingToLoadedStatePreview { MiniProfileCard(it) }
+private fun ProfileSummaryLoadingPreview() {
+    LoadingToLoadedStatePreview { ProfileSummary(it) }
 }


### PR DESCRIPTION
Closes #139 

### Description

Unify the UI component names to keep them at parity with the iOS SDK. We'll use the same names without the subfix "View," which is uncommon on Jetpack Compose.

### Testing Steps

- CI and code review should be enough.
