### PR TITLE
`gravatar`- Update date/time fields

### DIFF
--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -37,6 +37,8 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -72,6 +74,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+
     api("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
@@ -117,6 +121,17 @@ openApiGenerate {
             "groupId" to "com.gravatar",
             "packageName" to "com.gravatar.api",
             "useCoroutines" to "true",
+        ),
+    )
+    importMappings.set(
+        mapOf(
+            "DateTime" to "java.time.Instant",
+        ),
+    )
+
+    typeMappings.set(
+        mapOf(
+            "DateTime" to "java.time.Instant",
         ),
     )
 

--- a/gravatar/openapi/api-gravatar.json
+++ b/gravatar/openapi/api-gravatar.json
@@ -280,7 +280,7 @@
           "registration_date": {
             "type": "string",
             "description": "The date the user registered their account. This is only provided in authenticated API requests.",
-            "format": "date",
+            "format": "date-time",
             "examples": [ "2021-10-01" ]
           }
         }

--- a/gravatar/src/main/java/com/gravatar/api/models/Profile.kt
+++ b/gravatar/src/main/java/com/gravatar/api/models/Profile.kt
@@ -85,8 +85,8 @@ public data class Profile(
     val numberVerifiedAccounts: kotlin.Int? = null,
     // The date and time (UTC) the user last edited their profile. This is only provided in authenticated API requests.
     @SerializedName("last_profile_edit")
-    val lastProfileEdit: java.time.OffsetDateTime? = null,
+    val lastProfileEdit: java.time.Instant? = null,
     // The date the user registered their account. This is only provided in authenticated API requests.
     @SerializedName("registration_date")
-    val registrationDate: java.time.LocalDate? = null,
+    val registrationDate: java.time.Instant? = null,
 )

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -1,6 +1,9 @@
 package com.gravatar.di.container
 
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
 import com.gravatar.GravatarApiService
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V1
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V3
@@ -9,6 +12,8 @@ import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.lang.reflect.Type
+import java.time.Instant
 
 internal class GravatarSdkContainer private constructor() {
     companion object {
@@ -25,7 +30,14 @@ internal class GravatarSdkContainer private constructor() {
     val dispatcherDefault = Dispatchers.Default
     val dispatcherIO = Dispatchers.IO
 
-    private val gson = GsonBuilder().setLenient().create()
+    private val gson = GsonBuilder().setLenient()
+        .registerTypeAdapter(
+            Instant::class.java,
+            JsonDeserializer { json: JsonElement, _: Type, _: JsonDeserializationContext ->
+                Instant.parse(json.asString) // Parses date-time strings as ISO 8601 - "2021-08-31T00:00:00Z"
+            },
+        )
+        .create()
 
     /**
      * Get Gravatar API service

--- a/gravatar/src/main/java/com/gravatar/extensions/UserProfileExtensions.kt
+++ b/gravatar/src/main/java/com/gravatar/extensions/UserProfileExtensions.kt
@@ -11,6 +11,7 @@ import com.gravatar.api.models.ProfilePayments
 import com.gravatar.api.models.VerifiedAccount
 import com.gravatar.types.Hash
 import java.net.URI
+import java.time.Instant
 
 /**
  * Get the hash for a user profile.
@@ -66,8 +67,8 @@ public fun emptyProfile(
     contactInfo: ProfileContactInfo? = null,
     gallery: List<GalleryImage>? = null,
     numberVerifiedAccounts: Int? = null,
-    lastProfileEdit: java.time.OffsetDateTime? = null,
-    registrationDate: java.time.LocalDate? = null,
+    lastProfileEdit: Instant? = null,
+    registrationDate: Instant? = null,
 ): Profile = Profile(
     hash = hash,
     displayName = displayName,


### PR DESCRIPTION
Closes #157 

### Description

We'll need to update [api-gravatar.json](https://github.com/Automattic/Gravatar-SDK-Android/blob/trunk/gravatar/openapi/api-gravatar.json) with the final version of the definition. But in order to keep moving, updating it manually based on previous discussion.

On the other hand, [Instant](https://developer.android.com/reference/java/time/Instant) class is a better representation of the [DateTime](https://www.baeldung.com/openapi-map-date-types#2-date-time) format in our SDK. So, we are modifying the mapping configuration.

We also need to add an adapter to deserialize and string with the proper format to an Instant instance.

### Testing Steps

- Smoke test the demoApp, code review, and CI should be enough. (The change will be more important with a following PR that will enable the API Key so we'll receive those values).