### PR TITLE
Bump kotlin to v2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.kotlin/

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.22" />
+    <option name="version" value="2.0.0" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,8 @@ import org.jetbrains.dokka.versioning.VersioningPlugin
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.1.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
 
     // Ktlint
     id("org.jlleitschuh.gradle.ktlint") version "12.1.0" apply false

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -4,6 +4,7 @@ import java.util.Properties
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
 
     // Ktlint
     id("org.jlleitschuh.gradle.ktlint")
@@ -70,8 +71,13 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.8"
+    composeCompiler {
+        // Enable 'strong skipping'
+        // https://medium.com/androiddevelopers/jetpack-compose-strong-skipping-mode-explained-cbdb2aa4b900
+        enableStrongSkippingMode.set(true)
+        // Needed for Layout Inspector to be able to see all of the nodes in the component tree:
+        // https://issuetracker.google.com/issues/338842143
+        includeSourceInformation.set(true)
     }
     detekt {
         config.setFrom("${project.rootDir}/config/detekt/detekt.yml")

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -52,9 +52,6 @@ android {
         compose = true
     }
     composeCompiler {
-        // Enable 'strong skipping'
-        // https://medium.com/androiddevelopers/jetpack-compose-strong-skipping-mode-explained-cbdb2aa4b900
-        enableStrongSkippingMode.set(true)
         // Needed for Layout Inspector to be able to see all of the nodes in the component tree:
         // https://issuetracker.google.com/issues/338842143
         includeSourceInformation.set(true)

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("com.automattic.android.publish-to-s3")
 
     // Ktlint
@@ -50,8 +51,13 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.8"
+    composeCompiler {
+        // Enable 'strong skipping'
+        // https://medium.com/androiddevelopers/jetpack-compose-strong-skipping-mode-explained-cbdb2aa4b900
+        enableStrongSkippingMode.set(true)
+        // Needed for Layout Inspector to be able to see all of the nodes in the component tree:
+        // https://issuetracker.google.com/issues/338842143
+        includeSourceInformation.set(true)
     }
 
     tasks.withType<DokkaTaskPartial>().configureEach {


### PR DESCRIPTION

Closes #147 

### Description

- Bumped Kotlin to v2.0.0
- Applied compose compiler's Gradle plugin as it's now required for use with kotlin 2.0.0
- Enable skipping mode for compose compiler 



### Testing Steps

- Built and run the demo app to make sure it runs
- Ran `./gradlew ktlintcheck detekt` to make sure it was successful
- Ran `./gradlew assemble` to make sure it was successful
- Ran `./gradlew test` to make sure it was successful
- Ran `./gradlew :gravatar-ui:verifyRoborazziDebug -Pscreenshot`
