### PR TITLE
Run onSuccess and onError callbacks on the main instead of the main thread

### DIFF
--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder
 import com.gravatar.GravatarApiService
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL
 import com.gravatar.GravatarConstants.GRAVATAR_BASE_URL
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -20,8 +21,10 @@ internal class GravatarSdkContainer private constructor() {
 
     private fun getRetrofitBaseBuilder() = Retrofit.Builder().baseUrl(GRAVATAR_BASE_URL)
 
+    val dispatcherMain: CoroutineDispatcher = Dispatchers.Main
     val dispatcherDefault = Dispatchers.Default
     val dispatcherIO = Dispatchers.IO
+
     private val gson = GsonBuilder().setLenient().create()
 
     /**

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -22,7 +22,8 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
         const val LOG_TAG = "AvatarService"
     }
 
-    private val coroutineScope = CoroutineScope(GravatarSdkDI.dispatcherDefault)
+    // Run onResponse and onError callbacks on the main thread
+    private val coroutineScope = CoroutineScope(GravatarSdkDI.dispatcherMain)
 
     /**
      * Uploads a Gravatar image for the given email address.
@@ -61,7 +62,9 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
                 }
 
                 override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                    handleError(t, gravatarUploadListener, coroutineScope)
+                    coroutineScope.launch {
+                        gravatarUploadListener.onError(t.error())
+                    }
                 }
             },
         )

--- a/gravatar/src/main/java/com/gravatar/services/ErrorUtils.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorUtils.kt
@@ -1,18 +1,12 @@
 package com.gravatar.services
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
-internal fun handleError(t: Throwable, listener: GravatarListener<*, ErrorType>, coroutineScope: CoroutineScope) {
-    val error: ErrorType =
-        when (t) {
-            is SocketTimeoutException -> ErrorType.TIMEOUT
-            is UnknownHostException -> ErrorType.NETWORK
-            else -> ErrorType.UNKNOWN
-        }
-    coroutineScope.launch {
-        listener.onError(error)
+internal fun Throwable.error(): ErrorType {
+    return when (this) {
+        is SocketTimeoutException -> ErrorType.TIMEOUT
+        is UnknownHostException -> ErrorType.NETWORK
+        else -> ErrorType.UNKNOWN
     }
 }

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -22,7 +22,8 @@ public class ProfileService(private val okHttpClient: OkHttpClient? = null) {
         const val LOG_TAG = "ProfileService"
     }
 
-    private val coroutineScope = CoroutineScope(GravatarSdkDI.dispatcherDefault)
+    // Run onResponse and onError callbacks on the main thread
+    private val coroutineScope = CoroutineScope(GravatarSdkDI.dispatcherMain)
 
     private fun fetchWithListener(
         hashOrUsername: String,
@@ -52,7 +53,9 @@ public class ProfileService(private val okHttpClient: OkHttpClient? = null) {
                 }
 
                 override fun onFailure(call: Call<UserProfiles>, t: Throwable) {
-                    handleError(t, getProfileListener, coroutineScope)
+                    coroutineScope.launch {
+                        getProfileListener.onError(t.error())
+                    }
                 }
             },
         )

--- a/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
+++ b/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
@@ -23,8 +23,10 @@ class GravatarSdkContainerRule : TestRule {
                 gravatarSdkContainerMock = mockk<GravatarSdkContainer>()
                 gravatarApiServiceMock = mockk<GravatarApiService>(relaxed = true)
                 mockkObject(GravatarSdkContainer)
-                every { GravatarSdkContainer.instance } returns gravatarSdkContainerMock
+                every { gravatarSdkContainerMock.dispatcherMain } returns testDispatcher
                 every { gravatarSdkContainerMock.dispatcherDefault } returns testDispatcher
+                every { gravatarSdkContainerMock.dispatcherIO } returns testDispatcher
+                every { GravatarSdkContainer.instance } returns gravatarSdkContainerMock
                 every { gravatarSdkContainerMock.getGravatarApiService(any()) } returns gravatarApiServiceMock
 
                 base.evaluate()


### PR DESCRIPTION
Fix an issue reported on WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/issues/20739#issuecomment-2089853261

Run the `onSuccess` and `onError` callbacks of the AvatarService and ProfileService in the main threads. We're not doing any logic in there so I think it's fine to wrap the full `onSucces/onFailure` methods we get from Retrofit directly in the main thread.

Note: this branch is forked from 0.2.0.

We can either release a 0.2.1 (but we should target `release/0.2.1` instead of `trunk`) or a `0.3.0` with all the recent changes in trunk. Since 0.2.0, we focused on UI components that aren't used in WPAndroid and  there is no incompatible changes in current trunk and WPAndroid, so I lean toward releasing a 0.3.0.

In the process, I removed `dispatcherDefault` and `dispatcherIO` from `GravatarSdkContainer` as I found them very confusing in the services. I think they were only used for injecting a different thread in testing environments. There is another way to override the main thread (`Dispatchers.setMain(containerRule.testDispatcher)`), feels better to me.

cc @thomashorta 