### PR TITLE
QuickEditor: Create services for Avatars and Identities

### DIFF
--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -747,6 +747,14 @@ public final class com/gravatar/services/HttpException : java/lang/RuntimeExcept
 	public fun getMessage ()Ljava/lang/String;
 }
 
+public final class com/gravatar/services/IdentityService {
+	public static final field LOG_TAG Ljava/lang/String;
+	public fun <init> (Lokhttp3/OkHttpClient;Ljava/lang/String;)V
+	public synthetic fun <init> (Lokhttp3/OkHttpClient;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun retrieve (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieveCatching (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/gravatar/services/ProfileService {
 	public static final field LOG_TAG Ljava/lang/String;
 	public fun <init> ()V

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -753,6 +753,8 @@ public final class com/gravatar/services/IdentityService {
 	public synthetic fun <init> (Lokhttp3/OkHttpClient;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun retrieve (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieveCatching (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setAvatar (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setAvatarCatching (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/gravatar/services/ProfileService {

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -718,6 +718,8 @@ public final class com/gravatar/services/AvatarService {
 	public fun <init> ()V
 	public fun <init> (Lokhttp3/OkHttpClient;)V
 	public synthetic fun <init> (Lokhttp3/OkHttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun retrieve (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun retrieveCatching (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun upload (Ljava/io/File;Lcom/gravatar/types/Email;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun upload (Ljava/io/File;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun uploadCatching (Ljava/io/File;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -719,6 +719,8 @@ public final class com/gravatar/services/AvatarService {
 	public fun <init> (Lokhttp3/OkHttpClient;)V
 	public synthetic fun <init> (Lokhttp3/OkHttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun upload (Ljava/io/File;Lcom/gravatar/types/Email;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun upload (Ljava/io/File;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun uploadCatching (Ljava/io/File;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/gravatar/services/ErrorType : java/lang/Enum {

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -749,8 +749,9 @@ public final class com/gravatar/services/HttpException : java/lang/RuntimeExcept
 
 public final class com/gravatar/services/IdentityService {
 	public static final field LOG_TAG Ljava/lang/String;
-	public fun <init> (Lokhttp3/OkHttpClient;Ljava/lang/String;)V
-	public synthetic fun <init> (Lokhttp3/OkHttpClient;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Lokhttp3/OkHttpClient;)V
+	public synthetic fun <init> (Lokhttp3/OkHttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun retrieve (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieveCatching (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAvatar (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -55,6 +55,7 @@ internal class GravatarSdkContainer private constructor() {
         }.build().create(GravatarApi::class.java)
     }
 
+    @Deprecated("Use getGravatarV3Service instead", level = DeprecationLevel.WARNING)
     fun getGravatarApiV3Service(okHttpClient: OkHttpClient? = null): GravatarApiService {
         return getRetrofitApiV3Builder().apply {
             client((okHttpClient ?: OkHttpClient()).newBuilder().addInterceptor(AuthenticationInterceptor()).build())
@@ -62,9 +63,13 @@ internal class GravatarSdkContainer private constructor() {
             .build().create(GravatarApiService::class.java)
     }
 
-    fun getGravatarV3Service(okHttpClient: OkHttpClient? = null): GravatarApi {
+    fun getGravatarV3Service(okHttpClient: OkHttpClient? = null, oauthToken: String? = null): GravatarApi {
         return getRetrofitApiV3Builder().apply {
-            client((okHttpClient ?: OkHttpClient()).newBuilder().addInterceptor(AuthenticationInterceptor()).build())
+            client(
+                (okHttpClient ?: OkHttpClient()).newBuilder().addInterceptor(
+                    AuthenticationInterceptor(oauthToken),
+                ).build(),
+            )
         }.addConverterFactory(GsonConverterFactory.create(gson))
             .build().create(GravatarApi::class.java)
     }

--- a/gravatar/src/main/java/com/gravatar/services/AuthenticationInterceptor.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AuthenticationInterceptor.kt
@@ -5,7 +5,7 @@ import okhttp3.Request
 import okhttp3.Response
 import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
 
-internal class AuthenticationInterceptor : Interceptor {
+internal class AuthenticationInterceptor(private val oauthToken: String? = null) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         return chain.proceed(
             chain.request().newBuilder()
@@ -15,6 +15,8 @@ internal class AuthenticationInterceptor : Interceptor {
     }
 
     private fun Request.Builder.addAuthorizationHeaderIfPresent(): Request.Builder {
-        return GravatarSdkDI.apiKey?.let { addHeader("Authorization", "Bearer $it") } ?: this
+        return oauthToken?.let { addHeader(it) } ?: GravatarSdkDI.apiKey?.let { addHeader(it) } ?: this
     }
+
+    private fun Request.Builder.addHeader(bearer: String) = addHeader("Authorization", "Bearer $bearer")
 }

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -1,5 +1,6 @@
 package com.gravatar.services
 
+import com.gravatar.di.container.GravatarSdkContainer.Companion.instance
 import com.gravatar.logger.Logger
 import com.gravatar.types.Email
 import kotlinx.coroutines.withContext
@@ -12,7 +13,7 @@ import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as Grav
 /**
  * Service for managing Gravatar avatars.
  */
-public class AvatarService(okHttpClient: OkHttpClient? = null) {
+public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
     private companion object {
         const val LOG_TAG = "AvatarService"
     }
@@ -26,6 +27,7 @@ public class AvatarService(okHttpClient: OkHttpClient? = null) {
      * @param email The email address to associate the image with
      * @param wordpressBearerToken The bearer token for the user's WordPress/Gravatar account
      */
+    @Deprecated("Use upload(file: File, oauthToken: String) instead", level = DeprecationLevel.WARNING)
     public suspend fun upload(file: File, email: Email, wordpressBearerToken: String): Result<Unit, ErrorType> {
         val identity = MultipartBody.Part.createFormData("account", email.toString())
         val filePart =
@@ -47,5 +49,43 @@ public class AvatarService(okHttpClient: OkHttpClient? = null) {
                 }
             }
         }
+    }
+
+    /**
+     * Uploads an image to be used as Gravatar avatar.
+     *
+     * @param file The image file to upload
+     * @param oauthToken The OAuth token to use for authentication
+     */
+    public suspend fun upload(file: File, oauthToken: String): Unit = withContext(GravatarSdkDI.dispatcherIO) {
+        val service = instance.getGravatarV3Service(okHttpClient, oauthToken)
+
+        val filePart =
+            MultipartBody.Part.createFormData("image", file.name, file.asRequestBody())
+
+        val response = service.uploadAvatar(filePart)
+
+        if (response.isSuccessful) {
+            Unit
+        } else {
+            // Log the response body for debugging purposes if the response is not successful
+            Logger.w(
+                LOG_TAG,
+                "Network call unsuccessful trying to upload Gravatar: $response.body",
+            )
+            throw HttpException(response)
+        }
+    }
+
+    /**
+     * Uploads an image to be used as Gravatar avatar.
+     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     *
+     * @param file The image file to upload
+     * @param oauthToken The OAuth token to use for authentication
+     * @return The result of the operation
+     */
+    public suspend fun uploadCatching(file: File, oauthToken: String): Result<Unit, ErrorType> = runCatchingRequest {
+        upload(file, oauthToken)
     }
 }

--- a/gravatar/src/main/java/com/gravatar/services/GravatarApi.kt
+++ b/gravatar/src/main/java/com/gravatar/services/GravatarApi.kt
@@ -1,5 +1,7 @@
 package com.gravatar.services
 
+import com.gravatar.restapi.apis.AvatarsApi
+import com.gravatar.restapi.apis.IdentitiesApi
 import com.gravatar.restapi.apis.ProfilesApi
 import okhttp3.MultipartBody
 import okhttp3.ResponseBody
@@ -9,7 +11,7 @@ import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
 
-internal interface GravatarApi : ProfilesApi {
+internal interface GravatarApi : ProfilesApi, AvatarsApi, IdentitiesApi {
     @Multipart
     @POST("upload-image")
     suspend fun uploadImage(

--- a/gravatar/src/main/java/com/gravatar/services/IdentityService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/IdentityService.kt
@@ -2,6 +2,7 @@ package com.gravatar.services
 
 import com.gravatar.logger.Logger
 import com.gravatar.restapi.models.Identity
+import com.gravatar.restapi.models.SelectAvatar
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
@@ -49,5 +50,44 @@ public class IdentityService(private val okHttpClient: OkHttpClient? = null, oau
     public suspend fun retrieveCatching(hash: String, oauthToken: String): Result<Identity, ErrorType> =
         runCatchingRequest {
             retrieve(hash, oauthToken)
+        }
+
+    /**
+     * Sets the avatar for the given email (hash).
+     *
+     * @param hash The hash of the email to set the avatar for
+     * @param avatarId The ID of the avatar to set
+     * @param oauthToken The OAuth token to use for authentication
+     */
+    public suspend fun setAvatar(hash: String, avatarId: String, oauthToken: String): Unit =
+        withContext(GravatarSdkDI.dispatcherIO) {
+            val service = GravatarSdkDI.getGravatarV3Service(okHttpClient, oauthToken)
+
+            val response = service.setIdentityAvatar(hash, SelectAvatar { this.avatarId = avatarId })
+
+            if (response.isSuccessful) {
+                Unit
+            } else {
+                // Log the response body for debugging purposes if the response is not successful
+                Logger.w(
+                    LOG_TAG,
+                    "Network call unsuccessful trying to set Gravatar avatar: $response.body",
+                )
+                throw HttpException(response)
+            }
+        }
+
+    /**
+     * Sets the avatar for the given email (hash).
+     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     *
+     * @param hash The hash of the email to set the avatar for
+     * @param avatarId The ID of the avatar to set
+     * @param oauthToken The OAuth token to use for authentication
+     * @return The result of the operation
+     */
+    public suspend fun setAvatarCatching(hash: String, avatarId: String, oauthToken: String): Result<Unit, ErrorType> =
+        runCatchingRequest {
+            setAvatar(hash, avatarId, oauthToken)
         }
 }

--- a/gravatar/src/main/java/com/gravatar/services/IdentityService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/IdentityService.kt
@@ -10,7 +10,7 @@ import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as Grav
 /**
  * Service for managing Gravatar identities.
  */
-public class IdentityService(private val okHttpClient: OkHttpClient? = null, oauthToken: String) {
+public class IdentityService(private val okHttpClient: OkHttpClient? = null) {
     private companion object {
         const val LOG_TAG = "IdentityService"
     }

--- a/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
+++ b/gravatar/src/test/java/com/gravatar/GravatarSdkContainerRule.kt
@@ -38,6 +38,7 @@ class GravatarSdkContainerRule : TestRule {
                 every { gravatarSdkContainerMock.getGravatarV1Service(any()) } returns gravatarApiMock
                 every { gravatarSdkContainerMock.getGravatarApiV3Service(any()) } returns gravatarApiServiceMock
                 every { gravatarSdkContainerMock.getGravatarV3Service(any()) } returns gravatarApiMock
+                every { gravatarSdkContainerMock.getGravatarV3Service(any(), any()) } returns gravatarApiMock
 
                 mockkObject(Logger)
                 every { Logger.i(any(), any()) } returns 1

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody
@@ -20,12 +21,14 @@ class AvatarServiceTest {
     var containerRule = GravatarSdkContainerRule()
 
     private lateinit var avatarService: AvatarService
+    private val oauthToken = "oauthToken"
 
     @Before
     fun setUp() {
         avatarService = AvatarService()
     }
 
+    // V1 Deprecated Methods
     @Test
     fun `given a file, email and wordpressBearerToken when uploading avatar then Gravatar service is invoked`() =
         runTest {
@@ -75,5 +78,86 @@ class AvatarServiceTest {
         val uploadResponse = avatarService.upload(File("avatarFile"), Email("email"), "wordpressBearerToken")
 
         assertTrue((uploadResponse as Result.Failure).error == ErrorType.UNKNOWN)
+    }
+
+    // V3 Methods
+    @Test
+    fun `given a file when uploading avatar then Gravatar service is invoked`() = runTest {
+        val mockResponse = mockk<Response<Unit>>()
+        coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+        every { mockResponse.isSuccessful } returns true
+
+        avatarService.upload(File("avatarFile"), oauthToken)
+
+        coVerify(exactly = 1) {
+            containerRule.gravatarApiMock.uploadAvatar(
+                withArg {
+                    assertTrue(
+                        with(it.headers?.values("Content-Disposition").toString()) {
+                            contains("image") && contains("avatarFile")
+                        },
+                    )
+                },
+            )
+        }
+    }
+
+    @Test(expected = HttpException::class)
+    fun `given an avatar upload when an error occurs then an exception is thrown`() = runTest {
+        val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+            every { isSuccessful } returns false
+            every { code() } returns 500
+        }
+        coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+
+        avatarService.upload(File("avatarFile"), oauthToken)
+    }
+
+    @Test
+    fun `given a file when uploadCatching avatar then Gravatar service is invoked`() = runTest {
+        val mockResponse = mockk<Response<Unit>>()
+        coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+        every { mockResponse.isSuccessful } returns true
+
+        val response = avatarService.uploadCatching(File("avatarFile"), oauthToken)
+
+        coVerify(exactly = 1) {
+            containerRule.gravatarApiMock.uploadAvatar(
+                withArg {
+                    assertTrue(
+                        with(it.headers?.values("Content-Disposition").toString()) {
+                            contains("image") && contains("avatarFile")
+                        },
+                    )
+                },
+            )
+        }
+
+        assertTrue(response is Result.Success)
+    }
+
+    @Test
+    fun `given an avatar uploadCatching when an error occurs then a Result Failure is returned`() = runTest {
+        val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+            every { isSuccessful } returns false
+            every { code() } returns 500
+        }
+        coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+
+        val response = avatarService.uploadCatching(File("avatarFile"), oauthToken)
+
+        coVerify(exactly = 1) {
+            containerRule.gravatarApiMock.uploadAvatar(
+                withArg {
+                    assertTrue(
+                        with(it.headers?.values("Content-Disposition").toString()) {
+                            contains("image") && contains("avatarFile")
+                        },
+                    )
+                },
+            )
+        }
+
+        assertEquals(ErrorType.SERVER, (response as Result.Failure).error)
     }
 }

--- a/gravatar/src/test/java/com/gravatar/services/IdentityServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/IdentityServiceTest.kt
@@ -21,7 +21,7 @@ class IdentityServiceTest {
 
     @Before
     fun setUp() {
-        identityService = IdentityService(oauthToken = "oauthToken")
+        identityService = IdentityService()
     }
 
     @Test

--- a/gravatar/src/test/java/com/gravatar/services/IdentityServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/IdentityServiceTest.kt
@@ -1,0 +1,87 @@
+package com.gravatar.services
+
+import com.gravatar.GravatarSdkContainerRule
+import com.gravatar.restapi.models.Identity
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.Response
+
+class IdentityServiceTest {
+    @get:Rule
+    var containerRule = GravatarSdkContainerRule()
+
+    private lateinit var identityService: IdentityService
+    private val oauthToken = "oauthToken"
+
+    @Before
+    fun setUp() {
+        identityService = IdentityService(oauthToken = "oauthToken")
+    }
+
+    @Test
+    fun `given a hash when retrieving identity then Gravatar service is invoked`() = runTest {
+        val hash = "hash"
+        val identity = mockk<Identity>()
+        val mockResponse = mockk<Response<Identity>>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body() } returns identity
+        }
+
+        coEvery { containerRule.gravatarApiMock.getIdentity(hash) } returns mockResponse
+
+        val response = identityService.retrieve(hash, oauthToken)
+
+        assertEquals(identity, response)
+    }
+
+    @Test(expected = HttpException::class)
+    fun `given a hash when retrieving an identity and an error occurs then an exception is thrown`() = runTest {
+        val hash = "hash"
+        val mockResponse = mockk<Response<Identity>>(relaxed = true) {
+            every { isSuccessful } returns false
+            every { code() } returns 500
+        }
+
+        coEvery { containerRule.gravatarApiMock.getIdentity(hash) } returns mockResponse
+
+        identityService.retrieve(hash, oauthToken)
+    }
+
+    @Test
+    fun `given a hash when retrieveCatching identity then Gravatar service is invoked`() = runTest {
+        val hash = "hash"
+        val identity = mockk<Identity>()
+        val mockResponse = mockk<Response<Identity>>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body() } returns identity
+        }
+
+        coEvery { containerRule.gravatarApiMock.getIdentity(hash) } returns mockResponse
+
+        val response = identityService.retrieveCatching(hash, oauthToken)
+
+        assertEquals(identity, (response as Result.Success).value)
+    }
+
+    @Test
+    fun `given a hash when retrieveCatching identity and an error occurs then a Result Failure is returned`() =
+        runTest {
+            val hash = "hash"
+            val mockResponse = mockk<Response<Identity>>(relaxed = true) {
+                every { isSuccessful } returns false
+                every { code() } returns 500
+            }
+
+            coEvery { containerRule.gravatarApiMock.getIdentity(hash) } returns mockResponse
+
+            val response = identityService.retrieveCatching(hash, oauthToken)
+
+            assertEquals(ErrorType.SERVER, (response as Result.Failure).error)
+        }
+}

--- a/gravatar/src/test/java/com/gravatar/services/IdentityServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/IdentityServiceTest.kt
@@ -84,4 +84,64 @@ class IdentityServiceTest {
 
             assertEquals(ErrorType.SERVER, (response as Result.Failure).error)
         }
+
+    @Test
+    fun `given a hash and an avatarId when setting avatar then Gravatar service is invoked`() = runTest {
+        val hash = "hash"
+        val avatarId = "avatarId"
+        val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+            every { isSuccessful } returns true
+        }
+
+        coEvery { containerRule.gravatarApiMock.setIdentityAvatar(hash, any()) } returns mockResponse
+
+        identityService.setAvatar(hash, avatarId, oauthToken)
+    }
+
+    @Test(expected = HttpException::class)
+    fun `given a hash and an avatarId when setting an avatar and an error occurs then an exception is thrown`() =
+        runTest {
+            val hash = "hash"
+            val avatarId = "avatarId"
+            val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+                every { isSuccessful } returns false
+                every { code() } returns 500
+            }
+
+            coEvery { containerRule.gravatarApiMock.setIdentityAvatar(hash, any()) } returns mockResponse
+
+            identityService.setAvatar(hash, avatarId, oauthToken)
+        }
+
+    @Test
+    fun `given a hash and an avatarId when setAvatarCatching then Gravatar service is invoked`() = runTest {
+        val hash = "hash"
+        val avatarId = "avatarId"
+        val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+            every { isSuccessful } returns true
+        }
+
+        coEvery { containerRule.gravatarApiMock.setIdentityAvatar(hash, any()) } returns mockResponse
+
+        val response = identityService.setAvatarCatching(hash, avatarId, oauthToken)
+
+        assertEquals(Unit, (response as Result.Success).value)
+    }
+
+    @Test
+    fun `given a hash and an avatarId when setAvatarCatching and an error occurs then a Result Failure is returned`() =
+        runTest {
+            val hash = "hash"
+            val avatarId = "avatarId"
+            val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+                every { isSuccessful } returns false
+                every { code() } returns 500
+            }
+
+            coEvery { containerRule.gravatarApiMock.setIdentityAvatar(hash, any()) } returns mockResponse
+
+            val response = identityService.setAvatarCatching(hash, avatarId, oauthToken)
+
+            assertEquals(ErrorType.SERVER, (response as Result.Failure).error)
+        }
 }


### PR DESCRIPTION
Closes #243 

### Description

Adding new methods in `AvatarService` to upload images and retrieve information about already uploaded avatars. 
Creating `IdentityService` to retrieve identity info (we need this to know which avatar is currently selected) and to switch between avatars for a given `Identity`.

### Testing Steps

As we don't have an implementation using those services/endpoints, **CI and code review should be enough**. We'll need to double-check in following PRs when we implemented the QuickEditor selector.
