### PR TITLE
Migrate dependency management to version catalogs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,22 +5,18 @@ import org.jetbrains.dokka.versioning.VersioningPlugin
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.4.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
-
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.plugin.compose) apply false
     // Ktlint
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.0" apply false
-
+    alias(libs.plugins.ktlint) apply false
     // Detekt
-    id("io.gitlab.arturbosch.detekt") version "1.23.4" apply false
-
+    alias(libs.plugins.detekt) apply false
     // Dokka
-    id("org.jetbrains.dokka")
-
+    alias(libs.plugins.dokka)
     // Roborazzi
-    id("io.github.takahirom.roborazzi") version "1.15.0" apply false
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.15.0-Beta.2"
+    alias(libs.plugins.roborazzi) apply false
+    alias(libs.plugins.binary.compatibility.validator)
 }
 
 buildscript {

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -2,15 +2,13 @@ import java.io.FileInputStream
 import java.util.Properties
 
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
-
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.plugin.compose)
     // Ktlint
-    id("org.jlleitschuh.gradle.ktlint")
-
+    alias(libs.plugins.ktlint)
     // Detekt
-    id("io.gitlab.arturbosch.detekt")
+    alias(libs.plugins.detekt)
 }
 
 fun localProperties(): Properties {
@@ -91,30 +89,30 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    coreLibraryDesugaring(libs.desugarJdk)
 
     // Demo App dependencies
-    implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.11.0")
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.android.material)
 
-    implementation(platform("androidx.compose:compose-bom:2024.03.00"))
-    implementation("androidx.activity:activity-compose:1.8.2")
-    implementation("androidx.compose.ui:ui")
-    implementation("androidx.compose.ui:ui-graphics")
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.material:material-icons-extended")
-    implementation("io.coil-kt:coil-compose:2.5.0")
+    implementation(platform(libs.compose.bom))
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.graphics)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons)
+    implementation(libs.coil.compose)
     implementation(project(":gravatar"))
     implementation(project(":gravatar-ui"))
 
-    debugImplementation("androidx.compose.ui:ui-tooling:1.6.0")
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // Unit Test dependencies
-    testImplementation("junit:junit:4.13.2")
+    testImplementation(libs.junit)
 
     // Android Test dependencies
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,74 @@
+[versions]
+androidGradlePlugin = "8.4.1"
+kotlin = "2.0.0"
+ktlint = "12.1.0"
+detekt = "1.23.4"
+roborazzi = "1.15.0"
+dokka = "1.9.20"
+binaryValidator = "0.15.0-Beta.2"
+publishToS3 = "0.10.0"
+openapi = "7.4.0"
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+ktx = "1.12.0"
+desugarJdk = "2.0.4"
+junit = "4.13.2"
+mockk = "1.13.9"
+espresso = "3.5.1"
+androidXJunit = "1.1.5"
+appcompat = "1.6.1"
+material = "1.11.0"
+ucrop = "2.2.8"
+coil = "2.5.0"
+activityCompose = "1.8.2"
+robolectric = "4.11.1"
+composeUiTest = "1.6.7"
+kotlinCoroutines = "1.7.3"
+composeBom = "2024.03.00"
+
+[libraries]
+desugarJdk = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdk" }
+kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
+android-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "composeUiTest" }
+androidx-compose-junit = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "composeUiTest" }
+androidx-compose-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "composeUiTest" }
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+compose-ui = { module = "androidx.compose.ui:ui" }
+compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-material-icons = { module = "androidx.compose.material:material-icons-extended" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-gson-converter = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+ucrop = { group = "com.github.yalantis", name = "ucrop", version.ref = "ucrop" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+coil-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
+mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidXJunit" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }
+roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }
+roborazzi-junit-rule = { group = "io.github.takahirom.roborazzi", name = "roborazzi-junit-rule", version.ref = "roborazzi" }
+
+
+[plugins]
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-plugin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
+binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryValidator" }
+publish-to-s3 = { id = "com.automattic.android.publish-to-s3", version.ref = "publishToS3" }
+openapi-generator = { id = "org.openapi.generator", version.ref = "openapi" }

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -1,19 +1,16 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
-    id("com.automattic.android.publish-to-s3")
-
+    id(libs.plugins.android.library.get().pluginId)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.plugin.compose)
+    alias(libs.plugins.publish.to.s3)
     // Ktlint
-    id("org.jlleitschuh.gradle.ktlint")
-
+    alias(libs.plugins.ktlint)
     // Detekt
-    id("io.gitlab.arturbosch.detekt")
-
+    alias(libs.plugins.detekt)
     // Roborazzi
-    id("io.github.takahirom.roborazzi")
+    alias(libs.plugins.roborazzi)
 }
 
 android {
@@ -90,36 +87,36 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    coreLibraryDesugaring(libs.desugarJdk)
 
-    implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.11.0")
-    implementation("com.github.yalantis:ucrop:2.2.8")
-    implementation("io.coil-kt:coil-compose:2.5.0")
-    implementation("io.coil-kt:coil-svg:2.5.0")
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.android.material)
+    implementation(libs.ucrop)
+    implementation(libs.coil.compose)
+    implementation(libs.coil.svg)
     implementation(project(":gravatar"))
 
-    testImplementation("junit:junit:4.13.2")
+    testImplementation(libs.junit)
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 
     // Jetpack Compose
-    implementation(platform("androidx.compose:compose-bom:2024.02.00"))
-    implementation("androidx.activity:activity-compose:1.8.2")
-    implementation("androidx.compose.ui:ui")
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.6.2")
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    implementation(libs.androidx.activity.compose)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // Roborazzi
-    testImplementation("org.robolectric:robolectric:4.11.1")
-    testImplementation("androidx.compose.ui:ui-test-junit4:1.6.7")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.6.7")
-    testImplementation("io.github.takahirom.roborazzi:roborazzi:1.15.0")
-    testImplementation("io.github.takahirom.roborazzi:roborazzi-compose:1.15.0")
-    testImplementation("io.github.takahirom.roborazzi:roborazzi-junit-rule:1.15.0")
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.compose.junit)
+    debugImplementation(libs.androidx.compose.manifest)
+    testImplementation(libs.roborazzi)
+    testImplementation(libs.roborazzi.compose)
+    testImplementation(libs.roborazzi.junit.rule)
 }
 
 project.afterEvaluate {

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -1,20 +1,16 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
-
+    id(libs.plugins.android.library.get().pluginId)
+    alias(libs.plugins.kotlin.android)
     // Ktlint
-    id("org.jlleitschuh.gradle.ktlint")
-
+    alias(libs.plugins.ktlint)
     // Detekt
-    id("io.gitlab.arturbosch.detekt")
-
+    alias(libs.plugins.detekt)
     // Publish artifact to S3
-    id("com.automattic.android.publish-to-s3")
-
+    alias(libs.plugins.publish.to.s3)
     // OpenApi Generator
-    id("org.openapi.generator") version "7.4.0"
+    alias(libs.plugins.openapi.generator)
 }
 
 android {
@@ -74,21 +70,20 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    coreLibraryDesugaring(libs.desugarJdk)
 
-    api("com.squareup.okhttp3:okhttp:4.12.0")
-    val retrofitVersion = "2.11.0"
-    implementation("com.squareup.retrofit2:retrofit:$retrofitVersion")
-    implementation("com.squareup.retrofit2:converter-gson:$retrofitVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    api(libs.okhttp)
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.gson.converter)
+    implementation(libs.kotlinx.coroutines)
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("io.mockk:mockk-android:1.13.9")
-    testImplementation("io.mockk:mockk-agent:1.13.9")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk.android)
+    testImplementation(libs.mockk.agent)
+    testImplementation(libs.kotlinx.coroutines.test)
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 }
 
 project.afterEvaluate {

--- a/quickeditor/build.gradle.kts
+++ b/quickeditor/build.gradle.kts
@@ -1,14 +1,12 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
-
+    id(libs.plugins.android.library.get().pluginId)
+    alias(libs.plugins.kotlin.android)
     // Ktlint
-    id("org.jlleitschuh.gradle.ktlint")
-
+    alias(libs.plugins.ktlint)
     // Detekt
-    id("io.gitlab.arturbosch.detekt")
+    alias(libs.plugins.detekt)
 }
 
 android {


### PR DESCRIPTION


### Description
I wanted to update libraries to the latest versions but I figured it would be beneficial to migrate to the version catalogs first. 

We had all of the dependencies specified in each grade file and with each new module the pain of updating the libraries will increase. We also had some discrepancies so that should fix it. 

### Testing Steps
CI, changes review, run the demo app