### PR TITLE
Bump retrofit and and gson converter to `2.11.0`

### DIFF
--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -77,8 +77,9 @@ dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 
     api("com.squareup.okhttp3:okhttp:4.12.0")
-    implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    val retrofitVersion = "2.11.0"
+    implementation("com.squareup.retrofit2:retrofit:$retrofitVersion")
+    implementation("com.squareup.retrofit2:converter-gson:$retrofitVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 
     testImplementation("junit:junit:4.13.2")


### PR DESCRIPTION
### Description

To address https://github.com/Automattic/Gravatar-SDK-Android/security/dependabot/23

### Testing Steps

- Browse the changelog to see if some changes affected this project
  - I see one candidate: 
    > Eagerly reject suspend fun functions that return Call<Body>. These are never correct, and should declare a return type of Body directly.
  
  but it looks that this SDK is not using `Call<*>` anymore
- Smoke test the SDK