### PR TITLE
Presentation logic for the OAuthPage

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -34,10 +34,12 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -139,7 +141,7 @@ private fun GravatarTabs(
     onGravatarUrlChanged: (String) -> Unit,
     showSnackBar: (String?, Throwable?) -> Unit,
 ) {
-    var tabIndex by remember { mutableStateOf(0) }
+    var tabIndex by rememberSaveable { mutableIntStateOf(0) }
 
     val tabs = listOf(
         stringResource(R.string.tab_label_avatar),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ constraintlayout = "2.1.4"
 activity = "1.9.0"
 androidXLifecycle = "2.8.3"
 navigationCompose = "2.8.0-beta05"
+turbine = "1.1.0"
 
 [libraries]
 desugarJdk = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdk" }
@@ -64,6 +65,7 @@ roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi
 roborazzi-junit-rule = { group = "io.github.takahirom.roborazzi", name = "roborazzi-junit-rule", version.ref = "roborazzi" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
+turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ composeBom = "2024.06.00"
 browser = "1.8.0"
 constraintlayout = "2.1.4"
 activity = "1.9.0"
+androidXLifecycle = "2.8.3"
+navigationCompose = "2.8.0-beta05"
 
 [libraries]
 desugarJdk = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdk" }
@@ -35,6 +37,8 @@ android-material = { group = "com.google.android.material", name = "material", v
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidXLifecycle" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "composeUiTest" }
 androidx-compose-junit = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "composeUiTest" }
 androidx-compose-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "composeUiTest" }

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -1,3 +1,12 @@
+public final class com/gravatar/quickeditor/ui/ComposableSingletons$GravatarQuickEditorSplashPageKt {
+	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/ComposableSingletons$GravatarQuickEditorSplashPageKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/gravatar/quickeditor/ui/editor/AvatarUpdateResult {
 	public static final field $stable I
 	public fun <init> (Landroid/net/Uri;)V
@@ -58,8 +67,10 @@ public final class com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickE
 public final class com/gravatar/quickeditor/ui/oauth/ComposableSingletons$OAuthPageKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/oauth/ComposableSingletons$OAuthPageKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/gravatar/quickeditor/ui/oauth/OAuthParams {

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -107,5 +107,8 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     testImplementation(libs.junit)
+    testImplementation(libs.mockk.android)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
     testImplementation(project(":uitestutils"))
 }

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -91,6 +91,8 @@ dependencies {
     implementation(project(":gravatar-ui"))
 
     implementation(libs.androidx.browser)
+    implementation(libs.androidx.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
 
     implementation(libs.coil.compose)
     implementation(libs.retrofit)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/models/WordPressOAuthToken.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/models/WordPressOAuthToken.kt
@@ -1,0 +1,8 @@
+package com.gravatar.quickeditor.data.models
+
+import com.google.gson.annotations.SerializedName
+
+internal data class WordPressOAuthToken(
+    @SerializedName("access_token") val token: String,
+    @SerializedName("token_type") val type: String,
+)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthApi.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthApi.kt
@@ -10,10 +10,10 @@ internal interface WordPressOAuthApi {
     @POST("/oauth2/token")
     @FormUrlEncoded
     suspend fun getToken(
-        @Field("client_id") clientId: String?,
-        @Field("redirect_uri") redirectUri: String?,
-        @Field("client_secret") clientSecret: String?,
-        @Field("code") user: String?,
-        @Field("grant_type") grantType: String?,
+        @Field("client_id") clientId: String,
+        @Field("redirect_uri") redirectUri: String,
+        @Field("client_secret") clientSecret: String,
+        @Field("code") user: String,
+        @Field("grant_type") grantType: String,
     ): Response<WordPressOAuthToken>
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthApi.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthApi.kt
@@ -1,0 +1,19 @@
+package com.gravatar.quickeditor.data.service
+
+import com.gravatar.quickeditor.data.models.WordPressOAuthToken
+import retrofit2.Response
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+
+internal interface WordPressOAuthApi {
+    @POST("/oauth2/token")
+    @FormUrlEncoded
+    suspend fun getToken(
+        @Field("client_id") clientId: String?,
+        @Field("redirect_uri") redirectUri: String?,
+        @Field("client_secret") clientSecret: String?,
+        @Field("code") user: String?,
+        @Field("grant_type") grantType: String?,
+    ): Response<WordPressOAuthToken>
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthService.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthService.kt
@@ -1,0 +1,47 @@
+package com.gravatar.quickeditor.data.service
+
+import com.google.gson.GsonBuilder
+import com.gravatar.services.ErrorType
+import com.gravatar.services.Result
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import kotlin.coroutines.cancellation.CancellationException
+
+private val retrofit = Retrofit.Builder()
+    .baseUrl("https://public-api.wordpress.com")
+    .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+    .build()
+
+internal class WordPressOAuthService(
+    private val service: WordPressOAuthApi = retrofit.create(WordPressOAuthApi::class.java),
+) {
+    suspend fun getAccessToken(
+        code: String,
+        clientId: String,
+        clientSecret: String,
+        redirectUri: String,
+    ): Result<String, ErrorType> = withContext(Dispatchers.IO) {
+        @Suppress("TooGenericExceptionCaught", "SwallowedException")
+        try {
+            val response = service.getToken(
+                clientId,
+                redirectUri,
+                clientSecret,
+                code,
+                "authorization_code",
+            )
+            val body = response.body()
+            if (body != null) {
+                Result.Success(body.token)
+            } else {
+                Result.Failure(ErrorType.UNKNOWN)
+            }
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
+        } catch (ex: Exception) {
+            Result.Failure(ErrorType.SERVER)
+        }
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthService.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthService.kt
@@ -3,6 +3,7 @@ package com.gravatar.quickeditor.data.service
 import com.google.gson.GsonBuilder
 import com.gravatar.services.ErrorType
 import com.gravatar.services.Result
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
@@ -16,13 +17,14 @@ private val retrofit = Retrofit.Builder()
 
 internal class WordPressOAuthService(
     private val service: WordPressOAuthApi = retrofit.create(WordPressOAuthApi::class.java),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     suspend fun getAccessToken(
         code: String,
         clientId: String,
         clientSecret: String,
         redirectUri: String,
-    ): Result<String, ErrorType> = withContext(Dispatchers.IO) {
+    ): Result<String, ErrorType> = withContext(dispatcher) {
         @Suppress("TooGenericExceptionCaught", "SwallowedException")
         try {
             val response = service.getToken(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorSplashPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorSplashPage.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import com.gravatar.ui.GravatarTheme
@@ -13,9 +14,10 @@ import com.gravatar.ui.GravatarTheme
 @Composable
 internal fun GravatarQuickEditorSplashPage(onAuthorized: (Boolean) -> Unit) {
     val isAuthorized by rememberSaveable { mutableStateOf(false) }
+    val currentOnAuthorized by rememberUpdatedState(onAuthorized)
 
     LaunchedEffect(Unit) {
-        onAuthorized(isAuthorized)
+        currentOnAuthorized(isAuthorized)
     }
 
     GravatarTheme {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorSplashPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorSplashPage.kt
@@ -1,0 +1,24 @@
+package com.gravatar.quickeditor.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import com.gravatar.ui.GravatarTheme
+
+@Composable
+internal fun GravatarQuickEditorSplashPage(onAuthorized: (Boolean) -> Unit) {
+    val isAuthorized by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        onAuthorized(isAuthorized)
+    }
+
+    GravatarTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {}
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -17,6 +17,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.gravatar.quickeditor.ui.GravatarQuickEditorSplashPage
+import com.gravatar.quickeditor.ui.navigation.QuickEditorPage
 import com.gravatar.quickeditor.ui.oauth.OAuthPage
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
 import com.gravatar.ui.GravatarTheme
@@ -43,28 +44,28 @@ internal fun GravatarQuickEditorPage(
 
     NavHost(
         navController,
-        startDestination = "entry",
+        startDestination = QuickEditorPage.SPLASH.name,
         enterTransition = { EnterTransition.None },
         exitTransition = { ExitTransition.None },
     ) {
-        composable("entry") {
+        composable(QuickEditorPage.SPLASH.name) {
             GravatarQuickEditorSplashPage { isAuthorized ->
                 if (isAuthorized) {
-                    navController.navigate("quickeditor")
+                    navController.navigate(QuickEditorPage.EDITOR.name)
                 } else {
-                    navController.navigate("oauth")
+                    navController.navigate(QuickEditorPage.OAUTH.name)
                 }
             }
         }
-        composable("oauth", enterTransition = { EnterTransition.None }) {
+        composable(QuickEditorPage.OAUTH.name, enterTransition = { EnterTransition.None }) {
             OAuthPage(
                 appName = appName,
                 oauthParams = oAuthParams,
-                onAuthSuccess = { navController.navigate("quickeditor") },
                 onAuthError = { onDismiss(GravatarQuickEditorDismissReason.OauthFailed) },
+                onAuthSuccess = { navController.navigate(QuickEditorPage.EDITOR.name) },
             )
         }
-        composable("quickeditor") {
+        composable(QuickEditorPage.EDITOR.name) {
             GravatarTheme {
                 Surface {
                     Box(modifier = Modifier.fillMaxSize()) {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -1,20 +1,25 @@
 package com.gravatar.quickeditor.ui.editor
 
 import android.net.Uri
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.gravatar.quickeditor.ui.GravatarQuickEditorSplashPage
 import com.gravatar.quickeditor.ui.oauth.OAuthPage
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
+import com.gravatar.ui.GravatarTheme
 
 /**
  * Raw composable component for the Quick Editor.
@@ -34,28 +39,47 @@ internal fun GravatarQuickEditorPage(
     onAvatarSelected: (AvatarUpdateResult) -> Unit,
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
 ) {
-    val isAuthorized = rememberSaveable { mutableStateOf(false) }
+    val navController = rememberNavController()
 
-    Surface {
-        if (!isAuthorized.value) {
+    NavHost(
+        navController,
+        startDestination = "entry",
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None },
+    ) {
+        composable("entry") {
+            GravatarQuickEditorSplashPage { isAuthorized ->
+                if (isAuthorized) {
+                    navController.navigate("quickeditor")
+                } else {
+                    navController.navigate("oauth")
+                }
+            }
+        }
+        composable("oauth", enterTransition = { EnterTransition.None }) {
             OAuthPage(
                 appName = appName,
                 oauthParams = oAuthParams,
-                onAuthSuccess = { isAuthorized.value = true },
+                onAuthSuccess = { navController.navigate("quickeditor") },
                 onAuthError = { onDismiss(GravatarQuickEditorDismissReason.OauthFailed) },
             )
-        } else {
-            Box(modifier = Modifier.fillMaxSize()) {
-                TextButton(
-                    modifier = Modifier.align(Alignment.Center),
-                    onClick = {
-                        onAvatarSelected(AvatarUpdateResult(Uri.EMPTY))
-                    },
-                ) {
-                    Text(
-                        textAlign = TextAlign.Center,
-                        text = "Insert the real avatar picker page here",
-                    )
+        }
+        composable("quickeditor") {
+            GravatarTheme {
+                Surface {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        TextButton(
+                            modifier = Modifier.align(Alignment.Center),
+                            onClick = {
+                                onAvatarSelected(AvatarUpdateResult(Uri.EMPTY))
+                            },
+                        ) {
+                            Text(
+                                textAlign = TextAlign.Center,
+                                text = "Insert the real avatar picker page here",
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/navigation/QuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/navigation/QuickEditorPage.kt
@@ -1,0 +1,7 @@
+package com.gravatar.quickeditor.ui.navigation
+
+internal enum class QuickEditorPage {
+    SPLASH,
+    OAUTH,
+    EDITOR,
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
@@ -4,41 +4,35 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.ManagedActivityResultLauncher
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.core.util.Consumer
-import com.google.gson.GsonBuilder
-import com.google.gson.annotations.SerializedName
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gravatar.ui.GravatarTheme
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import retrofit2.Response
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.http.Field
-import retrofit2.http.FormUrlEncoded
-import retrofit2.http.POST
+import kotlinx.coroutines.withContext
 
 @Composable
 internal fun OAuthPage(
@@ -47,115 +41,110 @@ internal fun OAuthPage(
     onAuthSuccess: () -> Unit,
     onAuthError: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: OAuthViewModel = viewModel(factory = OAuthViewModel.Factory),
 ) {
     val context = LocalContext.current
     val activity = context.findComponentActivity()
-    val coroutineScope = rememberCoroutineScope()
-    var isAuthorizing by rememberSaveable { mutableStateOf(false) }
-    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        Log.d("QuickEditor", "Result is back: $it")
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.Main.immediate) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.actions.collect { action ->
+                    when (action) {
+                        OAuthAction.AuthorizationSuccess -> onAuthSuccess()
+                        OAuthAction.AuthorizationFailure -> onAuthError()
+                        OAuthAction.StartOAuth -> launchCustomTab(context, oauthParams)
+                    }
+                }
+            }
+        }
     }
 
     if (activity != null) {
         DisposableEffect(Unit) {
             val listener = Consumer<Intent> { newIntent ->
                 val code = newIntent.data?.getQueryParameter("code")
-                Log.d("QuickEditor", "code: $code, data: ${newIntent.data}")
                 if (code != null) {
-                    coroutineScope.launch(Dispatchers.IO) {
-                        isAuthorizing = true
-                        Log.d("QuickEditor", "code: $code, data: ${newIntent.data}")
-                        handleAuthorizationCode(code, oauthParams.clientId, oauthParams.clientSecret)?.let { token ->
-                            onAuthSuccess()
-                        }
-                    }
+                    viewModel.fetchAccessToken(
+                        code = code,
+                        clientId = oauthParams.clientId,
+                        clientSecret = oauthParams.clientSecret,
+                        redirectUri = oauthParams.redirectUri,
+                    )
                 } else {
-                    // handle error
-                    isAuthorizing = false
                     onAuthError()
-                    Log.d("QuickEditor", "Error: ${newIntent.data?.getQueryParameter("error")}")
                 }
             }
             activity.addOnNewIntentListener(listener)
-            launchCustomTab(launcher, oauthParams)
             onDispose {
                 activity.removeOnNewIntentListener(listener)
             }
         }
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        if (isAuthorizing) {
-            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-        } else {
-            Column(modifier = Modifier.align(Alignment.Center)) {
-                Text(
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                    text = "$appName needs access to your Gravatar profile",
-                    textAlign = TextAlign.Center,
-                )
-                TextButton(
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                    onClick = {
-                        launchCustomTab(launcher, oauthParams)
-                    },
-                ) {
-                    Text(text = "Authorize")
+    GravatarTheme {
+        Surface {
+            Box(modifier = modifier.fillMaxSize()) {
+                if (uiState.isAuthorizing) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                } else {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(horizontal = 40.dp),
+                    ) {
+                        Text(
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                            text = "$appName needs access to your Gravatar profile",
+                            textAlign = TextAlign.Center,
+                        )
+                        Button(
+                            modifier = Modifier
+                                .align(Alignment.CenterHorizontally)
+                                .padding(top = 8.dp),
+                            onClick = {
+                                launchCustomTab(context, oauthParams)
+                            },
+                        ) {
+                            Text(text = "Authorize")
+                        }
+                    }
                 }
             }
         }
     }
 }
 
-private fun launchCustomTab(launcher: ManagedActivityResultLauncher<Intent, ActivityResult>, oauthParams: OAuthParams) {
+private fun launchCustomTab(context: Context, oauthParams: OAuthParams) {
     val customTabIntent: CustomTabsIntent = CustomTabsIntent.Builder()
         .build()
-    launcher.launch(
-        customTabIntent.intent.apply {
-            setData(Uri.parse(WordPressOauth.buildUrl(oauthParams.clientId, oauthParams.redirectUri)))
-        },
+    customTabIntent.launchUrl(
+        context,
+        Uri.parse(WordPressOauth.buildUrl(oauthParams.clientId, oauthParams.redirectUri)),
     )
 }
 
-internal fun Context.findComponentActivity(): ComponentActivity? = when (this) {
+private fun Context.findComponentActivity(): ComponentActivity? = when (this) {
     is ComponentActivity -> this
     is ContextWrapper -> baseContext.findComponentActivity()
     else -> null
 }
 
-// This will be extracted
-private suspend fun handleAuthorizationCode(code: String, clientId: String, clientSecret: String): String? {
-    val retrofit = Retrofit.Builder()
-        .baseUrl("https://public-api.wordpress.com")
-        .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
-        .build()
-
-    val service: WordPressOAuthApi = retrofit.create(WordPressOAuthApi::class.java)
-    val result = service.getToken(
-        clientId,
-        "wp-oauth-test://authorization-callback",
-        clientSecret,
-        code,
-        "authorization_code",
-    )
-
-    Log.d("MainActivity", "Token: ${result.body()?.token}")
-    return result.body()?.token
+@Preview
+@Composable
+private fun OAuthPagePreview() {
+    GravatarTheme {
+        OAuthPage(
+            appName = "Third-party app",
+            oauthParams = OAuthParams {
+                clientId = "client_id"
+                clientSecret = "client_secret"
+                redirectUri = "redirect_uri"
+            },
+            onAuthSuccess = { },
+            onAuthError = { },
+        )
+    }
 }
-
-internal interface WordPressOAuthApi {
-    @POST("/oauth2/token")
-    @FormUrlEncoded
-    suspend fun getToken(
-        @Field("client_id") clientId: String?,
-        @Field("redirect_uri") redirectUri: String?,
-        @Field("client_secret") clientSecret: String?,
-        @Field("code") user: String?,
-        @Field("grant_type") grantType: String?,
-    ): Response<TokenModel>
-}
-
-internal class TokenModel(
-    @SerializedName("access_token") val token: String,
-    @SerializedName("token_type") val type: String,
-)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthUiState.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthUiState.kt
@@ -1,0 +1,13 @@
+package com.gravatar.quickeditor.ui.oauth
+
+internal data class OAuthUiState(
+    val isAuthorizing: Boolean = false,
+)
+
+internal sealed class OAuthAction {
+    internal data object StartOAuth : OAuthAction()
+
+    internal data object AuthorizationSuccess : OAuthAction()
+
+    internal data object AuthorizationFailure : OAuthAction()
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
@@ -1,0 +1,69 @@
+package com.gravatar.quickeditor.ui.oauth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.gravatar.quickeditor.data.service.WordPressOAuthService
+import com.gravatar.services.Result
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+internal class OAuthViewModel(
+    private val wordPressOAuthService: WordPressOAuthService,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(OAuthUiState())
+    val uiState: StateFlow<OAuthUiState> = _uiState.asStateFlow()
+
+    private val _actions = Channel<OAuthAction>(Channel.BUFFERED)
+    val actions = _actions.receiveAsFlow()
+
+    init {
+        viewModelScope.launch {
+            _actions.send(OAuthAction.StartOAuth)
+        }
+    }
+
+    fun fetchAccessToken(code: String, clientId: String, clientSecret: String, redirectUri: String) {
+        viewModelScope.launch {
+            _uiState.update { currentState -> currentState.copy(isAuthorizing = true) }
+            val result = wordPressOAuthService.getAccessToken(
+                code = code,
+                clientId = clientId,
+                clientSecret = clientSecret,
+                redirectUri = redirectUri,
+            )
+
+            when (result) {
+                is Result.Success -> {
+                    // todo: Save access token
+                    _uiState.update { currentState -> currentState.copy(isAuthorizing = false) }
+                    _actions.send(OAuthAction.AuthorizationSuccess)
+                }
+
+                is Result.Failure -> {
+                    _uiState.update { currentState -> currentState.copy(isAuthorizing = false) }
+                    _actions.send(OAuthAction.AuthorizationFailure)
+                }
+            }
+        }
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val wordPressOAuthService = WordPressOAuthService()
+
+                return OAuthViewModel(
+                    wordPressOAuthService,
+                ) as T
+            }
+        }
+    }
+}

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/service/WordPressOAuthServiceTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/service/WordPressOAuthServiceTest.kt
@@ -1,0 +1,79 @@
+package com.gravatar.quickeditor.data.service
+
+import com.gravatar.quickeditor.data.models.WordPressOAuthToken
+import com.gravatar.services.ErrorType
+import com.gravatar.services.Result
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WordPressOAuthServiceTest {
+    private val wordPressOAuthApi = mockk<WordPressOAuthApi>()
+
+    private lateinit var dispatcher: TestDispatcher
+    private lateinit var wordPressOAuthService: WordPressOAuthService
+
+    @Before
+    fun setup() {
+        dispatcher = UnconfinedTestDispatcher()
+        wordPressOAuthService = WordPressOAuthService(wordPressOAuthApi, dispatcher)
+    }
+
+    @Test
+    fun `given oAuth params when getting the access token and an http error occurs then Failure is returned`() =
+        runTest {
+            val mockResponse = mockk<Response<WordPressOAuthToken>> {
+                every { isSuccessful } returns false
+                every { errorBody() } returns mockk(relaxed = true)
+                every { code() } returns 400
+            }
+            coEvery {
+                wordPressOAuthApi.getToken(any(), any(), any(), any(), any())
+            } returns mockResponse
+
+            val result = wordPressOAuthService.getAccessToken("code", "clientId", "clientSecret", "redirectUri")
+
+            assertEquals(Result.Failure<WordPressOAuthToken, ErrorType>(ErrorType.SERVER), result)
+        }
+
+    @Test
+    fun `given oAuth params when getting the access token and the body is null then Failure is returned`() = runTest {
+        val mockResponse = mockk<Response<WordPressOAuthToken>> {
+            every { isSuccessful } returns true
+            every { body() } returns null
+        }
+        coEvery {
+            wordPressOAuthApi.getToken(any(), any(), any(), any(), any())
+        } returns mockResponse
+
+        val result = wordPressOAuthService.getAccessToken("code", "clientId", "clientSecret", "redirectUri")
+
+        assertEquals(Result.Failure<WordPressOAuthToken, ErrorType>(ErrorType.UNKNOWN), result)
+    }
+
+    @Test
+    fun `given oAuth params when getting the access token and the body is not null then Success is returned`() =
+        runTest {
+            val responseBody = WordPressOAuthToken("token", "type")
+            val mockResponse = mockk<Response<WordPressOAuthToken>> {
+                every { isSuccessful } returns true
+                every { body() } returns responseBody
+            }
+            coEvery {
+                wordPressOAuthApi.getToken(any(), any(), any(), any(), any())
+            } returns mockResponse
+
+            val result = wordPressOAuthService.getAccessToken("code", "clientId", "clientSecret", "redirectUri")
+
+            assertEquals(Result.Success<String, ErrorType>(responseBody.token), result)
+        }
+}

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/CoroutineTestRule.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/CoroutineTestRule.kt
@@ -1,0 +1,23 @@
+package com.gravatar.quickeditor.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoroutineTestRule(
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
@@ -2,32 +2,27 @@ package com.gravatar.quickeditor.ui.oauth
 
 import app.cash.turbine.test
 import com.gravatar.quickeditor.data.service.WordPressOAuthService
+import com.gravatar.quickeditor.ui.CoroutineTestRule
 import com.gravatar.services.ErrorType
 import com.gravatar.services.Result
 import io.mockk.coEvery
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class OAuthViewModelTest {
+    @get:Rule
+    var containerRule = CoroutineTestRule()
+
     private val wordPressOAuthService = mockk<WordPressOAuthService>()
 
-    private lateinit var dispatcher: TestDispatcher
     private lateinit var viewModel: OAuthViewModel
 
     @Before
     fun setup() {
-        dispatcher = StandardTestDispatcher()
-        Dispatchers.setMain(dispatcher)
-
         viewModel = OAuthViewModel(wordPressOAuthService)
     }
 

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
@@ -1,0 +1,97 @@
+package com.gravatar.quickeditor.ui.oauth
+
+import app.cash.turbine.test
+import com.gravatar.quickeditor.data.service.WordPressOAuthService
+import com.gravatar.services.ErrorType
+import com.gravatar.services.Result
+import io.mockk.coEvery
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OAuthViewModelTest {
+    private val wordPressOAuthService = mockk<WordPressOAuthService>()
+
+    private lateinit var dispatcher: TestDispatcher
+    private lateinit var viewModel: OAuthViewModel
+
+    @Before
+    fun setup() {
+        dispatcher = StandardTestDispatcher()
+        Dispatchers.setMain(dispatcher)
+
+        viewModel = OAuthViewModel(wordPressOAuthService)
+    }
+
+    @Test
+    fun `given viewModel when initialized then OAuthAction_StartOAuth sent`() = runTest {
+        viewModel.actions.test {
+            assertEquals(OAuthAction.StartOAuth, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given oAuth params when fetching the access token then UiState_IsAuthorizing is properly updated`() = runTest {
+        coEvery {
+            wordPressOAuthService.getAccessToken(
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns Result.Success("access_token")
+
+        viewModel.uiState.test {
+            assertEquals(OAuthUiState(isAuthorizing = false), awaitItem())
+
+            viewModel.fetchAccessToken("code", "client_id", "client_secret", "redirect_uri")
+            assertEquals(OAuthUiState(isAuthorizing = true), awaitItem())
+
+            assertEquals(OAuthUiState(isAuthorizing = false), awaitItem())
+        }
+    }
+
+    @Test
+    fun `given oAuth params when fetching token fails then OAuthAction_AuthorizationFailure sent`() = runTest {
+        coEvery {
+            wordPressOAuthService.getAccessToken(
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns Result.Failure(ErrorType.UNKNOWN)
+
+        viewModel.actions.test {
+            skipItems(1) // skipping the StartOAuth action
+            viewModel.fetchAccessToken("code", "client_id", "client_secret", "redirect_uri")
+            assertEquals(OAuthAction.AuthorizationFailure, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given oAuth params when fetching token successful then OAuthAction_AuthorizationSuccess sent`() = runTest {
+        coEvery {
+            wordPressOAuthService.getAccessToken(
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns Result.Success("access_token")
+
+        viewModel.actions.test {
+            skipItems(1) // skipping the StartOAuth action
+            viewModel.fetchAccessToken("code", "client_id", "client_secret", "redirect_uri")
+            assertEquals(OAuthAction.AuthorizationSuccess, awaitItem())
+        }
+    }
+}


### PR DESCRIPTION
### Description
Another Draft PR to get some initial feedback. 

We haven't yet needed to do more complicated presentation logic so we don't have any base standards for that. 

This PR adds the ViewModel for the `OAuthPage`. 

I've decided to do manual DI to not add any more dependencies for now. 
One problem is that the `ViewModel` is scoped to the Activity so in our case we would always get the same `ViewModel`. To overcome that I've added the `navigation-compose` because each destination acts as a `ViewModelStoreOwner`. 

This allowed me to move some logic out of the composable like the `launchCustomTab()` call that was triggered in `DisposableEffect`.

One thing I had to add because of the `navigation-compose` is the `GravatarQuickEditorSplashPage`. It acts as the start destination in the nav graph and will handle the routing later when we store the token. There needs to be a `startDestination` defined so we need something and I don't want to start with the `oauth` route and close it quickly if we detect that the token is present. 

For the `ViewModel` itself, there's nothing extraordinary. One thing different than what we can be used to is that the `Actions`  emitted from `ViewModel` are separate and not part of the `UiState`. 


### Testing Steps

Add these to your local.properties

```
demo-app.wordpress.oauth.clientId=yourId
demo-app.wordpress.oauth.clientSecret=yourSecret
demo-app.wordpress.oauth.redirectUri=yourURI
```
and play with the demo app.


1. Tap the `UpdateAvatar`
2. Continue with the required steps to finish the OAuthFlow
3. `Insert the real avatar picker page` text should appear - this is a placeholder for the avatar picker UI
4. Tap the above text
5. Toast message should appear with a confirmation
6. Tap the `UpdateAvatar` 
7. Close the browser with the `x` button
8. Tap the `Done` button
9. Toast with `Dissmised` info is shown
10. Tap the `UpdateAvatar` 
11. Tap `Deny`
12. Toast with `Error` info is shown  
