### PR TITLE
Add non-catching `retrieve` methods

### DIFF
--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -610,6 +610,11 @@ public abstract interface class com/gravatar/services/GravatarListener {
 	public abstract fun onSuccess (Ljava/lang/Object;)V
 }
 
+public final class com/gravatar/services/HttpException : java/lang/RuntimeException {
+	public final fun getCode ()I
+	public fun getMessage ()Ljava/lang/String;
+}
+
 public final class com/gravatar/services/ProfileService {
 	public static final field LOG_TAG Ljava/lang/String;
 	public fun <init> ()V

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -619,6 +619,10 @@ public final class com/gravatar/services/ProfileService {
 	public final fun fetch (Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fetch (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fetchByUsername (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieve (Lcom/gravatar/types/Email;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieve (Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieve (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieveByUsername (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieveByUsernameCatching (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieveCatching (Lcom/gravatar/types/Email;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieveCatching (Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -16,6 +16,7 @@ internal fun Throwable.errorType(): ErrorType {
     return when (this) {
         is SocketTimeoutException -> ErrorType.TIMEOUT
         is UnknownHostException -> ErrorType.NETWORK
+        is HttpException -> errorTypeFromHttpCode(code)
         else -> ErrorType.UNKNOWN
     }
 }

--- a/gravatar/src/main/java/com/gravatar/services/HttpException.kt
+++ b/gravatar/src/main/java/com/gravatar/services/HttpException.kt
@@ -1,0 +1,14 @@
+package com.gravatar.services
+
+import retrofit2.Response
+
+/**
+ * Exception thrown when an HTTP error occurs in a non-cathing method.
+ *
+ * [code] The HTTP status code.
+ * [message] The HTTP status message.
+ */
+public class HttpException internal constructor(response: Response<*>) : RuntimeException() {
+    public val code: Int = response.code()
+    public override val message: String = "HTTP ${response.code()} ${response.errorBody()?.string()}"
+}

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -99,11 +99,12 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
 
     /**
      * Fetches a Gravatar profile for the given hash or username.
+     * This method throws any exception that occurs during the execution.
      *
      * @param hashOrUsername The hash or username to fetch the profile for
      * @return The fetched profile
      */
-    public suspend fun retrieveCatching(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingService {
+    public suspend fun retrieve(hashOrUsername: String): Result<Profile, ErrorType> =
         withContext(GravatarSdkDI.dispatcherIO) {
             val response = service.getProfileById(hashOrUsername)
             if (response.isSuccessful) {
@@ -122,35 +123,81 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
                 Result.Failure(errorTypeFromHttpCode(response.code()))
             }
         }
+
+    /**
+     * Fetches a Gravatar profile for the given hash or username.
+     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     *
+     * @param hashOrUsername The hash or username to fetch the profile for
+     * @return The fetched profile
+     */
+    public suspend fun retrieveCatching(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingService {
+        retrieve(hashOrUsername)
     }
 
     /**
      * Fetches a Gravatar profile for the given email address.
+     * This method throws any exception that occurs during the execution.
      *
      * @param email The email address to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveCatching(email: Email): Result<Profile, ErrorType> {
-        return retrieveCatching(email.hash())
+    public suspend fun retrieve(email: Email): Result<Profile, ErrorType> {
+        return retrieve(email.hash())
+    }
+
+    /**
+     * Fetches a Gravatar profile for the given email address.
+     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     *
+     * @param email The email address to fetch the profile for
+     * @return The fetched profiles
+     */
+    public suspend fun retrieveCatching(email: Email): Result<Profile, ErrorType> = runCatchingService {
+        return retrieve(email.hash())
     }
 
     /**
      * Fetches a Gravatar profile for the given hash.
+     * This method throws any exception that occurs during the execution.
      *
      * @param hash The hash to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveCatching(hash: Hash): Result<Profile, ErrorType> {
-        return retrieveCatching(hash.toString())
+    public suspend fun retrieve(hash: Hash): Result<Profile, ErrorType> {
+        return retrieve(hash.toString())
+    }
+
+    /**
+     * Fetches a Gravatar profile for the given hash.
+     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     *
+     * @param hash The hash to fetch the profile for
+     * @return The fetched profiles
+     */
+    public suspend fun retrieveCatching(hash: Hash): Result<Profile, ErrorType> = runCatchingService {
+        return retrieve(hash)
     }
 
     /**
      * Fetches a Gravatar profile for the given username.
+     * This method throws any exception that occurs during the execution.
      *
      * @param username The username to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveByUsernameCatching(username: String): Result<Profile, ErrorType> {
-        return retrieveCatching(username)
+    public suspend fun retrieveByUsername(username: String): Result<Profile, ErrorType> {
+        return retrieve(username)
+    }
+
+    /**
+     * Fetches a Gravatar profile for the given username.
+     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     *
+     * @param username The username to fetch the profile for
+     * @return The fetched profiles
+     */
+    public suspend fun retrieveByUsernameCatching(username: String): Result<Profile, ErrorType> = runCatchingService {
+        retrieveByUsername(username)
     }
 }

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -104,25 +104,19 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param hashOrUsername The hash or username to fetch the profile for
      * @return The fetched profile
      */
-    public suspend fun retrieve(hashOrUsername: String): Result<Profile, ErrorType> =
-        withContext(GravatarSdkDI.dispatcherIO) {
-            val response = service.getProfileById(hashOrUsername)
-            if (response.isSuccessful) {
-                val data = response.body()
-                if (data != null) {
-                    Result.Success(data)
-                } else {
-                    Result.Failure(ErrorType.UNKNOWN)
-                }
-            } else {
-                // Log the response body for debugging purposes if the response is not successful
-                Logger.w(
-                    LOG_TAG,
-                    "Network call unsuccessful trying to get Gravatar profile: $response.body",
-                )
-                Result.Failure(errorTypeFromHttpCode(response.code()))
-            }
+    public suspend fun retrieve(hashOrUsername: String): Profile = withContext(GravatarSdkDI.dispatcherIO) {
+        val response = service.getProfileById(hashOrUsername)
+        if (response.isSuccessful) {
+            response.body() ?: error("Response body is null")
+        } else {
+            // Log the response body for debugging purposes if the response is not successful
+            Logger.w(
+                LOG_TAG,
+                "Network call unsuccessful trying to get Gravatar profile: ${response.code()}",
+            )
+            throw HttpException(response)
         }
+    }
 
     /**
      * Fetches a Gravatar profile for the given hash or username.
@@ -131,7 +125,7 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param hashOrUsername The hash or username to fetch the profile for
      * @return The fetched profile
      */
-    public suspend fun retrieveCatching(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingService {
+    public suspend fun retrieveCatching(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingRequest {
         retrieve(hashOrUsername)
     }
 
@@ -142,7 +136,7 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param email The email address to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieve(email: Email): Result<Profile, ErrorType> {
+    public suspend fun retrieve(email: Email): Profile {
         return retrieve(email.hash())
     }
 
@@ -153,8 +147,8 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param email The email address to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveCatching(email: Email): Result<Profile, ErrorType> = runCatchingService {
-        return retrieve(email.hash())
+    public suspend fun retrieveCatching(email: Email): Result<Profile, ErrorType> = runCatchingRequest {
+        retrieve(email.hash())
     }
 
     /**
@@ -164,7 +158,7 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param hash The hash to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieve(hash: Hash): Result<Profile, ErrorType> {
+    public suspend fun retrieve(hash: Hash): Profile {
         return retrieve(hash.toString())
     }
 
@@ -175,8 +169,8 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param hash The hash to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveCatching(hash: Hash): Result<Profile, ErrorType> = runCatchingService {
-        return retrieve(hash)
+    public suspend fun retrieveCatching(hash: Hash): Result<Profile, ErrorType> = runCatchingRequest {
+        retrieve(hash)
     }
 
     /**
@@ -186,7 +180,7 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param username The username to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveByUsername(username: String): Result<Profile, ErrorType> {
+    public suspend fun retrieveByUsername(username: String): Profile {
         return retrieve(username)
     }
 
@@ -197,7 +191,7 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * @param username The username to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveByUsernameCatching(username: String): Result<Profile, ErrorType> = runCatchingService {
+    public suspend fun retrieveByUsernameCatching(username: String): Result<Profile, ErrorType> = runCatchingRequest {
         retrieveByUsername(username)
     }
 }

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -1,5 +1,6 @@
 package com.gravatar.services
 
+import com.gravatar.HttpResponseCode
 import com.gravatar.logger.Logger
 import com.gravatar.restapi.models.Profile
 import com.gravatar.types.Email
@@ -102,9 +103,9 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * This method throws any exception that occurs during the execution.
      *
      * @param hashOrUsername The hash or username to fetch the profile for
-     * @return The fetched profile
+     * @return The fetched profile or null if profile not found
      */
-    public suspend fun retrieve(hashOrUsername: String): Profile = withContext(GravatarSdkDI.dispatcherIO) {
+    public suspend fun retrieve(hashOrUsername: String): Profile? = withContext(GravatarSdkDI.dispatcherIO) {
         val response = service.getProfileById(hashOrUsername)
         if (response.isSuccessful) {
             response.body() ?: error("Response body is null")
@@ -114,7 +115,11 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
                 LOG_TAG,
                 "Network call unsuccessful trying to get Gravatar profile: ${response.code()}",
             )
-            throw HttpException(response)
+            if (response.code() == HttpResponseCode.HTTP_NOT_FOUND) {
+                return@withContext null
+            } else {
+                throw HttpException(response)
+            }
         }
     }
 
@@ -134,9 +139,9 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * This method throws any exception that occurs during the execution.
      *
      * @param email The email address to fetch the profile for
-     * @return The fetched profiles
+     * @return The fetched profile or null if profile not found
      */
-    public suspend fun retrieve(email: Email): Profile {
+    public suspend fun retrieve(email: Email): Profile? {
         return retrieve(email.hash())
     }
 
@@ -156,9 +161,9 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * This method throws any exception that occurs during the execution.
      *
      * @param hash The hash to fetch the profile for
-     * @return The fetched profiles
+     * @return The fetched profile or null if profile not found
      */
-    public suspend fun retrieve(hash: Hash): Profile {
+    public suspend fun retrieve(hash: Hash): Profile? {
         return retrieve(hash.toString())
     }
 
@@ -178,9 +183,9 @@ public class ProfileService(okHttpClient: OkHttpClient? = null) {
      * This method throws any exception that occurs during the execution.
      *
      * @param username The username to fetch the profile for
-     * @return The fetched profiles
+     * @return The fetched profile or null if profile not found
      */
-    public suspend fun retrieveByUsername(username: String): Profile {
+    public suspend fun retrieveByUsername(username: String): Profile? {
         return retrieve(username)
     }
 

--- a/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
@@ -19,10 +19,15 @@ internal inline fun <T> runCatchingService(block: () -> Result<T, ErrorType>): R
     }
 }
 
-internal inline fun <T> runCatchingRequest(block: () -> T): Result<T, ErrorType> {
+internal inline fun <T> runCatchingRequest(block: () -> T?): Result<T, ErrorType> {
     @Suppress("TooGenericExceptionCaught")
     return try {
-        return Result.Success(block())
+        val result = block()
+        if (result != null) {
+            Result.Success(result)
+        } else {
+            Result.Failure(ErrorType.NOT_FOUND)
+        }
     } catch (cancellationException: CancellationException) {
         throw cancellationException
     } catch (ex: Exception) {

--- a/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
@@ -3,10 +3,26 @@ package com.gravatar.services
 import kotlinx.coroutines.CancellationException
 import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
 
+@Deprecated(
+    "This method is deprecated and should be removed in a future release.",
+    replaceWith = ReplaceWith("com.gravatar.services.runCatchingRequest"),
+    level = DeprecationLevel.WARNING,
+)
 internal inline fun <T> runCatchingService(block: () -> Result<T, ErrorType>): Result<T, ErrorType> {
     @Suppress("TooGenericExceptionCaught")
     return try {
         block()
+    } catch (cancellationException: CancellationException) {
+        throw cancellationException
+    } catch (ex: Exception) {
+        Result.Failure(ex.errorType())
+    }
+}
+
+internal inline fun <T> runCatchingRequest(block: () -> T): Result<T, ErrorType> {
+    @Suppress("TooGenericExceptionCaught")
+    return try {
+        return Result.Success(block())
     } catch (cancellationException: CancellationException) {
         throw cancellationException
     } catch (ex: Exception) {

--- a/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
+++ b/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
@@ -1,6 +1,7 @@
 package com.gravatar
 
 import com.gravatar.di.container.GravatarSdkContainer
+import com.gravatar.logger.Logger
 import com.gravatar.services.GravatarApi
 import io.mockk.every
 import io.mockk.mockk
@@ -37,6 +38,11 @@ class GravatarSdkContainerRule : TestRule {
                 every { gravatarSdkContainerMock.getGravatarV1Service(any()) } returns gravatarApiMock
                 every { gravatarSdkContainerMock.getGravatarApiV3Service(any()) } returns gravatarApiServiceMock
                 every { gravatarSdkContainerMock.getGravatarV3Service(any()) } returns gravatarApiMock
+
+                mockkObject(Logger)
+                every { Logger.i(any(), any()) } returns 1
+                every { Logger.w(any(), any()) } returns 1
+                every { Logger.e(any(), any()) } returns 1
 
                 base.evaluate()
             }

--- a/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
@@ -4,24 +4,26 @@ import com.gravatar.HttpResponseCode.HTTP_CLIENT_TIMEOUT
 import com.gravatar.HttpResponseCode.HTTP_NOT_FOUND
 import com.gravatar.HttpResponseCode.HTTP_TOO_MANY_REQUESTS
 import com.gravatar.HttpResponseCode.SERVER_ERRORS
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Test
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
 class ErrorTypeTest {
+    private val httpCodeToErrorTypeRelation = mutableListOf(
+        HTTP_CLIENT_TIMEOUT to ErrorType.TIMEOUT,
+        HTTP_NOT_FOUND to ErrorType.NOT_FOUND,
+        HTTP_TOO_MANY_REQUESTS to ErrorType.RATE_LIMIT_EXCEEDED,
+        600 to ErrorType.UNKNOWN,
+    ).apply {
+        SERVER_ERRORS.forEach { code ->
+            add(code to ErrorType.SERVER)
+        }
+    }
+
     @Test
     fun `given an http code when converting to error type then correct type is returned`() {
-        // Given
-        val httpCodeToErrorTypeRelation = mutableListOf(
-            HTTP_CLIENT_TIMEOUT to ErrorType.TIMEOUT,
-            HTTP_NOT_FOUND to ErrorType.NOT_FOUND,
-            HTTP_TOO_MANY_REQUESTS to ErrorType.RATE_LIMIT_EXCEEDED,
-            600 to ErrorType.UNKNOWN,
-        ).apply {
-            SERVER_ERRORS.forEach { code ->
-                add(code to ErrorType.SERVER)
-            }
-        }
         httpCodeToErrorTypeRelation.forEach { (code, expectedErrorType) ->
             // When
             val errorType = errorTypeFromHttpCode(code)
@@ -37,7 +39,13 @@ class ErrorTypeTest {
             SocketTimeoutException() to ErrorType.TIMEOUT,
             UnknownHostException() to ErrorType.NETWORK,
             Exception() to ErrorType.UNKNOWN,
-        )
+        ).apply {
+            httpCodeToErrorTypeRelation.forEach { (code, errorType) ->
+                val exception = mockk<HttpException>(relaxed = true)
+                every { exception.code } returns code
+                add(exception to errorType)
+            }
+        }
         exceptionToErrorTypeRelation.forEach { (exception, expectedErrorType) ->
             // When
             val errorType = exception.errorType()

--- a/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
@@ -29,7 +29,7 @@ class ProfileServiceTests {
     }
 
     @Test
-    fun `given an username when loading its profile and data is returned then result is successful`() = runTest {
+    fun `given a username when loading its profile and data is returned then result is successful`() = runTest {
         val username = "username"
         val mockResponse = mockk<Response<LegacyProfile>> {
             every { isSuccessful } returns true
@@ -44,7 +44,7 @@ class ProfileServiceTests {
     }
 
     @Test
-    fun `given an username when loading its profile but data is NOT returned then result is UNKNOWN failure`() =
+    fun `given a username when loading its profile but data is NOT returned then result is UNKNOWN failure`() =
         runTest {
             val username = "username"
             val mockResponse = mockk<Response<LegacyProfile>> {
@@ -60,7 +60,7 @@ class ProfileServiceTests {
         }
 
     @Test
-    fun `given an username when loading its profile and response is NOT successful then result is failure`() = runTest {
+    fun `given a username when loading its profile and response is NOT successful then result is failure`() = runTest {
         val username = "username"
         val mockResponse = mockk<Response<LegacyProfile>> {
             every { isSuccessful } returns false
@@ -74,7 +74,7 @@ class ProfileServiceTests {
     }
 
     @Test
-    fun `given an username when loading its profile and an exception is thrown then result is failure`() = runTest {
+    fun `given a username when loading its profile and an exception is thrown then result is failure`() = runTest {
         val username = "username"
         coEvery { containerRule.gravatarApiServiceMock.getProfileById(username) } throws Exception()
 
@@ -125,7 +125,7 @@ class ProfileServiceTests {
 
     // Catching Version of the methods
     @Test
-    fun `given an username when retrieving its profile and data is returned then result is successful`() = runTest {
+    fun `given a username when retrieving its profile and data is returned then result is successful`() = runTest {
         val username = "username"
         val mockResponse = mockk<Response<Profile>> {
             every { isSuccessful } returns true
@@ -140,7 +140,7 @@ class ProfileServiceTests {
     }
 
     @Test
-    fun `given an username when retrieving its profile but data is NOT returned then result is UNKNOWN failure`() =
+    fun `given a username when retrieving its profile but data is NOT returned then result is UNKNOWN failure`() =
         runTest {
             val username = "username"
             val mockResponse = mockk<Response<Profile>> {
@@ -156,7 +156,7 @@ class ProfileServiceTests {
         }
 
     @Test
-    fun `given an username when retrieving its profile and response is NOT successful then result is failure`() =
+    fun `given a username when retrieving its profile and response is NOT successful then result is failure`() =
         runTest {
             val username = "username"
             val mockResponse = mockk<Response<Profile>> {
@@ -205,7 +205,7 @@ class ProfileServiceTests {
     }
 
     @Test
-    fun `given an username when retrieving its profile and an exception is thrown then result is failure`() = runTest {
+    fun `given a username when retrieving its profile and an exception is thrown then result is failure`() = runTest {
         val username = "username"
         coEvery { containerRule.gravatarApiMock.getProfileById(username) } throws Exception()
 
@@ -241,7 +241,7 @@ class ProfileServiceTests {
 
     // Throwing Exception Version of the methods
     @Test(expected = TimeoutException::class)
-    fun `given an username when retrieving its profile and a timeout occurs then exception is thrown`() = runTest {
+    fun `given a username when retrieving its profile and a timeout occurs then exception is thrown`() = runTest {
         val username = "username"
         coEvery { containerRule.gravatarApiMock.getProfileById(username) } throws TimeoutException()
 

--- a/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
@@ -267,4 +267,35 @@ class ProfileServiceTests {
 
         profileService.retrieve(usernameEmail)
     }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given an email when retrieving its profile and the body is null then IllegalStateException is thrown`() =
+        runTest {
+            val usernameEmail = Email("username@automattic.com")
+            val mockResponse = mockk<Response<Profile>> {
+                every { isSuccessful } returns true
+                every { body() } returns null
+            }
+            coEvery {
+                containerRule.gravatarApiMock.getProfileById(usernameEmail.hash().toString())
+            } returns mockResponse
+
+            profileService.retrieve(usernameEmail)
+        }
+
+    @Test(expected = HttpException::class)
+    fun `given an email when retrieving its profile and a http error occurs then HttpException is thrown`() = runTest {
+        val usernameEmail = Email("username@automattic.com")
+        val mockResponse = mockk<Response<Profile>> {
+            every { isSuccessful } returns false
+            every { errorBody() } returns mockk(relaxed = true)
+            every { code() } returns 404
+            every { message() } returns "Not found"
+        }
+        coEvery {
+            containerRule.gravatarApiMock.getProfileById(usernameEmail.hash().toString())
+        } returns mockResponse
+
+        profileService.retrieve(usernameEmail)
+    }
 }


### PR DESCRIPTION
Closes #212 

### Description

In a previous commit, we added the retrieveCatching methods, which prevent them from throwing exceptions. Now, we are adding the throwing exception version of them based on [this discussion](https://github.com/Automattic/Gravatar-SDK-Android/pull/207#discussion_r1664026712).

### Testing Steps
- CI and code review should be enough
