### PR TITLE
Refactor `UserProfileState` to a generic state

### DIFF
--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ComponentState.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ComponentState.kt
@@ -14,38 +14,39 @@ import com.gravatar.api.models.Profile
 import com.gravatar.api.models.VerifiedAccount
 import com.gravatar.extensions.emptyProfile
 import com.gravatar.ui.GravatarTheme
-import com.gravatar.ui.components.UserProfileState.Loaded
-import com.gravatar.ui.components.UserProfileState.Loading
+import com.gravatar.ui.components.ComponentState.Loaded
+import com.gravatar.ui.components.ComponentState.Loading
 import kotlinx.coroutines.delay
 import java.net.URI
 
 /**
- * [UserProfileState] represents the state of a user profile loading.
+ * [ComponentState] represents the state of a user profile loading.
  * It can be in a [Loading] state or a [Loaded] state.
  */
-public sealed class UserProfileState {
+public sealed class ComponentState<out T> {
     /**
-     * [Loading] represents the state where the user profile is still loading.
+     * [Loading] represents the state where the data is still loading.
      */
-    public data object Loading : UserProfileState()
+    public data object Loading : ComponentState<Nothing>()
 
     /**
-     * [Loaded] represents the state where the user profile has been loaded.
+     * [Loaded] represents the state where the user data has been loaded.
      *
-     * @property userProfile The user's profile information
+     * @param T the type of the information to load
+     * @property loadedValue The loaded information
      */
-    public data class Loaded(val userProfile: Profile) : UserProfileState()
+    public data class Loaded<T>(val loadedValue: T) : ComponentState<T>()
 
     /**
-     * [Empty] represents the state where the user profile is empty, so it can be claimed.
+     * [Empty] represents the state where the data is empty
      */
-    public data object Empty : UserProfileState()
+    public data object Empty : ComponentState<Nothing>()
 }
 
 @Preview
 @Composable
-public fun LoadingToLoadedStatePreview(composable: @Composable (state: UserProfileState) -> Unit = {}) {
-    var state: UserProfileState by remember { mutableStateOf(Loading) }
+public fun LoadingToLoadedStatePreview(composable: @Composable (state: ComponentState<Profile>) -> Unit = {}) {
+    var state: ComponentState<Profile> by remember { mutableStateOf(Loading) }
     LaunchedEffect(key1 = state) {
         delay(5000)
         state = Loaded(

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfile.kt
@@ -35,7 +35,7 @@ import java.net.URI
  */
 @Composable
 public fun LargeProfile(profile: Profile, modifier: Modifier = Modifier) {
-    LargeProfile(state = UserProfileState.Loaded(profile), modifier = modifier)
+    LargeProfile(state = ComponentState.Loaded(profile), modifier = modifier)
 }
 
 /**
@@ -46,7 +46,7 @@ public fun LargeProfile(profile: Profile, modifier: Modifier = Modifier) {
  * @param modifier Composable modifier
  */
 @Composable
-public fun LargeProfile(state: UserProfileState, modifier: Modifier = Modifier) {
+public fun LargeProfile(state: ComponentState<Profile>, modifier: Modifier = Modifier) {
     GravatarTheme {
         EmptyProfileClickableContainer(state) {
             Column(
@@ -125,7 +125,7 @@ public fun DisplayNamePreview() {
 private fun ProfileEmptyPreview() {
     GravatarTheme {
         Surface(Modifier.fillMaxWidth()) {
-            LargeProfile(UserProfileState.Empty)
+            LargeProfile(ComponentState.Empty)
         }
     }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
@@ -33,7 +33,7 @@ import java.net.URI
  */
 @Composable
 public fun LargeProfileSummary(profile: Profile, modifier: Modifier = Modifier) {
-    LargeProfileSummary(UserProfileState.Loaded(profile), modifier)
+    LargeProfileSummary(ComponentState.Loaded(profile), modifier)
 }
 
 /**
@@ -44,7 +44,7 @@ public fun LargeProfileSummary(profile: Profile, modifier: Modifier = Modifier) 
  * @param modifier Composable modifier
  */
 @Composable
-public fun LargeProfileSummary(state: UserProfileState, modifier: Modifier = Modifier) {
+public fun LargeProfileSummary(state: ComponentState<Profile>, modifier: Modifier = Modifier) {
     GravatarTheme {
         EmptyProfileClickableContainer(state) {
             Column(
@@ -122,7 +122,7 @@ public fun LargeProfileLoadingPreview() {
 private fun ProfileEmptyPreview() {
     GravatarTheme {
         Surface(Modifier.fillMaxWidth()) {
-            LargeProfileSummary(UserProfileState.Empty)
+            LargeProfileSummary(ComponentState.Empty)
         }
     }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
@@ -39,7 +39,7 @@ import java.net.URI
  */
 @Composable
 public fun Profile(profile: Profile, modifier: Modifier = Modifier) {
-    Profile(state = UserProfileState.Loaded(profile), modifier = modifier)
+    Profile(state = ComponentState.Loaded(profile), modifier = modifier)
 }
 
 /**
@@ -50,7 +50,7 @@ public fun Profile(profile: Profile, modifier: Modifier = Modifier) {
  * @param modifier Composable modifier
  */
 @Composable
-public fun Profile(state: UserProfileState, modifier: Modifier = Modifier) {
+public fun Profile(state: ComponentState<Profile>, modifier: Modifier = Modifier) {
     GravatarTheme {
         EmptyProfileClickableContainer(state) {
             Column(
@@ -138,7 +138,7 @@ private fun ProfileLoadingPreview() {
 private fun ProfileEmptyPreview() {
     GravatarTheme {
         Surface(Modifier.fillMaxWidth()) {
-            Profile(UserProfileState.Empty)
+            Profile(ComponentState.Empty)
         }
     }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileComponentsUtils.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileComponentsUtils.kt
@@ -6,10 +6,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import com.gravatar.GravatarConstants
+import com.gravatar.api.models.Profile
 
 @Composable
-internal fun EmptyProfileClickableContainer(userProfileState: UserProfileState?, content: @Composable () -> Unit) {
-    if (userProfileState is UserProfileState.Empty) {
+internal fun EmptyProfileClickableContainer(
+    userProfileState: ComponentState<Profile>?,
+    content: @Composable () -> Unit,
+) {
+    if (userProfileState is ComponentState.Empty) {
         Box(Modifier.emptyProfileClick(userProfileState)) {
             content()
         }
@@ -19,8 +23,8 @@ internal fun EmptyProfileClickableContainer(userProfileState: UserProfileState?,
 }
 
 @Composable
-private fun Modifier.emptyProfileClick(userProfileState: UserProfileState?): Modifier {
-    return if (userProfileState is UserProfileState.Empty) {
+private fun Modifier.emptyProfileClick(userProfileState: ComponentState<Profile>?): Modifier {
+    return if (userProfileState is ComponentState.Empty) {
         val uriHandler = LocalUriHandler.current
         this.clickable {
             uriHandler.openUri(GravatarConstants.GRAVATAR_SIGN_IN_URL)

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
@@ -34,7 +34,7 @@ import com.gravatar.ui.components.atomic.ViewProfileButton
  */
 @Composable
 public fun ProfileSummary(profile: Profile, modifier: Modifier = Modifier) {
-    ProfileSummary(state = UserProfileState.Loaded(profile), modifier = modifier)
+    ProfileSummary(state = ComponentState.Loaded(profile), modifier = modifier)
 }
 
 /**
@@ -45,7 +45,7 @@ public fun ProfileSummary(profile: Profile, modifier: Modifier = Modifier) {
  * @param modifier Composable modifier
  */
 @Composable
-public fun ProfileSummary(state: UserProfileState, modifier: Modifier = Modifier) {
+public fun ProfileSummary(state: ComponentState<Profile>, modifier: Modifier = Modifier) {
     GravatarTheme {
         EmptyProfileClickableContainer(state) {
             Row(modifier = modifier) {
@@ -60,17 +60,17 @@ public fun ProfileSummary(state: UserProfileState, modifier: Modifier = Modifier
                         textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                     )
                     when (state) {
-                        is UserProfileState.Loaded -> {
-                            if (state.userProfile.location.isNotBlank()) {
+                        is ComponentState.Loaded -> {
+                            if (state.loadedValue.location.isNotBlank()) {
                                 Location(state)
                             }
                         }
 
-                        UserProfileState.Loading -> {
+                        ComponentState.Loading -> {
                             Location(state, modifier.width(120.dp))
                         }
 
-                        UserProfileState.Empty -> {
+                        ComponentState.Empty -> {
                             Location(state)
                         }
                     }
@@ -109,7 +109,7 @@ private fun ProfileSummaryLoadingPreview() {
 private fun ProfileSummaryEmptyPreview() {
     GravatarTheme {
         Surface(Modifier.fillMaxWidth()) {
-            ProfileSummary(UserProfileState.Empty)
+            ProfileSummary(ComponentState.Empty)
         }
     }
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/AboutMe.kt
@@ -20,8 +20,8 @@ import com.gravatar.api.models.Profile
 import com.gravatar.extensions.emptyProfile
 import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileState
 
 /**
  * [AboutMe] is a composable that displays a user's about me description.
@@ -53,7 +53,7 @@ public fun AboutMe(
  */
 @Composable
 public fun AboutMe(
-    state: UserProfileState,
+    state: ComponentState<Profile>,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.bodyMedium,
     content: @Composable ((String, Modifier) -> Unit) = { userInfo, contentModifier ->
@@ -61,15 +61,15 @@ public fun AboutMe(
     },
 ) {
     when (state) {
-        is UserProfileState.Loading -> {
+        is ComponentState.Loading -> {
             TextSkeletonEffect(textStyle = textStyle)
         }
 
-        is UserProfileState.Loaded -> {
-            AboutMe(state.userProfile, modifier, textStyle, content)
+        is ComponentState.Loaded -> {
+            AboutMe(state.loadedValue, modifier, textStyle, content)
         }
 
-        UserProfileState.Empty -> {
+        ComponentState.Empty -> {
             DashedBorder(modifier) {
                 content.invoke(
                     stringResource(id = R.string.empty_state_about_me),
@@ -125,7 +125,7 @@ private fun AboutMePreview() {
 @Preview
 @Composable
 private fun AboutMeEmptyState() {
-    AboutMe(UserProfileState.Empty)
+    AboutMe(ComponentState.Empty)
 }
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -15,8 +15,8 @@ import com.gravatar.api.models.Profile
 import com.gravatar.extensions.avatarUrl
 import com.gravatar.extensions.emptyProfile
 import com.gravatar.ui.R
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileState
 import com.gravatar.ui.components.isNightModeEnabled
 import com.gravatar.ui.skeletonEffect
 
@@ -67,13 +67,13 @@ private fun Avatar(model: Any?, size: Dp, modifier: Modifier) {
  */
 @Composable
 public fun Avatar(
-    state: UserProfileState,
+    state: ComponentState<Profile>,
     size: Dp,
     modifier: Modifier = Modifier,
     avatarQueryOptions: AvatarQueryOptions? = null,
 ) {
     when (state) {
-        is UserProfileState.Loading -> {
+        is ComponentState.Loading -> {
             Box(
                 modifier = modifier
                     .size(size)
@@ -81,16 +81,16 @@ public fun Avatar(
             )
         }
 
-        is UserProfileState.Loaded -> {
+        is ComponentState.Loaded -> {
             Avatar(
-                profile = state.userProfile,
+                profile = state.loadedValue,
                 size = size,
                 modifier = modifier,
                 avatarQueryOptions = avatarQueryOptions,
             )
         }
 
-        UserProfileState.Empty -> Avatar(
+        ComponentState.Empty -> Avatar(
             model = if (isNightModeEnabled()) {
                 R.drawable.empty_profile_avatar_dark
             } else {
@@ -118,5 +118,5 @@ private fun AvatarStatePreview() {
 @Preview
 @Composable
 private fun AvatarEmptyPreview() {
-    Avatar(UserProfileState.Empty, 256.dp)
+    Avatar(ComponentState.Empty, 256.dp)
 }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/DisplayName.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.api.models.Profile
 import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileState
 
 /**
  * [DisplayName] is a composable that displays the user's display name.
@@ -45,20 +45,20 @@ private fun DisplayName(displayName: String, modifier: Modifier, textStyle: Text
  */
 @Composable
 public fun DisplayName(
-    state: UserProfileState,
+    state: ComponentState<Profile>,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
 ) {
     when (state) {
-        is UserProfileState.Loading -> {
+        is ComponentState.Loading -> {
             TextSkeletonEffect(textStyle = textStyle)
         }
 
-        is UserProfileState.Loaded -> {
-            DisplayName(state.userProfile, modifier, textStyle)
+        is ComponentState.Loaded -> {
+            DisplayName(state.loadedValue, modifier, textStyle)
         }
 
-        UserProfileState.Empty -> DisplayName(
+        ComponentState.Empty -> DisplayName(
             displayName = stringResource(id = R.string.empty_state_display_name),
             modifier,
             textStyle,

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Location.kt
@@ -15,8 +15,8 @@ import com.gravatar.api.models.Profile
 import com.gravatar.extensions.emptyProfile
 import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileState
 
 /**
  * [Location] is a composable that displays a user's location in text format.
@@ -50,7 +50,7 @@ public fun Location(
  */
 @Composable
 public fun Location(
-    state: UserProfileState,
+    state: ComponentState<Profile>,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.outline),
     content: @Composable ((String, Modifier) -> Unit) = { location, contentModifier ->
@@ -58,15 +58,15 @@ public fun Location(
     },
 ) {
     when (state) {
-        is UserProfileState.Loading -> {
+        is ComponentState.Loading -> {
             TextSkeletonEffect(textStyle = textStyle, modifier = Modifier.width(120.dp))
         }
 
-        is UserProfileState.Loaded -> {
-            Location(state.userProfile, modifier, textStyle, content)
+        is ComponentState.Loaded -> {
+            Location(state.loadedValue, modifier, textStyle, content)
         }
 
-        UserProfileState.Empty -> {
+        ComponentState.Empty -> {
             content.invoke(stringResource(id = R.string.empty_state_user_info), modifier)
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -28,8 +28,8 @@ import com.gravatar.api.models.VerifiedAccount
 import com.gravatar.extensions.emptyProfile
 import com.gravatar.extensions.profileUrl
 import com.gravatar.ui.R
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileState
 import com.gravatar.ui.skeletonEffect
 import java.net.MalformedURLException
 import java.net.URI
@@ -194,9 +194,9 @@ public fun SocialIconRow(profile: Profile, modifier: Modifier = Modifier, maxIco
  * @param maxIcons The maximum number of icons to display
  */
 @Composable
-public fun SocialIconRow(state: UserProfileState, modifier: Modifier = Modifier, maxIcons: Int = 4) {
+public fun SocialIconRow(state: ComponentState<Profile>, modifier: Modifier = Modifier, maxIcons: Int = 4) {
     when (state) {
-        is UserProfileState.Loading -> {
+        is ComponentState.Loading -> {
             Row(modifier = modifier) {
                 repeat(maxIcons) {
                     Box(
@@ -210,11 +210,11 @@ public fun SocialIconRow(state: UserProfileState, modifier: Modifier = Modifier,
             }
         }
 
-        is UserProfileState.Loaded -> {
-            SocialIconRow(state.userProfile, modifier, maxIcons)
+        is ComponentState.Loaded -> {
+            SocialIconRow(state.loadedValue, modifier, maxIcons)
         }
 
-        UserProfileState.Empty -> {
+        ComponentState.Empty -> {
             SocialIcon(
                 media = SocialMedia(
                     URL(GravatarConstants.GRAVATAR_BASE_URL),

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/UserInfo.kt
@@ -16,8 +16,8 @@ import com.gravatar.extensions.emptyProfile
 import com.gravatar.extensions.formattedUserInfo
 import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileState
 
 /**
  * [UserInfo] is a composable that displays a user's information in a formatted way.
@@ -53,7 +53,7 @@ public fun UserInfo(
  */
 @Composable
 public fun UserInfo(
-    state: UserProfileState,
+    state: ComponentState<Profile>,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.outline),
     content: @Composable ((String, Modifier) -> Unit) = { userInfo, contentModifier ->
@@ -61,15 +61,15 @@ public fun UserInfo(
     },
 ) {
     when (state) {
-        is UserProfileState.Loading -> {
+        is ComponentState.Loading -> {
             TextSkeletonEffect(textStyle = textStyle, modifier = Modifier.width(120.dp))
         }
 
-        is UserProfileState.Loaded -> {
-            UserInfo(state.userProfile, modifier, textStyle, content)
+        is ComponentState.Loaded -> {
+            UserInfo(state.loadedValue, modifier, textStyle, content)
         }
 
-        UserProfileState.Empty -> content.invoke(stringResource(R.string.empty_state_user_info), modifier)
+        ComponentState.Empty -> content.invoke(stringResource(R.string.empty_state_user_info), modifier)
     }
 }
 

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/ViewProfileButton.kt
@@ -34,8 +34,8 @@ import com.gravatar.extensions.emptyProfile
 import com.gravatar.extensions.profileUrl
 import com.gravatar.ui.R
 import com.gravatar.ui.TextSkeletonEffect
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LoadingToLoadedStatePreview
-import com.gravatar.ui.components.UserProfileState
 
 /**
  * ViewProfileButton is a composable that displays a button to view a user's profile.
@@ -118,13 +118,13 @@ private fun ViewProfileButton(
  */
 @Composable
 public fun ViewProfileButton(
-    state: UserProfileState,
+    state: ComponentState<Profile>,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.titleSmall.copy(color = MaterialTheme.colorScheme.onBackground),
     inlineContent: @Composable ((String) -> Unit)? = { DefaultInlineContent(textStyle.color) },
 ) {
     when (state) {
-        is UserProfileState.Loading -> {
+        is ComponentState.Loading -> {
             TextButton(
                 onClick = {},
                 contentPadding = PaddingValues(start = 0.dp, end = 0.dp),
@@ -134,11 +134,11 @@ public fun ViewProfileButton(
             }
         }
 
-        is UserProfileState.Loaded -> {
-            ViewProfileButton(state.userProfile, modifier, textStyle, inlineContent)
+        is ComponentState.Loaded -> {
+            ViewProfileButton(state.loadedValue, modifier, textStyle, inlineContent)
         }
 
-        UserProfileState.Empty -> {
+        ComponentState.Empty -> {
             ViewProfileButton(
                 buttonText = stringResource(id = R.string.empty_state_view_profile_button),
                 url = GravatarConstants.GRAVATAR_SIGN_IN_URL,

--- a/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/components/LargeProfileSummaryTest.kt
+++ b/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/components/LargeProfileSummaryTest.kt
@@ -2,23 +2,23 @@ package com.gravatar.gravatar.ui.components
 
 import com.gravatar.gravatar.ui.RoborazziTest
 import com.gravatar.gravatar.ui.completeProfile
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LargeProfileSummary
-import com.gravatar.ui.components.UserProfileState
 import org.junit.Test
 import org.robolectric.annotation.Config
 
 class LargeProfileSummaryTest : RoborazziTest() {
     @Test
     @Config(qualifiers = "+night")
-    fun profileLoadingDark() = gravatarScreenshotTest { LargeProfileSummary(UserProfileState.Loading) }
+    fun profileLoadingDark() = gravatarScreenshotTest { LargeProfileSummary(ComponentState.Loading) }
 
     @Test
-    fun profileLoadingLight() = gravatarScreenshotTest { LargeProfileSummary(UserProfileState.Loading) }
+    fun profileLoadingLight() = gravatarScreenshotTest { LargeProfileSummary(ComponentState.Loading) }
 
     @Test
     @Config(qualifiers = "+night")
-    fun profileDark() = gravatarScreenshotTest { LargeProfileSummary(UserProfileState.Loaded(completeProfile)) }
+    fun profileDark() = gravatarScreenshotTest { LargeProfileSummary(ComponentState.Loaded(completeProfile)) }
 
     @Test
-    fun profileLight() = gravatarScreenshotTest { LargeProfileSummary(UserProfileState.Loaded(completeProfile)) }
+    fun profileLight() = gravatarScreenshotTest { LargeProfileSummary(ComponentState.Loaded(completeProfile)) }
 }

--- a/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/components/LargeProfileTest.kt
+++ b/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/components/LargeProfileTest.kt
@@ -2,23 +2,23 @@ package com.gravatar.gravatar.ui.components
 
 import com.gravatar.gravatar.ui.RoborazziTest
 import com.gravatar.gravatar.ui.completeProfile
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LargeProfile
-import com.gravatar.ui.components.UserProfileState
 import org.junit.Test
 import org.robolectric.annotation.Config
 
 class LargeProfileTest : RoborazziTest() {
     @Test
     @Config(qualifiers = "+night")
-    fun profileLoadingDark() = gravatarScreenshotTest { LargeProfile(UserProfileState.Loading) }
+    fun profileLoadingDark() = gravatarScreenshotTest { LargeProfile(ComponentState.Loading) }
 
     @Test
-    fun profileLoadingLight() = gravatarScreenshotTest { LargeProfile(UserProfileState.Loading) }
+    fun profileLoadingLight() = gravatarScreenshotTest { LargeProfile(ComponentState.Loading) }
 
     @Test
     @Config(qualifiers = "+night")
-    fun profileDark() = gravatarScreenshotTest { LargeProfile(UserProfileState.Loaded(completeProfile)) }
+    fun profileDark() = gravatarScreenshotTest { LargeProfile(ComponentState.Loaded(completeProfile)) }
 
     @Test
-    fun profileLight() = gravatarScreenshotTest { LargeProfile(UserProfileState.Loaded(completeProfile)) }
+    fun profileLight() = gravatarScreenshotTest { LargeProfile(ComponentState.Loaded(completeProfile)) }
 }

--- a/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/components/ProfileSummaryTest.kt
+++ b/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/components/ProfileSummaryTest.kt
@@ -2,23 +2,23 @@ package com.gravatar.gravatar.ui.components
 
 import com.gravatar.gravatar.ui.RoborazziTest
 import com.gravatar.gravatar.ui.completeProfile
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.ProfileSummary
-import com.gravatar.ui.components.UserProfileState
 import org.junit.Test
 import org.robolectric.annotation.Config
 
 class ProfileSummaryTest : RoborazziTest() {
     @Test
     @Config(qualifiers = "+night")
-    fun profileLoadingDark() = gravatarScreenshotTest { ProfileSummary(UserProfileState.Loading) }
+    fun profileLoadingDark() = gravatarScreenshotTest { ProfileSummary(ComponentState.Loading) }
 
     @Test
-    fun profileLoadingLight() = gravatarScreenshotTest { ProfileSummary(UserProfileState.Loading) }
+    fun profileLoadingLight() = gravatarScreenshotTest { ProfileSummary(ComponentState.Loading) }
 
     @Test
     @Config(qualifiers = "+night")
-    fun profileDark() = gravatarScreenshotTest { ProfileSummary(UserProfileState.Loaded(completeProfile)) }
+    fun profileDark() = gravatarScreenshotTest { ProfileSummary(ComponentState.Loaded(completeProfile)) }
 
     @Test
-    fun profileLight() = gravatarScreenshotTest { ProfileSummary(UserProfileState.Loaded(completeProfile)) }
+    fun profileLight() = gravatarScreenshotTest { ProfileSummary(ComponentState.Loaded(completeProfile)) }
 }

--- a/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/components/ProfileTest.kt
+++ b/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/components/ProfileTest.kt
@@ -2,23 +2,23 @@ package com.gravatar.gravatar.ui.components
 
 import com.gravatar.gravatar.ui.RoborazziTest
 import com.gravatar.gravatar.ui.completeProfile
+import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.Profile
-import com.gravatar.ui.components.UserProfileState
 import org.junit.Test
 import org.robolectric.annotation.Config
 
 class ProfileTest : RoborazziTest() {
     @Test
     @Config(qualifiers = "+night")
-    fun profileLoadingDark() = gravatarScreenshotTest { Profile(UserProfileState.Loading) }
+    fun profileLoadingDark() = gravatarScreenshotTest { Profile(ComponentState.Loading) }
 
     @Test
-    fun profileLoadingLight() = gravatarScreenshotTest { Profile(UserProfileState.Loading) }
+    fun profileLoadingLight() = gravatarScreenshotTest { Profile(ComponentState.Loading) }
 
     @Test
     @Config(qualifiers = "+night")
-    fun profileDark() = gravatarScreenshotTest { Profile(UserProfileState.Loaded(completeProfile)) }
+    fun profileDark() = gravatarScreenshotTest { Profile(ComponentState.Loaded(completeProfile)) }
 
     @Test
-    fun profileLight() = gravatarScreenshotTest { Profile(UserProfileState.Loaded(completeProfile)) }
+    fun profileLight() = gravatarScreenshotTest { Profile(ComponentState.Loaded(completeProfile)) }
 }


### PR DESCRIPTION
Closes #167 

### Description

Replacing the concrete `UserProfileState` with a generic state that can be used with different types of data. For example, image a component that receives a `String`; with that generic state, we can implement it. 

### Testing Steps

- Smoke test the app. Everything should work as before. Pay special attention to the `Profile` tab.