### PR TITLE
`demo-app` - Load AccessToken from `local.properties`

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
             )
             buildConfigField(
                 "String",
-                "DEMO_ACCESS_TOKEN",
-                "\"${properties["demo-app.accessToken"]?.toString() ?: ""}\"",
+                "DEMO_WORDPRESS_BEARER_TOKEN",
+                "\"${properties["demo-app.wordPressBearerToken"]?.toString() ?: ""}\"",
             )
         }
     }

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -41,6 +41,11 @@ android {
                 "DEMO_EMAIL",
                 "\"${properties["demo-app.email"]?.toString() ?: "gravatar@automattic.com"}\"",
             )
+            buildConfigField(
+                "String",
+                "DEMO_ACCESS_TOKEN",
+                "\"${properties["demo-app.accessToken"]?.toString() ?: ""}\"",
+            )
         }
     }
 

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -35,7 +35,7 @@ import com.gravatar.ui.GravatarImagePickerWrapperListener
 @Composable
 fun AvatarUpdateTab(showSnackBar: (String?, Throwable?) -> Unit, modifier: Modifier = Modifier) {
     var email by remember { mutableStateOf(BuildConfig.DEMO_EMAIL) }
-    var accessToken by remember { mutableStateOf("") }
+    var accessToken by remember { mutableStateOf(BuildConfig.DEMO_ACCESS_TOKEN) }
     var accessTokenVisible by rememberSaveable { mutableStateOf(false) }
     var isUploading by remember { mutableStateOf(false) }
 

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -35,8 +35,8 @@ import com.gravatar.ui.GravatarImagePickerWrapperListener
 @Composable
 fun AvatarUpdateTab(showSnackBar: (String?, Throwable?) -> Unit, modifier: Modifier = Modifier) {
     var email by remember { mutableStateOf(BuildConfig.DEMO_EMAIL) }
-    var accessToken by remember { mutableStateOf(BuildConfig.DEMO_ACCESS_TOKEN) }
-    var accessTokenVisible by rememberSaveable { mutableStateOf(false) }
+    var wordpressBearerToken by remember { mutableStateOf(BuildConfig.DEMO_WORDPRESS_BEARER_TOKEN) }
+    var wordpressBearerTokenVisible by rememberSaveable { mutableStateOf(false) }
     var isUploading by remember { mutableStateOf(false) }
 
     Column(
@@ -49,11 +49,11 @@ fun AvatarUpdateTab(showSnackBar: (String?, Throwable?) -> Unit, modifier: Modif
         val context = LocalContext.current
         GravatarEmailInput(email = email, onValueChange = { email = it }, Modifier.fillMaxWidth())
         GravatarPasswordInput(
-            password = accessToken,
-            passwordIsVisible = accessTokenVisible,
-            onValueChange = { accessToken = it },
-            onVisibilityChange = { accessTokenVisible = it },
-            label = { Text(stringResource(R.string.access_token_label)) },
+            password = wordpressBearerToken,
+            passwordIsVisible = wordpressBearerTokenVisible,
+            onValueChange = { wordpressBearerToken = it },
+            onVisibilityChange = { wordpressBearerTokenVisible = it },
+            label = { Text(stringResource(R.string.wordpress_bearer_token_label)) },
             modifier = Modifier
                 .padding(top = 16.dp)
                 .fillMaxWidth(),
@@ -61,7 +61,7 @@ fun AvatarUpdateTab(showSnackBar: (String?, Throwable?) -> Unit, modifier: Modif
         GravatarImagePickerWrapper(
             { UpdateAvatarComposable(isUploading) },
             email,
-            accessToken,
+            wordpressBearerToken,
             object : GravatarImagePickerWrapperListener {
                 override fun onAvatarUploadStarted() {
                     isUploading = true

--- a/demo-app/src/main/res/values/strings.xml
+++ b/demo-app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="text_display_name">Display Name: %1$s</string>
     <string name="text_url">Url: %1$s</string>
     <string name="button_load_gravatar">Load Gravatar</string>
-    <string name="access_token_label">Access Token</string>
+    <string name="wordpress_bearer_token_label">Wordpress Bearer Token</string>
     <string name="theme_label">Theme</string>
     <string name="update_avatar_button_label">Update Avatar</string>
     <string name="avatar_update_upload_success_toast">Upload success</string>

--- a/gravatar-ui/src/main/java/com/gravatar/ui/GravatarImagePickerWrapper.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/GravatarImagePickerWrapper.kt
@@ -31,7 +31,7 @@ import java.io.File
  *
  * @param content The content to be wrapped by the [GravatarImagePickerWrapper].
  * @param email The email associated with the Gravatar account.
- * @param accessToken The access token to authenticate the Gravatar account.
+ * @param wordpressBearerToken The wordpress bearer token to authenticate the Gravatar account.
  * @param listener The listener to be informed about the avatar upload status.
  * @param modifier Composable modifier that allows customize the [GravatarImagePickerWrapper].
  * @param imageEditionOptions The options to customize the image edition UI.
@@ -40,7 +40,7 @@ import java.io.File
 public fun GravatarImagePickerWrapper(
     content: @Composable () -> Unit,
     email: String,
-    accessToken: String,
+    wordpressBearerToken: String,
     listener: GravatarImagePickerWrapperListener,
     modifier: Modifier = Modifier,
     imageEditionOptions: ImageEditionStyling = ImageEditionStyling(),
@@ -53,7 +53,7 @@ public fun GravatarImagePickerWrapper(
         it.data?.let { intentData ->
             UCrop.getOutput(intentData)?.let { croppedImageUri ->
                 listener.onAvatarUploadStarted()
-                AvatarService().upload(croppedImageUri.toFile(), Email(email), accessToken, listener)
+                AvatarService().upload(croppedImageUri.toFile(), Email(email), wordpressBearerToken, listener)
             }
         }
     }

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -30,13 +30,13 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
      *
      * @param file The image file to upload
      * @param email The email address to associate the image with
-     * @param accessToken The bearer token for the user's WordPress/Gravatar account
+     * @param wordpressBearerToken The bearer token for the user's WordPress/Gravatar account
      * @param gravatarUploadListener The listener to notify of the upload result
      */
     public fun upload(
         file: File,
         email: Email,
-        accessToken: String,
+        wordpressBearerToken: String,
         gravatarUploadListener: GravatarListener<Unit, ErrorType>,
     ) {
         val service = GravatarSdkDI.getGravatarApiV1Service(okHttpClient)
@@ -44,7 +44,7 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
         val filePart =
             MultipartBody.Part.createFormData("filedata", file.name, file.asRequestBody())
 
-        service.uploadImage("Bearer $accessToken", identity, filePart).enqueue(
+        service.uploadImage("Bearer $wordpressBearerToken", identity, filePart).enqueue(
             object : Callback<ResponseBody> {
                 override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
                     coroutineScope.launch {

--- a/gravatar/src/test/java/com/gravatar/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/AvatarServiceTest.kt
@@ -35,43 +35,44 @@ class AvatarServiceTest {
     }
 
     @Test
-    fun `given a file, email and accessToken when uploading avatar then Gravatar service is invoked`() = runTest {
-        val uploadGravatarListener = spyk<GravatarListener<Unit, ErrorType>>()
-        val callResponse = mockk<Call<ResponseBody>>()
-        every { containerRule.gravatarApiServiceMock.uploadImage(any(), any(), any()) } returns callResponse
-        every { callResponse.enqueue(any()) } answers { call ->
-            @Suppress("UNCHECKED_CAST")
-            (call.invocation.args[0] as? Callback<ResponseBody>)?.onResponse(
-                callResponse,
-                mockk(relaxed = true) {
-                    every { isSuccessful } returns true
-                },
-            )
-        }
+    fun `given a file, email and wordpressBearerToken when uploading avatar then Gravatar service is invoked`() =
+        runTest {
+            val uploadGravatarListener = spyk<GravatarListener<Unit, ErrorType>>()
+            val callResponse = mockk<Call<ResponseBody>>()
+            every { containerRule.gravatarApiServiceMock.uploadImage(any(), any(), any()) } returns callResponse
+            every { callResponse.enqueue(any()) } answers { call ->
+                @Suppress("UNCHECKED_CAST")
+                (call.invocation.args[0] as? Callback<ResponseBody>)?.onResponse(
+                    callResponse,
+                    mockk(relaxed = true) {
+                        every { isSuccessful } returns true
+                    },
+                )
+            }
 
-        avatarService.upload(File("avatarFile"), Email("email"), "accessToken", uploadGravatarListener)
+            avatarService.upload(File("avatarFile"), Email("email"), "wordpressBearerToken", uploadGravatarListener)
 
-        verify(exactly = 1) {
-            containerRule.gravatarApiServiceMock.uploadImage(
-                "Bearer accessToken",
-                withArg {
-                    assertTrue(
-                        it.headers?.values("Content-Disposition").toString().contains("account"),
-                    )
-                },
-                withArg {
-                    assertTrue(
-                        with(it.headers?.values("Content-Disposition").toString()) {
-                            contains("filedata") && contains("avatarFile")
-                        },
-                    )
-                },
-            )
+            verify(exactly = 1) {
+                containerRule.gravatarApiServiceMock.uploadImage(
+                    "Bearer wordpressBearerToken",
+                    withArg {
+                        assertTrue(
+                            it.headers?.values("Content-Disposition").toString().contains("account"),
+                        )
+                    },
+                    withArg {
+                        assertTrue(
+                            with(it.headers?.values("Content-Disposition").toString()) {
+                                contains("filedata") && contains("avatarFile")
+                            },
+                        )
+                    },
+                )
+            }
+            verify(exactly = 1) {
+                uploadGravatarListener.onSuccess(Unit)
+            }
         }
-        verify(exactly = 1) {
-            uploadGravatarListener.onSuccess(Unit)
-        }
-    }
 
     @Test
     fun `given gravatar update when a unknown error occurs then Gravatar returns UNKNOWN error`() =
@@ -134,7 +135,7 @@ class AvatarServiceTest {
             )
         }
 
-        avatarService.upload(File("avatarFile"), Email("email"), "accessToken", uploadGravatarListener)
+        avatarService.upload(File("avatarFile"), Email("email"), "wordpressBearerToken", uploadGravatarListener)
 
         verify(exactly = 1) {
             uploadGravatarListener.onError(expectedErrorType)
@@ -156,7 +157,7 @@ class AvatarServiceTest {
             )
         }
 
-        avatarService.upload(File("avatarFile"), Email("email"), "accessToken", uploadGravatarListener)
+        avatarService.upload(File("avatarFile"), Email("email"), "wordpressBearerToken", uploadGravatarListener)
 
         verify(exactly = 1) {
             uploadGravatarListener.onError(expectedErrorType)


### PR DESCRIPTION
### Description

To simplify the development process, it would be nice to load the accessToken from the `local.properties`, as we do with the Email.

As a developer you just need to add the following line in your local.properties with your accessToken:

`demo-app.accessToken=YOUR_TOKEN_HERE`

### Testing Steps

- Verify that adding your `accessToken` in `local.properties` loads it in the Avatar Update Tab.
