### PR TITLE
`gravatar-ui` - Empty state in UI components

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -61,6 +61,7 @@ import com.gravatar.demoapp.R
 import com.gravatar.demoapp.theme.GravatarDemoAppTheme
 import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.demoapp.ui.model.SettingsState
+import com.gravatar.services.ErrorType
 import com.gravatar.services.ProfileService
 import com.gravatar.services.Result
 import com.gravatar.types.Email
@@ -258,8 +259,16 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                                 }
 
                                 is Result.Failure -> {
-                                    onError(result.error.name, null)
-                                    error = result.error.name
+                                    when (result.error) {
+                                        ErrorType.NOT_FOUND -> {
+                                            profileState = UserProfileState.Empty
+                                        }
+
+                                        else -> {
+                                            onError(result.error.name, null)
+                                            error = result.error.name
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfile.kt
@@ -47,26 +47,28 @@ public fun LargeProfile(profile: UserProfile, modifier: Modifier = Modifier) {
 @Composable
 public fun LargeProfile(state: UserProfileState, modifier: Modifier = Modifier) {
     GravatarTheme {
-        Column(
-            modifier = modifier,
-        ) {
-            Avatar(
-                state = state,
-                size = 132.dp,
-                modifier = Modifier.clip(CircleShape),
-            )
-            DisplayName(state, modifier = Modifier.padding(top = 16.dp))
-            UserInfo(state)
-            AboutMe(state, modifier = Modifier.padding(top = 8.dp))
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+        EmptyProfileClickableContainer(state) {
+            Column(
+                modifier = modifier,
             ) {
-                SocialIconRow(state, maxIcons = 4)
-                ViewProfileButton(state, Modifier.padding(0.dp))
+                Avatar(
+                    state = state,
+                    size = 132.dp,
+                    modifier = Modifier.clip(CircleShape),
+                )
+                DisplayName(state, modifier = Modifier.padding(top = 16.dp))
+                UserInfo(state)
+                AboutMe(state, modifier = Modifier.padding(top = 8.dp))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    SocialIconRow(state, maxIcons = 4)
+                    ViewProfileButton(state, Modifier.padding(0.dp))
+                }
             }
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfile.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -100,4 +101,15 @@ private fun LargeProfilePreview() {
 @Composable
 public fun DisplayNamePreview() {
     LoadingToLoadedStatePreview { LargeProfile(it) }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ProfileEmptyPreview() {
+    GravatarTheme {
+        Surface(Modifier.fillMaxWidth()) {
+            LargeProfile(UserProfileState.Empty)
+        }
+    }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -97,4 +98,15 @@ private fun LargeProfileSummaryPreview() {
 @Composable
 public fun LargeProfileLoadingPreview() {
     LoadingToLoadedStatePreview { LargeProfileSummary(it) }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ProfileEmptyPreview() {
+    GravatarTheme {
+        Surface(Modifier.fillMaxWidth()) {
+            LargeProfileSummary(UserProfileState.Empty)
+        }
+    }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
@@ -45,24 +45,26 @@ public fun LargeProfileSummary(profile: UserProfile, modifier: Modifier = Modifi
 @Composable
 public fun LargeProfileSummary(state: UserProfileState, modifier: Modifier = Modifier) {
     GravatarTheme {
-        Column(
-            modifier = modifier,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Avatar(
-                state = state,
-                size = 132.dp,
-                modifier = Modifier.clip(CircleShape),
-            )
-            DisplayName(state, modifier = Modifier.padding(top = 16.dp))
-            UserInfo(
-                state,
-                textStyle = MaterialTheme.typography.bodyMedium.copy(
-                    color = MaterialTheme.colorScheme.outline,
-                    textAlign = TextAlign.Center,
-                ),
-            )
-            ViewProfileButton(state, Modifier.padding(0.dp), inlineContent = null)
+        EmptyProfileClickableContainer(state) {
+            Column(
+                modifier = modifier,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Avatar(
+                    state = state,
+                    size = 132.dp,
+                    modifier = Modifier.clip(CircleShape),
+                )
+                DisplayName(state, modifier = Modifier.padding(top = 16.dp))
+                UserInfo(
+                    state,
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(
+                        color = MaterialTheme.colorScheme.outline,
+                        textAlign = TextAlign.Center,
+                    ),
+                )
+                ViewProfileButton(state, Modifier.padding(0.dp), inlineContent = null)
+            }
         }
     }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
@@ -51,35 +51,37 @@ public fun Profile(profile: UserProfile, modifier: Modifier = Modifier) {
 @Composable
 public fun Profile(state: UserProfileState, modifier: Modifier = Modifier) {
     GravatarTheme {
-        Column(
-            modifier = modifier,
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.Top,
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Avatar(
-                    state = state,
-                    size = 72.dp,
-                    modifier = Modifier.clip(CircleShape),
-                )
-                Column(modifier = Modifier.padding(14.dp, 0.dp, 0.dp, 0.dp)) {
-                    DisplayName(
-                        state,
-                        textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                    )
-                    UserInfo(state)
-                }
-            }
-            Spacer(modifier = Modifier.height(16.dp))
-            AboutMe(state)
-            Spacer(modifier = Modifier.height(4.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+        EmptyProfileClickableContainer(state) {
+            Column(
+                modifier = modifier,
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.Top,
             ) {
-                SocialIconRow(state, maxIcons = 4)
-                ViewProfileButton(state, Modifier.padding(0.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Avatar(
+                        state = state,
+                        size = 72.dp,
+                        modifier = Modifier.clip(CircleShape),
+                    )
+                    Column(modifier = Modifier.padding(14.dp, 0.dp, 0.dp, 0.dp)) {
+                        DisplayName(
+                            state,
+                            textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        )
+                        UserInfo(state)
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                AboutMe(state)
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    SocialIconRow(state, maxIcons = 4)
+                    ViewProfileButton(state, Modifier.padding(0.dp))
+                }
             }
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,7 +56,7 @@ public fun Profile(state: UserProfileState, modifier: Modifier = Modifier) {
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.Top,
         ) {
-            Row {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Avatar(
                     state = state,
                     size = 72.dp,
@@ -113,4 +114,15 @@ private fun ProfilePreview() {
 @Composable
 private fun ProfileLoadingPreview() {
     LoadingToLoadedStatePreview { Profile(it) }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ProfileEmptyPreview() {
+    GravatarTheme {
+        Surface(Modifier.fillMaxWidth()) {
+            Profile(UserProfileState.Empty)
+        }
+    }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileComponentsUtils.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileComponentsUtils.kt
@@ -1,0 +1,31 @@
+package com.gravatar.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import com.gravatar.GravatarConstants
+
+@Composable
+internal fun EmptyProfileClickableContainer(userProfileState: UserProfileState?, content: @Composable () -> Unit) {
+    if (userProfileState is UserProfileState.Empty) {
+        Box(Modifier.emptyProfileClick(userProfileState)) {
+            content()
+        }
+    } else {
+        content()
+    }
+}
+
+@Composable
+private fun Modifier.emptyProfileClick(userProfileState: UserProfileState?): Modifier {
+    return if (userProfileState is UserProfileState.Empty) {
+        val uriHandler = LocalUriHandler.current
+        this.clickable {
+            uriHandler.openUri(GravatarConstants.GRAVATAR_SIGN_IN_URL)
+        }
+    } else {
+        this
+    }
+}

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
@@ -46,36 +46,38 @@ public fun ProfileSummary(profile: UserProfile, modifier: Modifier = Modifier) {
 @Composable
 public fun ProfileSummary(state: UserProfileState, modifier: Modifier = Modifier) {
     GravatarTheme {
-        Row(modifier = modifier) {
-            Avatar(
-                state = state,
-                size = 72.dp,
-                modifier = Modifier.clip(CircleShape),
-            )
-            Column(modifier = Modifier.padding(start = 14.dp)) {
-                DisplayName(
-                    state,
-                    textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+        EmptyProfileClickableContainer(state) {
+            Row(modifier = modifier) {
+                Avatar(
+                    state = state,
+                    size = 72.dp,
+                    modifier = Modifier.clip(CircleShape),
                 )
-                when (state) {
-                    is UserProfileState.Loaded -> {
-                        if (!state.userProfile.currentLocation.isNullOrBlank()) {
+                Column(modifier = Modifier.padding(start = 14.dp)) {
+                    DisplayName(
+                        state,
+                        textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    )
+                    when (state) {
+                        is UserProfileState.Loaded -> {
+                            if (!state.userProfile.currentLocation.isNullOrBlank()) {
+                                Location(state)
+                            }
+                        }
+
+                        UserProfileState.Loading -> {
+                            Location(state, modifier.width(120.dp))
+                        }
+
+                        UserProfileState.Empty -> {
                             Location(state)
                         }
                     }
-
-                    UserProfileState.Loading -> {
-                        Location(state, modifier.width(120.dp))
-                    }
-
-                    UserProfileState.Empty -> {
-                        Location(state)
-                    }
+                    ViewProfileButton(
+                        state,
+                        modifier = Modifier.height(32.dp),
+                    )
                 }
-                ViewProfileButton(
-                    state,
-                    modifier = Modifier.height(32.dp),
-                )
             }
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
@@ -4,11 +4,13 @@ import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -65,6 +67,10 @@ public fun ProfileSummary(state: UserProfileState, modifier: Modifier = Modifier
                     UserProfileState.Loading -> {
                         Location(state, modifier.width(120.dp))
                     }
+
+                    UserProfileState.Empty -> {
+                        Location(state)
+                    }
                 }
                 ViewProfileButton(
                     state,
@@ -92,4 +98,15 @@ private fun ProfileSummaryPreview() {
 @Composable
 private fun ProfileSummaryLoadingPreview() {
     LoadingToLoadedStatePreview { ProfileSummary(it) }
+}
+
+@Preview(uiMode = UI_MODE_NIGHT_NO)
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun ProfileSummaryEmptyPreview() {
+    GravatarTheme {
+        Surface(Modifier.fillMaxWidth()) {
+            ProfileSummary(UserProfileState.Empty)
+        }
+    }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/UiUtils.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/UiUtils.kt
@@ -1,0 +1,9 @@
+package com.gravatar.ui.components
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+
+@Composable
+internal fun isNightModeEnabled() =
+    (LocalConfiguration.current.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/UserProfileState.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/UserProfileState.kt
@@ -34,6 +34,11 @@ public sealed class UserProfileState {
      * @property userProfile The user's profile information
      */
     public data class Loaded(val userProfile: UserProfile) : UserProfileState()
+
+    /**
+     * [Empty] represents the state where the user profile is empty, so it can be claimed.
+     */
+    public data object Empty : UserProfileState()
 }
 
 @Preview

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
@@ -1,14 +1,23 @@
 package com.gravatar.ui.components.atomic
 
 import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.gravatar.api.models.UserProfile
+import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
 import com.gravatar.ui.components.UserProfileState
@@ -58,6 +67,36 @@ public fun AboutMe(
         is UserProfileState.Loaded -> {
             AboutMe(state.userProfile, modifier, textStyle, content)
         }
+
+        UserProfileState.Empty -> {
+            DashedBorder(modifier) {
+                content.invoke(
+                    stringResource(id = R.string.empty_state_about_me),
+                    Modifier.padding(8.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DashedBorder(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    val stroke = Stroke(
+        width = 2f,
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(9f, 4f), 0f),
+    )
+    val borderColor = MaterialTheme.colorScheme.outlineVariant
+    Box(
+        modifier
+            .drawBehind {
+                drawRoundRect(
+                    color = borderColor,
+                    style = stroke,
+                    cornerRadius = CornerRadius(4.dp.toPx()),
+                )
+            },
+    ) {
+        content.invoke()
     }
 }
 
@@ -80,6 +119,12 @@ private fun AboutMePreview() {
                 "doctor away. This about me description is quite long, this is good for testing.",
         ),
     )
+}
+
+@Preview
+@Composable
+private fun AboutMeEmptyState() {
+    AboutMe(UserProfileState.Empty)
 }
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -13,8 +13,10 @@ import coil.compose.AsyncImage
 import com.gravatar.AvatarQueryOptions
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.avatarUrl
+import com.gravatar.ui.R
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
 import com.gravatar.ui.components.UserProfileState
+import com.gravatar.ui.components.isNightModeEnabled
 import com.gravatar.ui.skeletonEffect
 
 /**
@@ -33,13 +35,22 @@ public fun Avatar(
     avatarQueryOptions: AvatarQueryOptions? = null,
 ) {
     val preferredSize = with(LocalDensity.current) { size.roundToPx() }
-    AsyncImage(
-        profile.avatarUrl(
+    Avatar(
+        model = profile.avatarUrl(
             // Override the preferredSize
             avatarQueryOptions?.copy(
                 preferredSize = preferredSize,
             ) ?: AvatarQueryOptions(preferredSize = preferredSize),
         ).url().toString(),
+        size = size,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun Avatar(model: Any?, size: Dp, modifier: Modifier) {
+    AsyncImage(
+        model = model,
         contentDescription = "User profile image",
         modifier = modifier.size(size),
     )
@@ -77,6 +88,16 @@ public fun Avatar(
                 avatarQueryOptions = avatarQueryOptions,
             )
         }
+
+        UserProfileState.Empty -> Avatar(
+            model = if (isNightModeEnabled()) {
+                R.drawable.empty_profile_avatar_dark
+            } else {
+                R.drawable.empty_profile_avatar
+            },
+            size = size,
+            modifier = modifier,
+        )
     }
 }
 
@@ -91,4 +112,10 @@ private fun AvatarPreview() {
 @Composable
 private fun AvatarStatePreview() {
     LoadingToLoadedStatePreview { Avatar(it, 256.dp) }
+}
+
+@Preview
+@Composable
+private fun AvatarEmptyPreview() {
+    Avatar(UserProfileState.Empty, 256.dp)
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
@@ -5,10 +5,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.UserProfile
+import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
 import com.gravatar.ui.components.UserProfileState
@@ -26,7 +28,12 @@ public fun DisplayName(
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
 ) {
-    Text(text = profile.displayName.orEmpty(), modifier = modifier, style = textStyle)
+    DisplayName(profile.displayName.orEmpty(), modifier, textStyle)
+}
+
+@Composable
+private fun DisplayName(displayName: String, modifier: Modifier, textStyle: TextStyle) {
+    Text(text = displayName, modifier = modifier, style = textStyle)
 }
 
 /**
@@ -50,6 +57,12 @@ public fun DisplayName(
         is UserProfileState.Loaded -> {
             DisplayName(state.userProfile, modifier, textStyle)
         }
+
+        UserProfileState.Empty -> DisplayName(
+            displayName = stringResource(id = R.string.empty_state_display_name),
+            modifier,
+            textStyle,
+        )
     }
 }
 

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
@@ -6,11 +6,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.api.models.UserProfile
+import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
 import com.gravatar.ui.components.UserProfileState
@@ -63,7 +65,9 @@ public fun Location(
             Location(state.userProfile, modifier, textStyle, content)
         }
 
-        UserProfileState.Empty -> TODO()
+        UserProfileState.Empty -> {
+            content.invoke(stringResource(id = R.string.empty_state_user_info), modifier)
+        }
     }
 }
 

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
@@ -62,6 +62,8 @@ public fun Location(
         is UserProfileState.Loaded -> {
             Location(state.userProfile, modifier, textStyle, content)
         }
+
+        UserProfileState.Empty -> TODO()
     }
 }
 

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.decode.SvgDecoder
 import coil.request.ImageRequest
+import com.gravatar.GravatarConstants
 import com.gravatar.api.models.Account
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.profileUrl
@@ -197,6 +198,17 @@ public fun SocialIconRow(state: UserProfileState, modifier: Modifier = Modifier,
 
         is UserProfileState.Loaded -> {
             SocialIconRow(state.userProfile, modifier, maxIcons)
+        }
+
+        UserProfileState.Empty -> {
+            SocialIcon(
+                media = SocialMedia(
+                    URL(GravatarConstants.GRAVATAR_BASE_URL),
+                    LocalIcon.Gravatar.name,
+                    icon = LocalIcon.Gravatar,
+                ),
+                modifier = Modifier.size(32.dp),
+            )
         }
     }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
@@ -6,12 +6,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.formattedUserInfo
+import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
 import com.gravatar.ui.components.UserProfileState
@@ -65,6 +67,8 @@ public fun UserInfo(
         is UserProfileState.Loaded -> {
             UserInfo(state.userProfile, modifier, textStyle, content)
         }
+
+        UserProfileState.Empty -> content.invoke(stringResource(R.string.empty_state_user_info), modifier)
     }
 }
 

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
@@ -140,7 +140,7 @@ public fun ViewProfileButton(
         UserProfileState.Empty -> {
             ViewProfileButton(
                 buttonText = stringResource(id = R.string.empty_state_view_profile_button),
-                url = GravatarConstants.GRAVATAR_BASE_URL,
+                url = GravatarConstants.GRAVATAR_SIGN_IN_URL,
                 textStyle = textStyle,
                 inlineContent = inlineContent,
             )

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.gravatar.GravatarConstants
 import com.gravatar.api.models.UserProfile
 import com.gravatar.extensions.profileUrl
 import com.gravatar.ui.R
@@ -51,10 +52,27 @@ public fun ViewProfileButton(
     textStyle: TextStyle = MaterialTheme.typography.titleSmall.copy(color = MaterialTheme.colorScheme.onBackground),
     inlineContent: @Composable ((String) -> Unit)? = { DefaultInlineContent(textStyle.color) },
 ) {
+    ViewProfileButton(
+        stringResource(R.string.view_profile_button),
+        profile.profileUrl().url.toString(),
+        textStyle,
+        modifier,
+        inlineContent,
+    )
+}
+
+@Composable
+private fun ViewProfileButton(
+    buttonText: String,
+    url: String,
+    textStyle: TextStyle,
+    modifier: Modifier = Modifier,
+    inlineContent: @Composable ((String) -> Unit)?,
+) {
     val uriHandler = LocalUriHandler.current
     val iconInlineId = "->"
     val text = buildAnnotatedString {
-        append(stringResource(R.string.view_profile_button))
+        append(buttonText)
         if (inlineContent != null) {
             append(" ")
             // Append a placeholder string "[myBox]" and attach an annotation "inlineContent" on it.
@@ -79,7 +97,7 @@ public fun ViewProfileButton(
 
     TextButton(
         onClick = {
-            uriHandler.openUri(profile.profileUrl().url.toString())
+            uriHandler.openUri(url)
         },
         contentPadding = PaddingValues(start = 0.dp, end = 0.dp),
         modifier = modifier,
@@ -117,6 +135,15 @@ public fun ViewProfileButton(
 
         is UserProfileState.Loaded -> {
             ViewProfileButton(state.userProfile, modifier, textStyle, inlineContent)
+        }
+
+        UserProfileState.Empty -> {
+            ViewProfileButton(
+                buttonText = stringResource(id = R.string.empty_state_view_profile_button),
+                url = GravatarConstants.GRAVATAR_BASE_URL,
+                textStyle = textStyle,
+                inlineContent = inlineContent,
+            )
         }
     }
 }

--- a/gravatar-ui/src/main/res/drawable/empty_profile_avatar.xml
+++ b/gravatar-ui/src/main/res/drawable/empty_profile_avatar.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+  <group>
+    <clip-path
+        android:pathData="M36,0L36,0A36,36 0,0 1,72 36L72,36A36,36 0,0 1,36 72L36,72A36,36 0,0 1,0 36L0,36A36,36 0,0 1,36 0z"/>
+    <path
+        android:pathData="M36,0L36,0A36,36 0,0 1,72 36L72,36A36,36 0,0 1,36 72L36,72A36,36 0,0 1,0 36L0,36A36,36 0,0 1,36 0z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M19.5,48.5C19.9,46.1 24,31.5 26,24.5C-2,2.5 43.5,-21.63 72,12C92,35.6 74.5,60 68,66.5C61.5,73 51.5,74.689 39,73C27.101,71.392 27.833,55.692 29,50.5C26.454,50.654 19.22,50.182 19.5,48.5Z"
+        android:fillColor="#DADADA"/>
+  </group>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M36,0.5L36,0.5A35.5,35.5 0,0 1,71.5 36L71.5,36A35.5,35.5 0,0 1,36 71.5L36,71.5A35.5,35.5 0,0 1,0.5 36L0.5,36A35.5,35.5 0,0 1,36 0.5z"
+      android:fillColor="#00000000"
+      android:strokeColor="#DADADA"/>
+</vector>

--- a/gravatar-ui/src/main/res/drawable/empty_profile_avatar_dark.xml
+++ b/gravatar-ui/src/main/res/drawable/empty_profile_avatar_dark.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+  <group>
+    <clip-path
+        android:pathData="M36,0L36,0A36,36 0,0 1,72 36L72,36A36,36 0,0 1,36 72L36,72A36,36 0,0 1,0 36L0,36A36,36 0,0 1,36 0z"/>
+    <path
+        android:pathData="M36,0L36,0A36,36 0,0 1,72 36L72,36A36,36 0,0 1,36 72L36,72A36,36 0,0 1,0 36L0,36A36,36 0,0 1,36 0z"
+        android:fillColor="#101517"/>
+    <path
+        android:pathData="M19.5,48.5C19.9,46.1 24,31.5 26,24.5C-2,2.5 43.5,-21.63 72,12C92,35.6 74.5,60 68,66.5C61.5,73 51.5,74.689 39,73C27.101,71.392 27.833,55.692 29,50.5C26.454,50.654 19.22,50.182 19.5,48.5Z"
+        android:fillColor="#50575E"/>
+  </group>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M36,0.5L36,0.5A35.5,35.5 0,0 1,71.5 36L71.5,36A35.5,35.5 0,0 1,36 71.5L36,71.5A35.5,35.5 0,0 1,0.5 36L0.5,36A35.5,35.5 0,0 1,36 0.5z"
+      android:fillColor="#00000000"
+      android:strokeColor="#F0F0F0"/>
+</vector>

--- a/gravatar-ui/src/main/res/values/strings.xml
+++ b/gravatar-ui/src/main/res/values/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="view_profile_button">View Profile</string>
+    <string name="empty_state_about_me">Tell the world who you are. Your avatar and bio that follows you across the web.</string>
+    <string name="empty_state_display_name">Your Name</string>
+    <string name="empty_state_user_info">Add your location, pronouns, etc</string>
+    <string name="empty_state_view_profile_button">Claim profile</string>
 </resources>

--- a/gravatar/src/main/java/com/gravatar/GravatarConstants.kt
+++ b/gravatar/src/main/java/com/gravatar/GravatarConstants.kt
@@ -18,4 +18,7 @@ public object GravatarConstants {
 
     /** Gravatar base host */
     public const val GRAVATAR_BASE_URL: String = "https://gravatar.com"
+
+    /** Gravatar Sign-in URL */
+    public const val GRAVATAR_SIGN_IN_URL: String = "$GRAVATAR_BASE_URL/profile"
 }

--- a/gravatar/src/main/java/com/gravatar/GravatarConstants.kt
+++ b/gravatar/src/main/java/com/gravatar/GravatarConstants.kt
@@ -1,18 +1,21 @@
 package com.gravatar
 
-internal object GravatarConstants {
+/**
+ * Gravatar constants
+ */
+public object GravatarConstants {
     /** Gravatar base host */
-    const val GRAVATAR_BASE_HOST = "gravatar.com"
+    internal const val GRAVATAR_BASE_HOST = "gravatar.com"
 
     /** Gravatar host */
-    const val GRAVATAR_WWW_BASE_HOST = "www.gravatar.com"
+    internal const val GRAVATAR_WWW_BASE_HOST = "www.gravatar.com"
 
     /** Gravatar image path */
-    const val GRAVATAR_IMAGE_PATH = "avatar"
+    internal const val GRAVATAR_IMAGE_PATH = "avatar"
 
     /** Gravatar API base URL */
-    const val GRAVATAR_API_BASE_URL = "https://api.gravatar.com/v1/"
+    internal const val GRAVATAR_API_BASE_URL = "https://api.gravatar.com/v1/"
 
     /** Gravatar base host */
-    const val GRAVATAR_BASE_URL = "https://gravatar.com"
+    public const val GRAVATAR_BASE_URL: String = "https://gravatar.com"
 }


### PR DESCRIPTION
Closes #132 

### Description

This PR adds the `empty state` in all the UI components.

| Light | Dark |
|----------|-----------|
|![image](https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/6eb97a90-5d6d-431c-bc34-b6e621330db3)|![image](https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/afb143b8-1ea7-4a24-bb5a-e39e97e54e5e)|

### Testing Steps

Using the demo app, in the `Profile` tab, look for an email without a Gravatar account, (ex: `gravatarr@automattic.com`) and verify that the empty views look as expected. 

While reviewing the views switch between `light` / `dark` and `system` theme.

Verify that tapping over the `Gravatar` icon brings you to the `www.gravatar.com`.
Verify that tapping over the `Claim profile` or any other part of the profile components brings you to the `Sign-up` page.

Smoke test that loading and loaded states also looks as expected.

