### PR TITLE
Publish `gravatar-quickeditor` to A8C artifact repository

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,6 +58,8 @@ steps:
       :gravatar:publish \
       :gravatar-ui:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
       :gravatar-ui:publish \
+      :gravatar-quickeditor:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
+      :gravatar-quickeditor:publish \
       --no-configuration-cache
     plugins: [$CI_TOOLKIT]
     notify:

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           dependency-graph: generate-and-submit
       - name: Generate the dependency graph which will be submitted post-job
-        run: ./gradlew :gravatar:dependencies :gravatar-ui:dependencies
+        run: ./gradlew :gravatar:dependencies :gravatar-ui:dependencies :gravatar-quickeditor:dependencies

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ dependencies {
     implementation ("com.gravatar:gravatar:<version>")
     // OR
     implementation ("com.gravatar:gravatar-ui:<version>")
+    // OR
+    implementation ("com.gravatar:gravatar-quickeditor:<version>")
 }
 ```
 

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id(libs.plugins.android.library.get().pluginId)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.plugin.compose)
+    alias(libs.plugins.publish.to.s3)
     // Ktlint
     alias(libs.plugins.ktlint)
     // Detekt
@@ -115,4 +116,18 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(libs.robolectric)
     testImplementation(project(":uitestutils"))
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("maven") {
+                from(components["release"])
+
+                groupId = "com.gravatar"
+                artifactId = "gravatar-quickeditor"
+                // version is set by `publish-to-s3` plugin
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #217 

### Description

This PR adds support for publishing `gravatar-quickeditor` module to A8C S3 instance.

### Testing Steps

Please add dependency like

```
implementation "com.gravatar:gravatar-quickeditor:hamorillo_217-publish-quickeditor-artifact-facc457aa2b3ee0447a53e66a4ab8e72be4e5bb9`
```

in an external Gradle build and verify that classes are available.

cc: @AdamGrzybkowski  @mlumeau 