### PR TITLE
Create QuickEditorContainer to hold Quick Editor dependencies

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
@@ -1,0 +1,31 @@
+package com.gravatar.quickeditor
+
+import com.google.gson.GsonBuilder
+import com.gravatar.quickeditor.data.service.WordPressOAuthApi
+import com.gravatar.quickeditor.data.service.WordPressOAuthService
+import kotlinx.coroutines.Dispatchers
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+internal class QuickEditorContainer private constructor() {
+    companion object {
+        val instance: QuickEditorContainer by lazy {
+            QuickEditorContainer()
+        }
+    }
+
+    val wordPressOAuthService: WordPressOAuthService by lazy {
+        WordPressOAuthService(
+            wordPressOAuthApi = getWordpressOAuthApi(),
+            dispatcher = Dispatchers.IO,
+        )
+    }
+
+    private fun getWordpressOAuthApi(): WordPressOAuthApi {
+        return Retrofit.Builder()
+            .baseUrl("https://public-api.wordpress.com")
+            .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+            .build()
+            .create(WordPressOAuthApi::class.java)
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthService.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthService.kt
@@ -1,23 +1,14 @@
 package com.gravatar.quickeditor.data.service
 
-import com.google.gson.GsonBuilder
 import com.gravatar.services.ErrorType
 import com.gravatar.services.Result
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 import kotlin.coroutines.cancellation.CancellationException
 
-private val retrofit = Retrofit.Builder()
-    .baseUrl("https://public-api.wordpress.com")
-    .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
-    .build()
-
 internal class WordPressOAuthService(
-    private val service: WordPressOAuthApi = retrofit.create(WordPressOAuthApi::class.java),
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val wordPressOAuthApi: WordPressOAuthApi,
+    private val dispatcher: CoroutineDispatcher,
 ) {
     suspend fun getAccessToken(
         code: String,
@@ -27,7 +18,7 @@ internal class WordPressOAuthService(
     ): Result<String, ErrorType> = withContext(dispatcher) {
         @Suppress("TooGenericExceptionCaught", "SwallowedException")
         try {
-            val response = service.getToken(
+            val response = wordPressOAuthApi.getToken(
                 clientId,
                 redirectUri,
                 clientSecret,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.gravatar.quickeditor.QuickEditorContainer
 import com.gravatar.quickeditor.data.service.WordPressOAuthService
 import com.gravatar.services.Result
 import kotlinx.coroutines.channels.Channel
@@ -58,10 +59,8 @@ internal class OAuthViewModel(
         val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
-                val wordPressOAuthService = WordPressOAuthService()
-
                 return OAuthViewModel(
-                    wordPressOAuthService,
+                    QuickEditorContainer.instance.wordPressOAuthService,
                 ) as T
             }
         }


### PR DESCRIPTION
### Description

Following the `:gravatar` module I've added the `QuickEditorContainer` to hold all the dependencies we need in the QE. 

### Testing Steps
Add these to your local.properties

```
demo-app.wordpress.oauth.clientId=yourId
demo-app.wordpress.oauth.clientSecret=yourSecret
demo-app.wordpress.oauth.redirectUri=yourURI
```
and play with the demo app.

1. Tap the `UpdateAvatar`
2. Continue with the required steps to finish the OAuthFlow
3. `Insert the real avatar picker page` text should appear - this is a placeholder for the avatar picker UI
4. Tap the above text
5. Toast message should appear with a confirmation
6. Close the bottom sheet
7. Tap the `UpdateAvatar` 
8. Close the browser with the `x` button
9. Tap the `Done` button
10. Toast with `Finished` info is shown
11. Tap the `UpdateAvatar` 
12. Tap `OaythFailed`
13. Toast with `Error` info is shown  