### PR TITLE
Remove Robolectric from the :gravatar module

### DIFF
--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -83,7 +83,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.11.1")
     testImplementation("io.mockk:mockk-android:1.13.9")
     testImplementation("io.mockk:mockk-agent:1.13.9")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")

--- a/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
+++ b/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
@@ -11,11 +11,8 @@ import com.gravatar.types.sha256Hash
 import junit.framework.TestCase.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.net.URL
 
-@RunWith(RobolectricTestRunner::class)
 class AvatarUrlTest {
     @Test
     fun `AvatarUrl created via an email address must not add any query param if not set`() {

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -12,12 +12,9 @@ import okhttp3.ResponseBody
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import retrofit2.Response
 import java.io.File
 
-@RunWith(RobolectricTestRunner::class)
 class AvatarServiceTest {
     @get:Rule
     var containerRule = GravatarSdkContainerRule()

--- a/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
@@ -13,11 +13,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import retrofit2.Response
 
-@RunWith(RobolectricTestRunner::class)
 class ProfileServiceTests {
     @get:Rule
     var containerRule = GravatarSdkContainerRule()


### PR DESCRIPTION
Closes #191 

### Description

We do have a dependency on Robolectric in the `:gravatar` module despite the fact that we don't need it to run the tests there. This may be a leftover from before the `:-ui` module was created. 

Robolectrc adds additional overhead to the tests and makes them significantly slower so there's no reason to use it unless necessary. 

### Testing Steps

Passing tests on CI should be enough.
