### PR TITLE
Bump AGP version + enabling desugaring in other modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.dokka.versioning.VersioningPlugin
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.0" apply false
+    id("com.android.application") version "8.4.1" apply false
     id("org.jetbrains.kotlin.android") version "2.0.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
 

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -62,6 +62,8 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -89,6 +91,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+
     // Demo App dependencies
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")

--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -44,6 +44,35 @@ dependencies {
 }
 ```
 
+### Enable desugaring
+
+The Gravatar SDK uses Java 8 features in it's core module, so you need to [enable desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) in each module depending on the SDK. You can do this by adding the following to your `build.gradle` file:
+
+```groovy
+android {
+    compileOptions {
+        // For AGP 4.1+
+        isCoreLibraryDesugaringEnabled = true
+        // For AGP 4.0
+        // coreLibraryDesugaringEnabled = true
+
+        // Sets Java compatibility to Java 8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    // For AGP 7.4+
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    // For AGP 7.3
+    // coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.3")
+    // For AGP 4.0 to 7.2
+    // coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.9")
+}
+
+```
+
 ### Store the Gravatar API key in your app
 
 There are many ways to store the Gravatar API key in your app. The best way to do this depends on your app's architecture and requirements and how you're already storing other sensitive information. Make sure to avoid hardcoding the API key in your app's code and make sure to avoid storing it in a public repository.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jan 12 17:57:23 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -35,6 +35,8 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -88,6 +90,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")


### PR DESCRIPTION
### Description

After bumping Kotlin to 2.0.0 #173, some CI tasks [have started failing](https://github.com/Automattic/Gravatar-SDK-Android/actions/runs/9461375953/job/26062126862). You can replicate it locally by executing:

```
./gradlew :gravatar:dependencies :gravatar-ui:dependencies
```

Bumping the AGP solves the issue.

**Note:** The latest version of AGP requires your modules to enable desugaring if they depend on another module using desugaring ([see](
https://issuetracker.google.com/issues/329346764)). In our case, `gravatar-ui` and `demo-app` depend on `core,` which has desugaring enabled. It shouldn't be a problem, but feel free to open a discussion if you think of another way.

### Testing Steps

- Checkout locally the code and execute:

```
./gradlew :gravatar:dependencies :gravatar-ui:dependencies
```
