### PR TITLE
#198/2 - Deprecate old model classes and update services to use the new ones

### DIFF
--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -580,6 +580,10 @@ public final class com/gravatar/services/ProfileService {
 	public final fun fetch (Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fetch (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fetchByUsername (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieve (Lcom/gravatar/types/Email;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieve (Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieve (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieveByUsername (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class com/gravatar/services/Result {

--- a/gravatar/src/main/java/com/gravatar/api/apis/ProfilesApi.kt
+++ b/gravatar/src/main/java/com/gravatar/api/apis/ProfilesApi.kt
@@ -12,6 +12,11 @@ import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
 
+@Deprecated(
+    "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.restapi.apis.ProfilesApi"),
+    level = DeprecationLevel.WARNING,
+)
 internal interface ProfilesApi {
     /**
      * Get profile by identifier

--- a/gravatar/src/main/java/com/gravatar/api/models/CryptoWalletAddress.kt
+++ b/gravatar/src/main/java/com/gravatar/api/models/CryptoWalletAddress.kt
@@ -16,6 +16,11 @@ import com.google.gson.annotations.SerializedName
  * @param address The wallet address for the crypto currency.
  */
 
+@Deprecated(
+    "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.restapi.models.CryptoWalletAddress"),
+    level = DeprecationLevel.WARNING,
+)
 public data class CryptoWalletAddress(
     // The label for the crypto currency.
     @SerializedName("label")

--- a/gravatar/src/main/java/com/gravatar/api/models/GalleryImage.kt
+++ b/gravatar/src/main/java/com/gravatar/api/models/GalleryImage.kt
@@ -15,6 +15,11 @@ import com.google.gson.annotations.SerializedName
  * @param url The URL to the image.
  */
 
+@Deprecated(
+    "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.restapi.models.GalleryImage"),
+    level = DeprecationLevel.WARNING,
+)
 public data class GalleryImage(
     // The URL to the image.
     @SerializedName("url")

--- a/gravatar/src/main/java/com/gravatar/api/models/Link.kt
+++ b/gravatar/src/main/java/com/gravatar/api/models/Link.kt
@@ -16,6 +16,11 @@ import com.google.gson.annotations.SerializedName
  * @param url The URL to the link.
  */
 
+@Deprecated(
+    "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.restapi.models.Link"),
+    level = DeprecationLevel.WARNING,
+)
 public data class Link(
     // The label for the link.
     @SerializedName("label")

--- a/gravatar/src/main/java/com/gravatar/api/models/Profile.kt
+++ b/gravatar/src/main/java/com/gravatar/api/models/Profile.kt
@@ -33,6 +33,11 @@ import com.google.gson.annotations.SerializedName
  * @param registrationDate The date the user registered their account. This is only provided in authenticated API requests.
  */
 
+@Deprecated(
+    "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.restapi.models.Profile"),
+    level = DeprecationLevel.WARNING,
+)
 public data class Profile(
     // The SHA256 hash of the user's primary email address.
     @SerializedName("hash")

--- a/gravatar/src/main/java/com/gravatar/api/models/ProfileContactInfo.kt
+++ b/gravatar/src/main/java/com/gravatar/api/models/ProfileContactInfo.kt
@@ -20,6 +20,11 @@ import com.google.gson.annotations.SerializedName
  * @param calendar The URL to the user's calendar.
  */
 
+@Deprecated(
+    "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.restapi.models.ProfileContactInfo"),
+    level = DeprecationLevel.WARNING,
+)
 public data class ProfileContactInfo(
     // The user's home phone number.
     @SerializedName("home_phone")

--- a/gravatar/src/main/java/com/gravatar/api/models/ProfilePayments.kt
+++ b/gravatar/src/main/java/com/gravatar/api/models/ProfilePayments.kt
@@ -16,6 +16,11 @@ import com.google.gson.annotations.SerializedName
  * @param cryptoWallets A list of crypto currencies the user accepts.
  */
 
+@Deprecated(
+    "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.restapi.models.ProfilePayments"),
+    level = DeprecationLevel.WARNING,
+)
 public data class ProfilePayments(
     // A list of payment URLs the user has added to their profile.
     @SerializedName("links")

--- a/gravatar/src/main/java/com/gravatar/api/models/VerifiedAccount.kt
+++ b/gravatar/src/main/java/com/gravatar/api/models/VerifiedAccount.kt
@@ -18,6 +18,11 @@ import com.google.gson.annotations.SerializedName
  * @param url The URL to the user's profile on the service.
  */
 
+@Deprecated(
+    "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.restapi.models.VerifiedAccount"),
+    level = DeprecationLevel.WARNING,
+)
 public data class VerifiedAccount(
     // The type of the service.
     @SerializedName("service_type")

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -8,6 +8,7 @@ import com.gravatar.GravatarApiService
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V1
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V3
 import com.gravatar.services.AuthenticationInterceptor
+import com.gravatar.services.GravatarApi
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
@@ -48,10 +49,10 @@ internal class GravatarSdkContainer private constructor() {
      * @param okHttpClient The OkHttp client to use
      * @return The Gravatar API service
      */
-    fun getGravatarApiV1Service(okHttpClient: OkHttpClient? = null): GravatarApiService {
+    fun getGravatarV1Service(okHttpClient: OkHttpClient? = null): GravatarApi {
         return getRetrofitApiV1Builder().apply {
             okHttpClient?.let { client(it) }
-        }.build().create(GravatarApiService::class.java)
+        }.build().create(GravatarApi::class.java)
     }
 
     fun getGravatarApiV3Service(okHttpClient: OkHttpClient? = null): GravatarApiService {
@@ -59,5 +60,12 @@ internal class GravatarSdkContainer private constructor() {
             client((okHttpClient ?: OkHttpClient()).newBuilder().addInterceptor(AuthenticationInterceptor()).build())
         }.addConverterFactory(GsonConverterFactory.create(gson))
             .build().create(GravatarApiService::class.java)
+    }
+
+    fun getGravatarV3Service(okHttpClient: OkHttpClient? = null): GravatarApi {
+        return getRetrofitApiV3Builder().apply {
+            client((okHttpClient ?: OkHttpClient()).newBuilder().addInterceptor(AuthenticationInterceptor()).build())
+        }.addConverterFactory(GsonConverterFactory.create(gson))
+            .build().create(GravatarApi::class.java)
     }
 }

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -17,7 +17,7 @@ public class AvatarService(okHttpClient: OkHttpClient? = null) {
         const val LOG_TAG = "AvatarService"
     }
 
-    private val service = GravatarSdkDI.getGravatarApiV1Service(okHttpClient)
+    private val service = GravatarSdkDI.getGravatarV1Service(okHttpClient)
 
     /**
      * Uploads a Gravatar image for the given email address.

--- a/gravatar/src/main/java/com/gravatar/services/GravatarApi.kt
+++ b/gravatar/src/main/java/com/gravatar/services/GravatarApi.kt
@@ -1,6 +1,6 @@
-package com.gravatar
+package com.gravatar.services
 
-import com.gravatar.api.apis.ProfilesApi
+import com.gravatar.restapi.apis.ProfilesApi
 import okhttp3.MultipartBody
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -9,12 +9,7 @@ import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
 
-@Deprecated(
-    "This class is deprecated and will be removed in a future release.",
-    replaceWith = ReplaceWith("com.gravatar.services.GravatarApi"),
-    level = DeprecationLevel.WARNING,
-)
-internal interface GravatarApiService : ProfilesApi {
+internal interface GravatarApi : ProfilesApi {
     @Multipart
     @POST("upload-image")
     suspend fun uploadImage(

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -1,11 +1,12 @@
 package com.gravatar.services
 
-import com.gravatar.api.models.Profile
 import com.gravatar.logger.Logger
+import com.gravatar.restapi.models.Profile
 import com.gravatar.types.Email
 import com.gravatar.types.Hash
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
+import com.gravatar.api.models.Profile as LegacyProfile
 import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
 
 /**
@@ -16,7 +17,8 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
         const val LOG_TAG = "ProfileService"
     }
 
-    private val service = GravatarSdkDI.getGravatarApiV3Service(okHttpClient)
+    private val deprecatedService = GravatarSdkDI.getGravatarApiV3Service(okHttpClient)
+    private val service = GravatarSdkDI.getGravatarV3Service(okHttpClient)
 
     /**
      * Fetches a Gravatar profile for the given hash or username.
@@ -24,7 +26,69 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param hashOrUsername The hash or username to fetch the profile for
      * @return The fetched profile
      */
-    public suspend fun fetch(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingService {
+    @Deprecated(
+        "This class is deprecated and will be removed in a future release.",
+        replaceWith = ReplaceWith("com.gravatar.services.ProfileService.retrieve"),
+        level = DeprecationLevel.WARNING,
+    )
+    public suspend fun fetch(hashOrUsername: String): Result<LegacyProfile, ErrorType> = runCatchingService {
+        withContext(GravatarSdkDI.dispatcherIO) {
+            val response = deprecatedService.getProfileById(hashOrUsername)
+            if (response.isSuccessful) {
+                val data = response.body()
+                if (data != null) {
+                    Result.Success(data)
+                } else {
+                    Result.Failure(ErrorType.UNKNOWN)
+                }
+            } else {
+                // Log the response body for debugging purposes if the response is not successful
+                Logger.w(
+                    LOG_TAG,
+                    "Network call unsuccessful trying to get Gravatar profile: $response.body",
+                )
+                Result.Failure(errorTypeFromHttpCode(response.code()))
+            }
+        }
+    }
+
+    /**
+     * Fetches a Gravatar profile for the given email address.
+     *
+     * @param email The email address to fetch the profile for
+     * @return The fetched profiles
+     */
+    public suspend fun fetch(email: Email): Result<LegacyProfile, ErrorType> {
+        return fetch(email.hash())
+    }
+
+    /**
+     * Fetches a Gravatar profile for the given hash.
+     *
+     * @param hash The hash to fetch the profile for
+     * @return The fetched profiles
+     */
+    public suspend fun fetch(hash: Hash): Result<LegacyProfile, ErrorType> {
+        return fetch(hash.toString())
+    }
+
+    /**
+     * Fetches a Gravatar profile for the given username.
+     *
+     * @param username The username to fetch the profile for
+     * @return The fetched profiles
+     */
+    public suspend fun fetchByUsername(username: String): Result<LegacyProfile, ErrorType> {
+        return fetch(username)
+    }
+
+    /**
+     * Fetches a Gravatar profile for the given hash or username.
+     *
+     * @param hashOrUsername The hash or username to fetch the profile for
+     * @return The fetched profile
+     */
+    public suspend fun retrieve(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingService {
         withContext(GravatarSdkDI.dispatcherIO) {
             val response = service.getProfileById(hashOrUsername)
             if (response.isSuccessful) {
@@ -51,8 +115,8 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param email The email address to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun fetch(email: Email): Result<Profile, ErrorType> {
-        return fetch(email.hash())
+    public suspend fun retrieve(email: Email): Result<Profile, ErrorType> {
+        return retrieve(email.hash())
     }
 
     /**
@@ -61,8 +125,8 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param hash The hash to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun fetch(hash: Hash): Result<Profile, ErrorType> {
-        return fetch(hash.toString())
+    public suspend fun retrieve(hash: Hash): Result<Profile, ErrorType> {
+        return retrieve(hash.toString())
     }
 
     /**
@@ -71,7 +135,7 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param username The username to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun fetchByUsername(username: String): Result<Profile, ErrorType> {
-        return fetch(username)
+    public suspend fun retrieveByUsername(username: String): Result<Profile, ErrorType> {
+        return retrieve(username)
     }
 }

--- a/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
+++ b/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
@@ -1,6 +1,7 @@
 package com.gravatar
 
 import com.gravatar.di.container.GravatarSdkContainer
+import com.gravatar.services.GravatarApi
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -20,6 +21,7 @@ class GravatarSdkContainerRule : TestRule {
 
     internal var gravatarSdkContainerMock = mockk<GravatarSdkContainer>()
     internal var gravatarApiServiceMock = mockk<GravatarApiService>()
+    internal var gravatarApiMock = mockk<GravatarApi>()
 
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
@@ -32,8 +34,9 @@ class GravatarSdkContainerRule : TestRule {
                 every { gravatarSdkContainerMock.dispatcherIO } returns testDispatcher
                 every { gravatarSdkContainerMock.apiKey } returns null
                 every { GravatarSdkContainer.instance } returns gravatarSdkContainerMock
-                every { gravatarSdkContainerMock.getGravatarApiV1Service(any()) } returns gravatarApiServiceMock
+                every { gravatarSdkContainerMock.getGravatarV1Service(any()) } returns gravatarApiMock
                 every { gravatarSdkContainerMock.getGravatarApiV3Service(any()) } returns gravatarApiServiceMock
+                every { gravatarSdkContainerMock.getGravatarV3Service(any()) } returns gravatarApiMock
 
                 base.evaluate()
             }

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -30,13 +30,13 @@ class AvatarServiceTest {
     fun `given a file, email and wordpressBearerToken when uploading avatar then Gravatar service is invoked`() =
         runTest {
             val mockResponse = mockk<Response<ResponseBody>>()
-            coEvery { containerRule.gravatarApiServiceMock.uploadImage(any(), any(), any()) } returns mockResponse
+            coEvery { containerRule.gravatarApiMock.uploadImage(any(), any(), any()) } returns mockResponse
             every { mockResponse.isSuccessful } returns true
 
             val uploadResponse = avatarService.upload(File("avatarFile"), Email("email"), "wordpressBearerToken")
 
             coVerify(exactly = 1) {
-                containerRule.gravatarApiServiceMock.uploadImage(
+                containerRule.gravatarApiMock.uploadImage(
                     "Bearer wordpressBearerToken",
                     withArg {
                         assertTrue(
@@ -61,7 +61,7 @@ class AvatarServiceTest {
             every { isSuccessful } returns false
             every { code() } returns 100
         }
-        coEvery { containerRule.gravatarApiServiceMock.uploadImage(any(), any(), any()) } returns mockResponse
+        coEvery { containerRule.gravatarApiMock.uploadImage(any(), any(), any()) } returns mockResponse
 
         val uploadResponse = avatarService.upload(File("avatarFile"), Email("email"), "wordpressBearerToken")
 
@@ -70,7 +70,7 @@ class AvatarServiceTest {
 
     @Test
     fun `given gravatar update when an Exception occurs then Gravatar returns an error`() = runTest {
-        coEvery { containerRule.gravatarApiServiceMock.uploadImage(any(), any(), any()) } throws Exception()
+        coEvery { containerRule.gravatarApiMock.uploadImage(any(), any(), any()) } throws Exception()
 
         val uploadResponse = avatarService.upload(File("avatarFile"), Email("email"), "wordpressBearerToken")
 

--- a/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
@@ -1,7 +1,7 @@
 package com.gravatar.services
 
 import com.gravatar.GravatarSdkContainerRule
-import com.gravatar.api.models.Profile
+import com.gravatar.restapi.models.Profile
 import com.gravatar.types.Email
 import com.gravatar.types.Hash
 import io.mockk.coEvery
@@ -14,6 +14,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import retrofit2.Response
+import com.gravatar.api.models.Profile as LegacyProfile
 
 class ProfileServiceTests {
     @get:Rule
@@ -29,7 +30,7 @@ class ProfileServiceTests {
     @Test
     fun `given an username when loading its profile and data is returned then result is successful`() = runTest {
         val username = "username"
-        val mockResponse = mockk<Response<Profile>> {
+        val mockResponse = mockk<Response<LegacyProfile>> {
             every { isSuccessful } returns true
             every { body() } returns mockk()
         }
@@ -45,7 +46,7 @@ class ProfileServiceTests {
     fun `given an username when loading its profile but data is NOT returned then result is UNKNOWN failure`() =
         runTest {
             val username = "username"
-            val mockResponse = mockk<Response<Profile>> {
+            val mockResponse = mockk<Response<LegacyProfile>> {
                 every { isSuccessful } returns true
                 every { body() } returns null
             }
@@ -60,7 +61,7 @@ class ProfileServiceTests {
     @Test
     fun `given an username when loading its profile and response is NOT successful then result is failure`() = runTest {
         val username = "username"
-        val mockResponse = mockk<Response<Profile>> {
+        val mockResponse = mockk<Response<LegacyProfile>> {
             every { isSuccessful } returns false
         }
         coEvery { containerRule.gravatarApiServiceMock.getProfileById(username) } returns mockResponse
@@ -85,7 +86,7 @@ class ProfileServiceTests {
     @Test
     fun `given a hash when loading its profile and data is returned then result is successful`() = runTest {
         val usernameHash = Hash("username")
-        val mockResponse = mockk<Response<Profile>> {
+        val mockResponse = mockk<Response<LegacyProfile>> {
             every { isSuccessful } returns true
             every { body() } returns mockk()
         }
@@ -102,7 +103,7 @@ class ProfileServiceTests {
     @Test
     fun `given an email when loading its profile and data is returned then result is successful`() = runTest {
         val usernameEmail = Email("username@automattic.com")
-        val mockResponse = mockk<Response<Profile>> {
+        val mockResponse = mockk<Response<LegacyProfile>> {
             every { isSuccessful } returns true
             every { body() } returns mockk()
         }
@@ -113,6 +114,102 @@ class ProfileServiceTests {
         val loadProfileResponse = profileService.fetch(usernameEmail)
 
         coVerify(exactly = 1) { containerRule.gravatarApiServiceMock.getProfileById(usernameEmail.hash().toString()) }
+        assertTrue(loadProfileResponse is Result.Success)
+    }
+
+    /*
+     Same tests as before but using the "retrieve" method so using new models.
+     Previous tests should be removed when the deprecated code is removed
+     */
+
+    @Test
+    fun `given an username when retrieving its profile and data is returned then result is successful`() = runTest {
+        val username = "username"
+        val mockResponse = mockk<Response<Profile>> {
+            every { isSuccessful } returns true
+            every { body() } returns mockk()
+        }
+        coEvery { containerRule.gravatarApiMock.getProfileById(username) } returns mockResponse
+
+        val loadProfileResponse = profileService.retrieveByUsername(username)
+
+        coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
+        assertTrue(loadProfileResponse is Result.Success)
+    }
+
+    @Test
+    fun `given an username when retrieving its profile but data is NOT returned then result is UNKNOWN failure`() =
+        runTest {
+            val username = "username"
+            val mockResponse = mockk<Response<Profile>> {
+                every { isSuccessful } returns true
+                every { body() } returns null
+            }
+            coEvery { containerRule.gravatarApiMock.getProfileById(username) } returns mockResponse
+
+            val loadProfileResponse = profileService.retrieveByUsername(username)
+
+            coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
+            assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.UNKNOWN)
+        }
+
+    @Test
+    fun `given an username when retrieving its profile and response is NOT successful then result is failure`() =
+        runTest {
+            val username = "username"
+            val mockResponse = mockk<Response<Profile>> {
+                every { isSuccessful } returns false
+            }
+            coEvery { containerRule.gravatarApiMock.getProfileById(username) } returns mockResponse
+
+            val loadProfileResponse = profileService.retrieveByUsername(username)
+
+            coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
+            assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.UNKNOWN)
+        }
+
+    @Test
+    fun `given an username when retrieving its profile and an exception is thrown then result is failure`() = runTest {
+        val username = "username"
+        coEvery { containerRule.gravatarApiMock.getProfileById(username) } throws Exception()
+
+        val loadProfileResponse = profileService.retrieveByUsername(username)
+
+        coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
+        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.UNKNOWN)
+    }
+
+    @Test
+    fun `given a hash when retrieving its profile and data is returned then result is successful`() = runTest {
+        val usernameHash = Hash("username")
+        val mockResponse = mockk<Response<Profile>> {
+            every { isSuccessful } returns true
+            every { body() } returns mockk()
+        }
+        coEvery {
+            containerRule.gravatarApiMock.getProfileById(usernameHash.toString())
+        } returns mockResponse
+
+        val loadProfileResponse = profileService.retrieve(usernameHash)
+
+        coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(usernameHash.toString()) }
+        assertTrue(loadProfileResponse is Result.Success)
+    }
+
+    @Test
+    fun `given an email when retrieving its profile and data is returned then result is successful`() = runTest {
+        val usernameEmail = Email("username@automattic.com")
+        val mockResponse = mockk<Response<Profile>> {
+            every { isSuccessful } returns true
+            every { body() } returns mockk()
+        }
+        coEvery {
+            containerRule.gravatarApiMock.getProfileById(usernameEmail.hash().toString())
+        } returns mockResponse
+
+        val loadProfileResponse = profileService.retrieve(usernameEmail)
+
+        coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(usernameEmail.hash().toString()) }
         assertTrue(loadProfileResponse is Result.Success)
     }
 }


### PR DESCRIPTION
Closes #198 

### Description

This PR deprecates old model classes and updates services to use and return new model classes while keeping compatibility with previous versions. 

We are only refactoring `gravatar-core` classes. This approach allows us to verify that `gravatar-ui` elements and `demo-app` continue working as they should without any changes in the rest of the modules. 

### Testing Steps

- Run `demo-app` and verify everything works as expected
