### PR TITLE
Closes 133: fix dokka publishing for latest release

### DIFF
--- a/.github/workflows/dokka-github-pages.yml
+++ b/.github/workflows/dokka-github-pages.yml
@@ -1,9 +1,7 @@
 name: Deploy Dokka docs with GitHub Pages
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+  push
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/dokka-github-pages.yml
+++ b/.github/workflows/dokka-github-pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate dokka docs
         run: ./gradlew dokkaHtmlMultiModule
       - name: Move generated docs to branch directory
-        run: mkdir -p ./_site/${{ github.ref_name }} && mv ./docs/dokka/* ./_site/${{ github.ref_name }}/ && ln -s ./_site/${{ github.ref_name }} ./_site/latest
+        run: mkdir -p ./_site/${{ github.ref_name }} && mv ./docs/dokka/* ./_site/${{ github.ref_name }}/ && cp -r ./_site/${{ github.ref_name }} ./_site/latest
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
Closes #133

### Description

Replace symbolic link by a recursive copy action. After doing a release we'll have 2 urls with the same content:

- https://automattic.github.io/Gravatar-SDK-Android/x.x.x/
- https://automattic.github.io/Gravatar-SDK-Android/latest/

I'll drop f9f53afbdd868eb5500a37c4e5a8945c33647984 and merge this after the review 

### Testing Steps

Visit https://automattic.github.io/Gravatar-SDK-Android/latest and  https://automattic.github.io/Gravatar-SDK-Android/maxme/133-fix-dokka-publishing-only-for-latest-release/