### PR TITLE
`gravatar`- Add API Key initialization to the SDK

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -46,6 +46,11 @@ android {
                 "DEMO_WORDPRESS_BEARER_TOKEN",
                 "\"${properties["demo-app.wordPressBearerToken"]?.toString() ?: ""}\"",
             )
+            buildConfigField(
+                "String",
+                "DEMO_GRAVATAR_API_KEY",
+                properties["demo-app.gravatar.api.key"]?.let { "\"$it\"" } ?: "null",
+            )
         }
     }
 

--- a/demo-app/src/main/java/com/gravatar/demoapp/MainActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/MainActivity.kt
@@ -3,11 +3,16 @@ package com.gravatar.demoapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.gravatar.Gravatar
 import com.gravatar.demoapp.ui.DemoGravatarApp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Initialize the Gravatar SDK with the API key if it is available
+        BuildConfig.DEMO_GRAVATAR_API_KEY?.let { Gravatar.initialize(it) }
+
         setContent {
             DemoGravatarApp()
         }

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -59,8 +59,10 @@ import com.gravatar.ImageRating
 import com.gravatar.demoapp.BuildConfig
 import com.gravatar.demoapp.R
 import com.gravatar.demoapp.theme.GravatarDemoAppTheme
+import com.gravatar.demoapp.ui.components.ExpandableSection
 import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.demoapp.ui.model.SettingsState
+import com.gravatar.demoapp.ui.utils.prettyPrint
 import com.gravatar.services.ErrorType
 import com.gravatar.services.ProfileService
 import com.gravatar.services.Result
@@ -310,6 +312,14 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
+            profileState?.let { state ->
+                if (state is UserProfileState.Loaded) {
+                    ExpandableSection(title = stringResource(R.string.raw_profile_title)) {
+                        Text(text = state.userProfile.prettyPrint())
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+            }
             ProfileComponents(profileState, theme, error)
         }
     }

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/components/ExpandableSection.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/components/ExpandableSection.kt
@@ -1,0 +1,62 @@
+package com.gravatar.demoapp.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ExpandableSection(modifier: Modifier = Modifier, title: String, content: @Composable () -> Unit) {
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
+    Column(
+        modifier = modifier
+            .clickable { isExpanded = !isExpanded }
+            .background(color = MaterialTheme.colorScheme.primaryContainer)
+            .fillMaxWidth(),
+    ) {
+        ExpandableSectionTitle(isExpanded = isExpanded, title = title)
+
+        AnimatedVisibility(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.secondaryContainer)
+                .fillMaxWidth(),
+            visible = isExpanded,
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+fun ExpandableSectionTitle(modifier: Modifier = Modifier, isExpanded: Boolean, title: String) {
+    val icon = if (isExpanded) Icons.Rounded.KeyboardArrowUp else Icons.Rounded.KeyboardArrowDown
+
+    Row(modifier = modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
+        Image(
+            modifier = Modifier.size(32.dp),
+            imageVector = icon,
+            colorFilter = ColorFilter.tint(color = MaterialTheme.colorScheme.onPrimaryContainer),
+            contentDescription = "",
+        )
+        Text(text = title, style = MaterialTheme.typography.headlineMedium)
+    }
+}

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/utils/UtilExtensions.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/utils/UtilExtensions.kt
@@ -1,0 +1,41 @@
+package com.gravatar.demoapp.ui.utils
+
+@Suppress("MagicNumber")
+fun Any.prettyPrint() = toString().let { toString ->
+    var indentLevel = 0
+    val indentWidth = 4
+
+    fun padding() = "".padStart(indentLevel * indentWidth)
+    buildString {
+        var ignoreSpace = false
+        toString.onEach { char ->
+            when (char) {
+                '(', '[', '{' -> {
+                    indentLevel++
+                    appendLine(char)
+                    append(padding())
+                }
+
+                ')', ']', '}' -> {
+                    indentLevel--
+                    appendLine()
+                    append(padding())
+                    append(char)
+                }
+
+                ',' -> {
+                    appendLine(char)
+                    append(padding())
+                    ignoreSpace = true
+                }
+
+                ' ' -> {
+                    if (!ignoreSpace) append(char)
+                    ignoreSpace = false
+                }
+
+                else -> append(char)
+            }
+        }
+    }
+}

--- a/demo-app/src/main/res/values/strings.xml
+++ b/demo-app/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="update_avatar_button_label">Update Avatar</string>
     <string name="avatar_update_upload_success_toast">Upload success</string>
     <string name="avatar_update_upload_failed_toast">Upload error: %1$s</string>
+    <string name="raw_profile_title">Raw Profile</string>
 </resources>

--- a/gravatar/openapi/api-gravatar.json
+++ b/gravatar/openapi/api-gravatar.json
@@ -281,9 +281,16 @@
             "type": "string",
             "description": "The date the user registered their account. This is only provided in authenticated API requests.",
             "format": "date-time",
-            "examples": [ "2021-10-01" ]
+            "examples": [ "2021-10-01T12:00:00Z" ]
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Bearer token to authenticate the request. Full profile information is only available in authenticated requests."
       }
     }
   },
@@ -301,19 +308,10 @@
             "name": "profileIdentifier",
             "in": "path",
             "required": true,
-            "description": "This can either be an email address, SHA256 hash of an email address, or profile URL slug.",
+            "description": "This can either be an SHA256 hash of an email address or profile URL slug.",
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Bearer token to authenticate the request. Full profile information is only available in authenticated requests."
           }
         ],
         "responses": {
@@ -339,5 +337,10 @@
         }
       }
     }
-  }
+  },
+  "security": [
+    {
+      "apiKey": []
+    }
+  ]
 }

--- a/gravatar/src/main/java/com/gravatar/Gravatar.kt
+++ b/gravatar/src/main/java/com/gravatar/Gravatar.kt
@@ -1,0 +1,17 @@
+package com.gravatar
+
+import com.gravatar.di.container.GravatarSdkContainer
+
+/**
+ * Entry point for initializing the Gravatar SDK.
+ */
+public object Gravatar {
+    /**
+     * Initializes the Gravatar SDK with the given API key.
+     *
+     * @param gravatarApiKey The API key to use when making requests to the Gravatar backend.
+     */
+    public fun initialize(gravatarApiKey: String) {
+        GravatarSdkContainer.instance.apiKey = gravatarApiKey
+    }
+}

--- a/gravatar/src/main/java/com/gravatar/api/apis/ProfilesApi.kt
+++ b/gravatar/src/main/java/com/gravatar/api/apis/ProfilesApi.kt
@@ -10,7 +10,6 @@ package com.gravatar.api.apis
 import com.gravatar.api.models.Profile
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.Path
 
 internal interface ProfilesApi {
@@ -23,13 +22,11 @@ internal interface ProfilesApi {
      *  - 429: Rate limit exceeded
      *  - 500: Internal server error
      *
-     * @param profileIdentifier This can either be an email address, SHA256 hash of an email address, or profile URL slug.
-     * @param authorization Bearer token to authenticate the request. Full profile information is only available in authenticated requests. (optional)
+     * @param profileIdentifier This can either be an SHA256 hash of an email address or profile URL slug.
      * @return [Profile]
      */
     @GET("profiles/{profileIdentifier}")
     suspend fun getProfileById(
         @Path("profileIdentifier") profileIdentifier: kotlin.String,
-        @Header("Authorization") authorization: kotlin.String? = null,
     ): Response<Profile>
 }

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -26,10 +26,6 @@ internal class GravatarSdkContainer private constructor() {
 
     private fun getRetrofitApiV3Builder() = Retrofit.Builder().baseUrl(GRAVATAR_API_BASE_URL_V3)
 
-    val dispatcherMain: CoroutineDispatcher = Dispatchers.Main
-    val dispatcherDefault = Dispatchers.Default
-    val dispatcherIO = Dispatchers.IO
-
     private val gson = GsonBuilder().setLenient()
         .registerTypeAdapter(
             Instant::class.java,
@@ -38,6 +34,12 @@ internal class GravatarSdkContainer private constructor() {
             },
         )
         .create()
+
+    val dispatcherMain: CoroutineDispatcher = Dispatchers.Main
+    val dispatcherDefault = Dispatchers.Default
+    val dispatcherIO = Dispatchers.IO
+
+    var apiKey: String? = null
 
     /**
      * Get Gravatar API service

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -56,7 +56,7 @@ internal class GravatarSdkContainer private constructor() {
 
     fun getGravatarApiV3Service(okHttpClient: OkHttpClient? = null): GravatarApiService {
         return getRetrofitApiV3Builder().apply {
-            client(okHttpClient ?: OkHttpClient().newBuilder().addInterceptor(AuthenticationInterceptor()).build())
+            client((okHttpClient ?: OkHttpClient()).newBuilder().addInterceptor(AuthenticationInterceptor()).build())
         }.addConverterFactory(GsonConverterFactory.create(gson))
             .build().create(GravatarApiService::class.java)
     }

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -7,6 +7,7 @@ import com.google.gson.JsonElement
 import com.gravatar.GravatarApiService
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V1
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V3
+import com.gravatar.services.AuthenticationInterceptor
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
@@ -55,7 +56,7 @@ internal class GravatarSdkContainer private constructor() {
 
     fun getGravatarApiV3Service(okHttpClient: OkHttpClient? = null): GravatarApiService {
         return getRetrofitApiV3Builder().apply {
-            okHttpClient?.let { client(it) }
+            client(okHttpClient ?: OkHttpClient().newBuilder().addInterceptor(AuthenticationInterceptor()).build())
         }.addConverterFactory(GsonConverterFactory.create(gson))
             .build().create(GravatarApiService::class.java)
     }

--- a/gravatar/src/main/java/com/gravatar/services/AuthenticationInterceptor.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AuthenticationInterceptor.kt
@@ -1,0 +1,17 @@
+package com.gravatar.services
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
+
+internal class AuthenticationInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.proceed(
+            chain.request().newBuilder().apply {
+                if (GravatarSdkDI.apiKey != null) {
+                    addHeader("Authorization", "Bearer " + GravatarSdkDI.apiKey)
+                }
+            }.build(),
+        )
+    }
+}

--- a/gravatar/src/main/java/com/gravatar/services/AuthenticationInterceptor.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AuthenticationInterceptor.kt
@@ -1,17 +1,20 @@
 package com.gravatar.services
 
 import okhttp3.Interceptor
+import okhttp3.Request
 import okhttp3.Response
 import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
 
 internal class AuthenticationInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         return chain.proceed(
-            chain.request().newBuilder().apply {
-                if (GravatarSdkDI.apiKey != null) {
-                    addHeader("Authorization", "Bearer " + GravatarSdkDI.apiKey)
-                }
-            }.build(),
+            chain.request().newBuilder()
+                .addAuthorizationHeaderIfPresent()
+                .build(),
         )
+    }
+
+    private fun Request.Builder.addAuthorizationHeaderIfPresent(): Request.Builder {
+        return GravatarSdkDI.apiKey?.let { addHeader("Authorization", "Bearer $it") } ?: this
     }
 }

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -26,7 +26,7 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      */
     public suspend fun fetch(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingService {
         withContext(GravatarSdkDI.dispatcherIO) {
-            val response = service.getProfileById(hashOrUsername, authenticationBearer)
+            val response = service.getProfileById(hashOrUsername)
             if (response.isSuccessful) {
                 val data = response.body()
                 if (data != null) {

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -26,7 +26,7 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      */
     public suspend fun fetch(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingService {
         withContext(GravatarSdkDI.dispatcherIO) {
-            val response = service.getProfileById(hashOrUsername)
+            val response = service.getProfileById(hashOrUsername, authenticationBearer)
             if (response.isSuccessful) {
                 val data = response.body()
                 if (data != null) {

--- a/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
@@ -1,6 +1,7 @@
 package com.gravatar.services
 
 import kotlinx.coroutines.CancellationException
+import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
 
 internal inline fun <T> runCatchingService(block: () -> Result<T, ErrorType>): Result<T, ErrorType> {
     @Suppress("TooGenericExceptionCaught")
@@ -12,3 +13,6 @@ internal inline fun <T> runCatchingService(block: () -> Result<T, ErrorType>): R
         Result.Failure(ex.errorType())
     }
 }
+
+internal val authenticationBearer: String?
+    get() = GravatarSdkDI.apiKey?.let { "Bearer $it" }

--- a/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
+++ b/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
@@ -14,18 +14,23 @@ import org.junit.runners.model.Statement
 class GravatarSdkContainerRule : TestRule {
     val testDispatcher = UnconfinedTestDispatcher()
 
+    companion object {
+        const val DEFAULT_API_KEY = "apiKey"
+    }
+
     internal var gravatarSdkContainerMock = mockk<GravatarSdkContainer>()
     internal var gravatarApiServiceMock = mockk<GravatarApiService>()
 
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
-                gravatarSdkContainerMock = mockk<GravatarSdkContainer>()
+                gravatarSdkContainerMock = mockk<GravatarSdkContainer>(relaxed = true)
                 gravatarApiServiceMock = mockk<GravatarApiService>(relaxed = true)
                 mockkObject(GravatarSdkContainer)
                 every { gravatarSdkContainerMock.dispatcherMain } returns testDispatcher
                 every { gravatarSdkContainerMock.dispatcherDefault } returns testDispatcher
                 every { gravatarSdkContainerMock.dispatcherIO } returns testDispatcher
+                every { gravatarSdkContainerMock.apiKey } returns null
                 every { GravatarSdkContainer.instance } returns gravatarSdkContainerMock
                 every { gravatarSdkContainerMock.getGravatarApiV1Service(any()) } returns gravatarApiServiceMock
                 every { gravatarSdkContainerMock.getGravatarApiV3Service(any()) } returns gravatarApiServiceMock
@@ -33,5 +38,9 @@ class GravatarSdkContainerRule : TestRule {
                 base.evaluate()
             }
         }
+    }
+
+    fun withApiKey(apiKey: String? = DEFAULT_API_KEY) {
+        every { gravatarSdkContainerMock.apiKey } returns apiKey
     }
 }

--- a/gravatar/src/test/java/com/gravatar/GravatarTest.kt
+++ b/gravatar/src/test/java/com/gravatar/GravatarTest.kt
@@ -1,0 +1,19 @@
+package com.gravatar
+
+import io.mockk.coVerify
+import org.junit.Rule
+import org.junit.Test
+
+class GravatarTest {
+    @get:Rule
+    var containerRule = GravatarSdkContainerRule()
+
+    @Test
+    fun `given an api key when initialize method is invoked with it then it should be set internally`() {
+        val apiKey = "API_KEY"
+
+        Gravatar.initialize(apiKey)
+
+        coVerify(exactly = 1) { containerRule.gravatarSdkContainerMock.apiKey = apiKey }
+    }
+}

--- a/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
@@ -1,6 +1,7 @@
 package com.gravatar.services
 
 import com.gravatar.GravatarSdkContainerRule
+import com.gravatar.GravatarSdkContainerRule.Companion.DEFAULT_API_KEY
 import com.gravatar.api.models.Profile
 import com.gravatar.types.Email
 import com.gravatar.types.Hash
@@ -118,4 +119,31 @@ class ProfileServiceTests {
         coVerify(exactly = 1) { containerRule.gravatarApiServiceMock.getProfileById(usernameEmail.hash().toString()) }
         assertTrue(loadProfileResponse is Result.Success)
     }
+
+    @Test
+    fun `given an username and an api key when loading the profile then api key is sent and result is successful`() =
+        runTest {
+            val username = "username"
+            val mockResponse = mockk<Response<Profile>> {
+                every { isSuccessful } returns true
+                every { body() } returns mockk()
+            }
+            containerRule.withApiKey()
+            coEvery {
+                containerRule.gravatarApiServiceMock.getProfileById(
+                    username,
+                    "Bearer $DEFAULT_API_KEY",
+                )
+            } returns mockResponse
+
+            val loadProfileResponse = profileService.fetchByUsername(username)
+
+            coVerify(exactly = 1) {
+                containerRule.gravatarApiServiceMock.getProfileById(
+                    username,
+                    "Bearer $DEFAULT_API_KEY",
+                )
+            }
+            assertTrue(loadProfileResponse is Result.Success)
+        }
 }

--- a/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
@@ -1,7 +1,6 @@
 package com.gravatar.services
 
 import com.gravatar.GravatarSdkContainerRule
-import com.gravatar.GravatarSdkContainerRule.Companion.DEFAULT_API_KEY
 import com.gravatar.api.models.Profile
 import com.gravatar.types.Email
 import com.gravatar.types.Hash
@@ -37,7 +36,7 @@ class ProfileServiceTests {
             every { isSuccessful } returns true
             every { body() } returns mockk()
         }
-        coEvery { containerRule.gravatarApiServiceMock.getProfileById(username, any()) } returns mockResponse
+        coEvery { containerRule.gravatarApiServiceMock.getProfileById(username) } returns mockResponse
 
         val loadProfileResponse = profileService.fetchByUsername(username)
 
@@ -53,7 +52,7 @@ class ProfileServiceTests {
                 every { isSuccessful } returns true
                 every { body() } returns null
             }
-            coEvery { containerRule.gravatarApiServiceMock.getProfileById(username, any()) } returns mockResponse
+            coEvery { containerRule.gravatarApiServiceMock.getProfileById(username) } returns mockResponse
 
             val loadProfileResponse = profileService.fetchByUsername(username)
 
@@ -67,7 +66,7 @@ class ProfileServiceTests {
         val mockResponse = mockk<Response<Profile>> {
             every { isSuccessful } returns false
         }
-        coEvery { containerRule.gravatarApiServiceMock.getProfileById(username, any()) } returns mockResponse
+        coEvery { containerRule.gravatarApiServiceMock.getProfileById(username) } returns mockResponse
 
         val loadProfileResponse = profileService.fetchByUsername(username)
 
@@ -78,7 +77,7 @@ class ProfileServiceTests {
     @Test
     fun `given an username when loading its profile and an exception is thrown then result is failure`() = runTest {
         val username = "username"
-        coEvery { containerRule.gravatarApiServiceMock.getProfileById(username, any()) } throws Exception()
+        coEvery { containerRule.gravatarApiServiceMock.getProfileById(username) } throws Exception()
 
         val loadProfileResponse = profileService.fetchByUsername(username)
 
@@ -94,7 +93,7 @@ class ProfileServiceTests {
             every { body() } returns mockk()
         }
         coEvery {
-            containerRule.gravatarApiServiceMock.getProfileById(usernameHash.toString(), any())
+            containerRule.gravatarApiServiceMock.getProfileById(usernameHash.toString())
         } returns mockResponse
 
         val loadProfileResponse = profileService.fetch(usernameHash)
@@ -111,7 +110,7 @@ class ProfileServiceTests {
             every { body() } returns mockk()
         }
         coEvery {
-            containerRule.gravatarApiServiceMock.getProfileById(usernameEmail.hash().toString(), any())
+            containerRule.gravatarApiServiceMock.getProfileById(usernameEmail.hash().toString())
         } returns mockResponse
 
         val loadProfileResponse = profileService.fetch(usernameEmail)
@@ -119,31 +118,4 @@ class ProfileServiceTests {
         coVerify(exactly = 1) { containerRule.gravatarApiServiceMock.getProfileById(usernameEmail.hash().toString()) }
         assertTrue(loadProfileResponse is Result.Success)
     }
-
-    @Test
-    fun `given an username and an api key when loading the profile then api key is sent and result is successful`() =
-        runTest {
-            val username = "username"
-            val mockResponse = mockk<Response<Profile>> {
-                every { isSuccessful } returns true
-                every { body() } returns mockk()
-            }
-            containerRule.withApiKey()
-            coEvery {
-                containerRule.gravatarApiServiceMock.getProfileById(
-                    username,
-                    "Bearer $DEFAULT_API_KEY",
-                )
-            } returns mockResponse
-
-            val loadProfileResponse = profileService.fetchByUsername(username)
-
-            coVerify(exactly = 1) {
-                containerRule.gravatarApiServiceMock.getProfileById(
-                    username,
-                    "Bearer $DEFAULT_API_KEY",
-                )
-            }
-            assertTrue(loadProfileResponse is Result.Success)
-        }
 }

--- a/gravatar/src/test/java/com/gravatar/services/ServiceUtilsTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ServiceUtilsTest.kt
@@ -1,0 +1,28 @@
+package com.gravatar.services
+
+import com.gravatar.GravatarSdkContainerRule
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+class ServiceUtilsTest {
+    @get:Rule
+    var containerRule = GravatarSdkContainerRule()
+
+    @Test
+    fun `given an api key when the sdk has been initialized then authenticationBearer should return a Bearer token`() {
+        val apiKey = "API_KEY"
+
+        containerRule.withApiKey(apiKey)
+
+        assertEquals("Bearer $apiKey", authenticationBearer)
+    }
+
+    @Test
+    fun `given no api key when getting authenticationBearer then it should be null`() {
+        containerRule.withApiKey(null)
+
+        assertNull(authenticationBearer)
+    }
+}


### PR DESCRIPTION
Closes #156 

### Description

Adding the method to initialize the SDK with the API Key. At the moment, that API Key is required by the new REST API when you want to get a full profile. Without the API  Key, some fields are not returned by the backend because you need to be authenticated.

Also adding in the DemoApp an expandable section that allows to review the profile raw data:

<img width="250" alt="image" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/22574a03-ae7c-4647-bef2-7a561c7f93d6">  <img width="250" alt="image" src="https://github.com/Automattic/Gravatar-SDK-Android/assets/6974554/6c48c9ff-f514-4111-9574-eaea371c9393">

### Testing Steps

- Add your ApiKey in `local.properties` as follows:
```
demo-app.gravatar.api.key=YOUR_API_KEY_HERE
```
- Launch the DemoApp
- Go to the `Profile` tab
- Get any profile
- Expand the `Raw Profile`
- Verify it contains fields only present within authenticated requests like: `registrationDate`, `lastProfileEdit`, `contactInfo` etc.

- You can also verify that you don't receive those fields when the ApiKey is removed from `local.properties`.