### PR TITLE
QuickEditor - Fix `minSdk`to 21

### DIFF
--- a/quickeditor/build.gradle.kts
+++ b/quickeditor/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
### Description

The minSdk in all modules should be 21. In #217 we set the wrong minSdk.

### Testing Steps

- CI and code review should be enough