### PR TITLE
`demo-app` - Allowing SSL Proxying in DemoApp

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/demo-app/src/main/res/xml/network_security_config.xml
+++ b/demo-app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
### Description

Allowing the SSL Proxying in the DemoApp simplifies testing when we want to replace the backend response.

One of the key advantages of enabling SSL Proxying is the flexibility it provides. For instance, we can leverage tools like Charles to easily override the backend response, giving testers more control over their testing scenarios.

https://www.charlesproxy.com/documentation/using-charles/ssl-certificates/

**Note:** Adding this configuration is not a security risk because the DemoApp will not be published (at least for now). In addition, that configuration is applied only to the debug version. 

### Testing Steps

- Code review and CI should be enough. If you want to test it and have everything configured (emulator and Charles), you can verify it's working.