### PR TITLE
Run the binary compatibility check on each code push

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,6 @@ steps:
       - "**/build/test-results/*/*.xml"
 
   - label: "Binary compatibility check"
-    if: build.pull_request.base_branch == "trunk"
     command: |
       echo "--- Validating binary compatibility"
       ./gradlew apiCheck


### PR DESCRIPTION
### Description

The CI checks are started on each code push. That means the check to run only for PRs doesn't work because that's rarely the case (only when you push updats to an already opened PR). 

I'm removing the check to always run the step.

### Testing Steps
Make sure you see the `validating binary compatibility` check in CI steps below