### PR TITLE
`gravatar-ui` - Profile components over a `surface`

### DIFF
--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfile.kt
@@ -28,7 +28,7 @@ import java.net.URI
 
 /**
  * [LargeProfile] is a composable that displays a user's profile card.
- * Given a [UserProfile], it displays a [LargeProfile] using the other atomic components provided within the SDK.
+ * Given a [ComponentState], it displays a [LargeProfile] using the other atomic components provided within the SDK.
  *
  * @param profile The user's profile information
  * @param modifier Composable modifier
@@ -40,7 +40,7 @@ public fun LargeProfile(profile: Profile, modifier: Modifier = Modifier) {
 
 /**
  * [LargeProfile] is a composable that displays a user's profile card.
- * Given a [UserProfileState], it displays a [LargeProfile] or the skeleton if it's in a loading state.
+ * Given a [ComponentState] for a [Profile], it displays a [LargeProfile] or the skeleton if it's in a loading state.
  *
  * @param state The user's profile state
  * @param modifier Composable modifier
@@ -48,27 +48,29 @@ public fun LargeProfile(profile: Profile, modifier: Modifier = Modifier) {
 @Composable
 public fun LargeProfile(state: ComponentState<Profile>, modifier: Modifier = Modifier) {
     GravatarTheme {
-        EmptyProfileClickableContainer(state) {
-            Column(
-                modifier = modifier,
-            ) {
-                Avatar(
-                    state = state,
-                    size = 132.dp,
-                    modifier = Modifier.clip(CircleShape),
-                )
-                DisplayName(state, modifier = Modifier.padding(top = 16.dp))
-                UserInfo(state)
-                AboutMe(state, modifier = Modifier.padding(top = 8.dp))
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 4.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
+        Surface {
+            EmptyProfileClickableContainer(state) {
+                Column(
+                    modifier = modifier,
                 ) {
-                    SocialIconRow(state, maxIcons = 4)
-                    ViewProfileButton(state, Modifier.padding(0.dp))
+                    Avatar(
+                        state = state,
+                        size = 132.dp,
+                        modifier = Modifier.clip(CircleShape),
+                    )
+                    DisplayName(state, modifier = Modifier.padding(top = 16.dp))
+                    UserInfo(state)
+                    AboutMe(state, modifier = Modifier.padding(top = 8.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        SocialIconRow(state, maxIcons = 4)
+                        ViewProfileButton(state, Modifier.padding(0.dp))
+                    }
                 }
             }
         }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/LargeProfileSummary.kt
@@ -38,7 +38,8 @@ public fun LargeProfileSummary(profile: Profile, modifier: Modifier = Modifier) 
 
 /**
  * [LargeProfileSummary] is a composable that displays a user's profile in a resumed way.
- * Given a [UserProfileState], it displays a [LargeProfileSummary] or the skeleton if it's in a loading state.
+ * Given a [ComponentState] for a [Profile], it displays a [LargeProfileSummary] or the skeleton if it's
+ * in a loading state.
  *
  * @param state The user's profile state
  * @param modifier Composable modifier
@@ -46,25 +47,27 @@ public fun LargeProfileSummary(profile: Profile, modifier: Modifier = Modifier) 
 @Composable
 public fun LargeProfileSummary(state: ComponentState<Profile>, modifier: Modifier = Modifier) {
     GravatarTheme {
-        EmptyProfileClickableContainer(state) {
-            Column(
-                modifier = modifier,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Avatar(
-                    state = state,
-                    size = 132.dp,
-                    modifier = Modifier.clip(CircleShape),
-                )
-                DisplayName(state, modifier = Modifier.padding(top = 16.dp))
-                UserInfo(
-                    state,
-                    textStyle = MaterialTheme.typography.bodyMedium.copy(
-                        color = MaterialTheme.colorScheme.outline,
-                        textAlign = TextAlign.Center,
-                    ),
-                )
-                ViewProfileButton(state, Modifier.padding(0.dp), inlineContent = null)
+        Surface {
+            EmptyProfileClickableContainer(state) {
+                Column(
+                    modifier = modifier,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Avatar(
+                        state = state,
+                        size = 132.dp,
+                        modifier = Modifier.clip(CircleShape),
+                    )
+                    DisplayName(state, modifier = Modifier.padding(top = 16.dp))
+                    UserInfo(
+                        state,
+                        textStyle = MaterialTheme.typography.bodyMedium.copy(
+                            color = MaterialTheme.colorScheme.outline,
+                            textAlign = TextAlign.Center,
+                        ),
+                    )
+                    ViewProfileButton(state, Modifier.padding(0.dp), inlineContent = null)
+                }
             }
         }
     }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/Profile.kt
@@ -44,7 +44,7 @@ public fun Profile(profile: Profile, modifier: Modifier = Modifier) {
 
 /**
  * [Profile] is a composable that displays a user's profile card.
- * Given a [UserProfileState], it displays a profile UI component or the skeleton if it's in a loading state.
+ * Given a [ComponentState] for a [Profile], it displays a [Profile] or the skeleton if it's in a loading state.
  *
  * @param state The user's profile state
  * @param modifier Composable modifier
@@ -52,36 +52,38 @@ public fun Profile(profile: Profile, modifier: Modifier = Modifier) {
 @Composable
 public fun Profile(state: ComponentState<Profile>, modifier: Modifier = Modifier) {
     GravatarTheme {
-        EmptyProfileClickableContainer(state) {
-            Column(
-                modifier = modifier,
-                horizontalAlignment = Alignment.Start,
-                verticalArrangement = Arrangement.Top,
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Avatar(
-                        state = state,
-                        size = 72.dp,
-                        modifier = Modifier.clip(CircleShape),
-                    )
-                    Column(modifier = Modifier.padding(14.dp, 0.dp, 0.dp, 0.dp)) {
-                        DisplayName(
-                            state,
-                            textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                        )
-                        UserInfo(state)
-                    }
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-                AboutMe(state)
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
+        Surface {
+            EmptyProfileClickableContainer(state) {
+                Column(
+                    modifier = modifier,
+                    horizontalAlignment = Alignment.Start,
+                    verticalArrangement = Arrangement.Top,
                 ) {
-                    SocialIconRow(state, maxIcons = 4)
-                    ViewProfileButton(state, Modifier.padding(0.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Avatar(
+                            state = state,
+                            size = 72.dp,
+                            modifier = Modifier.clip(CircleShape),
+                        )
+                        Column(modifier = Modifier.padding(14.dp, 0.dp, 0.dp, 0.dp)) {
+                            DisplayName(
+                                state,
+                                textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                            )
+                            UserInfo(state)
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    AboutMe(state)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        SocialIconRow(state, maxIcons = 4)
+                        ViewProfileButton(state, Modifier.padding(0.dp))
+                    }
                 }
             }
         }

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/ProfileSummary.kt
@@ -39,7 +39,7 @@ public fun ProfileSummary(profile: Profile, modifier: Modifier = Modifier) {
 
 /**
  * [ProfileSummary] is a composable that displays a mini profile card.
- * Given a [UserProfileState], it displays a profile summary card using the other atomic components.
+ * Given a [ComponentState] for a [Profile], it displays a [ProfileSummary] or the skeleton if it's in a loading state.
  *
  * @param state The user's profile state
  * @param modifier Composable modifier
@@ -47,37 +47,39 @@ public fun ProfileSummary(profile: Profile, modifier: Modifier = Modifier) {
 @Composable
 public fun ProfileSummary(state: ComponentState<Profile>, modifier: Modifier = Modifier) {
     GravatarTheme {
-        EmptyProfileClickableContainer(state) {
-            Row(modifier = modifier) {
-                Avatar(
-                    state = state,
-                    size = 72.dp,
-                    modifier = Modifier.clip(CircleShape),
-                )
-                Column(modifier = Modifier.padding(start = 14.dp)) {
-                    DisplayName(
-                        state,
-                        textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+        Surface {
+            EmptyProfileClickableContainer(state) {
+                Row(modifier = modifier) {
+                    Avatar(
+                        state = state,
+                        size = 72.dp,
+                        modifier = Modifier.clip(CircleShape),
                     )
-                    when (state) {
-                        is ComponentState.Loaded -> {
-                            if (state.loadedValue.location.isNotBlank()) {
+                    Column(modifier = Modifier.padding(start = 14.dp)) {
+                        DisplayName(
+                            state,
+                            textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        )
+                        when (state) {
+                            is ComponentState.Loaded -> {
+                                if (state.loadedValue.location.isNotBlank()) {
+                                    Location(state)
+                                }
+                            }
+
+                            ComponentState.Loading -> {
+                                Location(state, modifier.width(120.dp))
+                            }
+
+                            ComponentState.Empty -> {
                                 Location(state)
                             }
                         }
-
-                        ComponentState.Loading -> {
-                            Location(state, modifier.width(120.dp))
-                        }
-
-                        ComponentState.Empty -> {
-                            Location(state)
-                        }
+                        ViewProfileButton(
+                            state,
+                            modifier = Modifier.height(32.dp),
+                        )
                     }
-                    ViewProfileButton(
-                        state,
-                        modifier = Modifier.height(32.dp),
-                    )
                 }
             }
         }

--- a/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/RoborazziTest.kt
+++ b/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/RoborazziTest.kt
@@ -1,6 +1,5 @@
 package com.gravatar.gravatar.ui
 
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -36,9 +35,7 @@ abstract class RoborazziTest {
     fun gravatarScreenshotTest(composable: @Composable () -> Unit) {
         captureRoboImage {
             GravatarTheme {
-                Surface {
-                    composable()
-                }
+                composable()
             }
         }
     }


### PR DESCRIPTION
### Description

In order to use the proper theme values, we should show the profile UI component over a surface element. That way, client apps can override the themes as needed.

When overriding `GravatarTheme` to customize the styles, we could obtain some unexpected results due to components not being on a surface.

The client app could add the Gravatar `@Composable` over a surface, but I would expect the SDK to work out of the box just by coding something like:

```kotlin
CompositionLocalProvider(
    LocalGravatarTheme provides object : GravatarTheme {
        // Override theme colors
        override val colorScheme: ColorScheme
            @Composable
            get() = colorScheme
    },
) {
    LargeProfileSummary(state)
}
```

### Testing Steps

- Code review and screenshot tests should be enough