### PR TITLE
Add extensions to start the GQE from Activity/Fragment

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -36,6 +36,23 @@
                     android:scheme="wp-oauth-test" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.activity.QuickEditorTestActivity"
+            android:launchMode="singleTask"
+            android:label="Old good Activity"
+            android:theme="@style/Theme.Gravatar"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="authorization-callback"
+                    android:scheme="wp-oauth-test" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -1,15 +1,19 @@
 package com.gravatar.demoapp.ui
 
+import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AccountCircle
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -29,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.demoapp.BuildConfig
 import com.gravatar.demoapp.R
+import com.gravatar.demoapp.ui.activity.QuickEditorTestActivity
 import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
@@ -54,6 +59,14 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
             },
             isUploading = false,
         )
+        Spacer(modifier = Modifier.height(20.dp))
+        Button(
+            onClick = {
+                context.startActivity(Intent(context, QuickEditorTestActivity::class.java))
+            },
+        ) {
+            Text(text = "Test with Activity without Compose")
+        }
     }
     if (showBottomSheet) {
         val applicationName = stringResource(id = R.string.app_name)

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
@@ -1,0 +1,95 @@
+package com.gravatar.demoapp.ui.activity
+
+import android.os.Bundle
+import android.util.Log
+import android.widget.Button
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import com.gravatar.demoapp.BuildConfig
+import com.gravatar.demoapp.R
+import com.gravatar.quickeditor.GravatarQuickEditor
+import com.gravatar.quickeditor.ui.oauth.OAuthParams
+import com.gravatar.restapi.models.Profile
+import com.gravatar.services.ProfileService
+import com.gravatar.services.Result
+import com.gravatar.types.Email
+import com.gravatar.ui.components.ComponentState
+import com.gravatar.ui.components.ProfileSummary
+
+class QuickEditorTestActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_quick_editor_test)
+        setupViews()
+    }
+
+    private fun setupViews() {
+        val profileCard = findViewById<ComposeView>(R.id.profile_card)
+        val btnUpdateAvatar = findViewById<Button>(R.id.btn_update_avatar)
+
+        profileCard.setContent {
+            GravatarProfileSummary(emailAddress = BuildConfig.DEMO_EMAIL)
+        }
+
+        btnUpdateAvatar.setOnClickListener {
+            GravatarQuickEditor.show(
+                activity = this,
+                appName = getString(R.string.app_name),
+                oAuthParams = OAuthParams {
+                    clientId = BuildConfig.DEMO_WORDPRESS_CLIENT_ID
+                    clientSecret = BuildConfig.DEMO_WORDPRESS_CLIENT_SECRET
+                    redirectUri = BuildConfig.DEMO_WORDPRESS_REDIRECT_URI
+                },
+                onAvatarSelected = {
+                    Toast.makeText(this, it.toString(), Toast.LENGTH_SHORT).show()
+                },
+                onDismiss = {
+                    Toast.makeText(this, it.toString(), Toast.LENGTH_SHORT).show()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+fun GravatarProfileSummary(emailAddress: String = "gravatar@automattic.com") {
+    val profileService = ProfileService()
+
+    var profileState: ComponentState<Profile> by remember { mutableStateOf(ComponentState.Loading, neverEqualPolicy()) }
+
+    LaunchedEffect(emailAddress) {
+        profileState = ComponentState.Loading
+        when (val result = profileService.retrieveCatching(Email(emailAddress))) {
+            is Result.Success -> {
+                result.value.let {
+                    profileState = ComponentState.Loaded(it)
+                }
+            }
+
+            is Result.Failure -> {
+                Log.e("Gravatar", result.error.name)
+                profileState = ComponentState.Empty
+            }
+        }
+    }
+
+    // Show the profile as a ProfileCard
+    ProfileSummary(
+        profileState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+    )
+}

--- a/demo-app/src/main/res/layout/activity_quick_editor_test.xml
+++ b/demo-app/src/main/res/layout/activity_quick_editor_test.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activity.QuickEditorTestActivity">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/profile_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="12dp"
+        android:layout_marginTop="16dp"
+        app:cardCornerRadius="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/profile_card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </androidx.cardview.widget.CardView>
+
+    <Button
+        android:id="@+id/btn_update_avatar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="Update Avatar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/profile_container" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -1,3 +1,10 @@
+public final class com/gravatar/quickeditor/GravatarQuickEditor {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/gravatar/quickeditor/GravatarQuickEditor;
+	public static final fun show (Landroid/app/Activity;Ljava/lang/String;Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static final fun show (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+}
+
 public final class com/gravatar/quickeditor/ui/ComposableSingletons$GravatarQuickEditorSplashPageKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/ComposableSingletons$GravatarQuickEditorSplashPageKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     implementation(project(":gravatar-ui"))
 
     implementation(libs.androidx.browser)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
@@ -1,0 +1,61 @@
+package com.gravatar.quickeditor
+
+import android.app.Activity
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.gravatar.quickeditor.ui.editor.AvatarUpdateResult
+import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
+import com.gravatar.quickeditor.ui.editor.extensions.addQuickEditorToView
+import com.gravatar.quickeditor.ui.oauth.OAuthParams
+
+/**
+ * Singleton object that provides easy to use functions to interact with the Gravatar Quick Editor.
+ */
+public object GravatarQuickEditor {
+    /**
+     * Helper function to launch the Gravatar Quick Editor from the activity.
+     *
+     * @param activity The activity to launch the Gravatar Quick Editor from.
+     * @param appName Name of the app that is launching the Quick Editor
+     * @param oAuthParams The parameters to configure the OAuth.
+     * @param onAvatarSelected The callback for the avatar update result, check [AvatarUpdateResult].
+     *                       Can be invoked multiple times while the Quick Editor is open.
+     * @param onDismiss The callback for the dismiss action.
+     *                  [GravatarQuickEditorError] will be non-null if the dismiss was caused by an error.
+     */
+    @JvmStatic
+    public fun show(
+        activity: Activity,
+        appName: String,
+        oAuthParams: OAuthParams,
+        onAvatarSelected: (AvatarUpdateResult) -> Unit,
+        onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
+    ) {
+        val viewGroup: ViewGroup = activity.findViewById(android.R.id.content)
+        addQuickEditorToView(viewGroup, appName, oAuthParams, onAvatarSelected, onDismiss)
+    }
+
+    /**
+     * Helper function to launch the Gravatar Quick Editor from the fragment. Internally it uses
+     * `Activity.requireActivity()` to get the activity.
+     *
+     * @param fragment The fragment to launch the Gravatar Quick Editor from.
+     * @param appName Name of the app that is launching the Quick Editor
+     * @param oAuthParams The parameters to configure the OAuth.
+     * @param onAvatarSelected The callback for the avatar update result, check [AvatarUpdateResult].
+     *                       Can be invoked multiple times while the Quick Editor is open.
+     * @param onDismiss The callback for the dismiss action.
+     *                  [GravatarQuickEditorError] will be non-null if the dismiss was caused by an error.
+     */
+    @JvmStatic
+    public fun show(
+        fragment: Fragment,
+        appName: String,
+        oAuthParams: OAuthParams,
+        onAvatarSelected: (AvatarUpdateResult) -> Unit,
+        onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
+    ) {
+        val viewGroup: ViewGroup = fragment.requireActivity().findViewById(android.R.id.content)
+        addQuickEditorToView(viewGroup, appName, oAuthParams, onAvatarSelected, onDismiss)
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
@@ -1,0 +1,89 @@
+package com.gravatar.quickeditor.ui.editor.extensions
+
+import android.view.ViewGroup
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import com.gravatar.quickeditor.ui.editor.AvatarUpdateResult
+import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
+import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
+import com.gravatar.quickeditor.ui.oauth.OAuthParams
+import kotlinx.coroutines.launch
+
+internal fun addQuickEditorToView(
+    viewGroup: ViewGroup,
+    appName: String,
+    oAuthParams: OAuthParams,
+    onAvatarUpdateResult: (AvatarUpdateResult) -> Unit,
+    onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
+) {
+    viewGroup.addView(
+        ComposeView(viewGroup.context).apply {
+            setContent {
+                GravatarQuickEditorBottomSheetWrapper(
+                    parent = viewGroup,
+                    composeView = this,
+                    appName = appName,
+                    oAuthParams = oAuthParams,
+                    onAvatarUpdateResult = onAvatarUpdateResult,
+                    onDismiss = onDismiss,
+                )
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GravatarQuickEditorBottomSheetWrapper(
+    parent: ViewGroup,
+    composeView: ComposeView,
+    appName: String,
+    oAuthParams: OAuthParams,
+    onAvatarUpdateResult: (AvatarUpdateResult) -> Unit,
+    onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    var isSheetOpened by remember { mutableStateOf(false) }
+
+    val modalBottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    GravatarQuickEditorBottomSheet(
+        appName = appName,
+        oAuthParams = oAuthParams,
+        onAvatarSelected = onAvatarUpdateResult,
+        onDismiss = onDismiss,
+        modalBottomSheetState = modalBottomSheetState,
+    )
+
+    BackHandler {
+        coroutineScope.launch {
+            modalBottomSheetState.hide()
+        }
+        onDismiss(GravatarQuickEditorDismissReason.Finished)
+    }
+
+    LaunchedEffect(modalBottomSheetState.currentValue) {
+        when (modalBottomSheetState.currentValue) {
+            SheetValue.Hidden -> {
+                if (isSheetOpened) {
+                    parent.removeView(composeView)
+                } else {
+                    isSheetOpened = true
+                    modalBottomSheetState.show()
+                }
+            }
+
+            else -> Unit
+        }
+    }
+}


### PR DESCRIPTION

### Description

Extra functions that help start the Quick Editor from either Fragment or Activity.

This was briefly discussed [here](https://github.com/Automattic/Gravatar-SDK-Android/pull/239#discussion_r1687831585). 
@hamorillo correctly pointed out that this adds an extra dependency that not everyone might use.

My thoughts on that are the `appcompat` library is likely already included in any Android project and we should make sure our SDK works by default with the old system as it's likely still used in the majority of the apps.

### Testing Steps

To make this easier you can comment the `<intent-filter>` for the `.MainActivity` in the demoApp manifest. 

1. Tap the `Test with Activity without Compose`
2. Tap `Update Avatar`
3. Continue with the required steps to finish the OAuthFlow
4. `Insert the real avatar picker page` text should appear - this is a placeholder for the avatar picker UI
5. Tap the above text
6. Toast message should appear with a confirmation
7. Tap the `UpdateAvatar` 
8. Close the browser with the `x` button
9. Tap the `Done` button
10. Toast with `Dissmised` info is shown
11. Tap the `UpdateAvatar` 
12. Tap `Deny`
13. Toast with `Error` info is shown  