### PR TITLE
QuickEditor: Update the avatar in the ProfileCard after selection

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -267,5 +267,5 @@ private fun AvatarSectionPreview() {
     }
 }
 
-private val Avatar.fullUrl: String
+internal val Avatar.fullUrl: String
     get() = "https://www.gravatar.com$imageUrl?size=200"

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -118,7 +118,7 @@ internal class AvatarPickerViewModelFactory(
     }
 }
 
-private fun Profile.copyAvatar(avatar: Avatar): Profile {
+internal fun Profile.copyAvatar(avatar: Avatar): Profile {
     return Profile {
         hash = this@copyAvatar.hash
         displayName = this@copyAvatar.displayName

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import com.gravatar.quickeditor.QuickEditorContainer
 import com.gravatar.quickeditor.data.repository.AvatarRepository
 import com.gravatar.restapi.models.Avatar
+import com.gravatar.restapi.models.Profile
 import com.gravatar.services.ProfileService
 import com.gravatar.services.Result
 import com.gravatar.types.Email
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.net.URI
 
 internal class AvatarPickerViewModel(
     private val email: Email,
@@ -47,10 +49,12 @@ internal class AvatarPickerViewModel(
                             currentState.copy(
                                 identityAvatars = currentState.identityAvatars?.copy(selectedAvatarId = avatarId),
                                 selectingAvatarId = null,
+                                profile = currentState.profile?.copy { copyAvatar(avatar) },
                             )
                         }
                         _actions.send(AvatarPickerAction.AvatarSelected(avatar))
                     }
+
                     is Result.Failure -> {
                         _uiState.update { currentState ->
                             currentState.copy(selectingAvatarId = null)
@@ -112,4 +116,42 @@ internal class AvatarPickerViewModelFactory(
             avatarRepository = QuickEditorContainer.getInstance().avatarRepository,
         ) as T
     }
+}
+
+private fun Profile.copyAvatar(avatar: Avatar): Profile {
+    return Profile {
+        hash = this@copyAvatar.hash
+        displayName = this@copyAvatar.displayName
+        profileUrl = this@copyAvatar.profileUrl
+        avatarUrl = URI.create(avatar.fullUrl)
+        avatarAltText = avatar.altText
+        location = this@copyAvatar.location
+        description = this@copyAvatar.description
+        jobTitle = this@copyAvatar.jobTitle
+        description = this@copyAvatar.description
+        jobTitle = this@copyAvatar.jobTitle
+        company = this@copyAvatar.company
+        verifiedAccounts = this@copyAvatar.verifiedAccounts
+        pronunciation = this@copyAvatar.pronunciation
+        pronouns = this@copyAvatar.pronouns
+        timezone = this@copyAvatar.timezone
+        languages = this@copyAvatar.languages
+        firstName = this@copyAvatar.firstName
+        lastName = this@copyAvatar.lastName
+        isOrganization = this@copyAvatar.isOrganization
+        links = this@copyAvatar.links
+        interests = this@copyAvatar.interests
+        payments = this@copyAvatar.payments
+        contactInfo = this@copyAvatar.contactInfo
+        gallery = this@copyAvatar.gallery
+        numberVerifiedAccounts = this@copyAvatar.numberVerifiedAccounts
+        lastProfileEdit = this@copyAvatar.lastProfileEdit
+        registrationDate = this@copyAvatar.registrationDate
+    }
+}
+
+private fun <T> ComponentState<T>.copy(transform: T.() -> T): ComponentState<T> = when (this) {
+    is ComponentState.Loaded -> ComponentState.Loaded(loadedValue.transform())
+    is ComponentState.Loading -> this
+    is ComponentState.Empty -> this
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/ProfileCard.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/ProfileCard.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -13,6 +15,7 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -21,6 +24,7 @@ import com.gravatar.restapi.models.Profile
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.ProfileSummary
+import com.gravatar.ui.components.atomic.Avatar
 
 @Composable
 internal fun ProfileCard(profile: ComponentState<Profile>?, modifier: Modifier = Modifier) {
@@ -32,6 +36,13 @@ internal fun ProfileCard(profile: ComponentState<Profile>?, modifier: Modifier =
                     .fillMaxWidth()
                     .background(backgroundColor)
                     .padding(horizontal = 16.dp, vertical = 11.dp),
+                avatar = {
+                    Avatar(
+                        state = profile.transform { profileValue -> profileValue.avatarUrl.toString() },
+                        size = 72.dp,
+                        modifier = Modifier.clip(CircleShape),
+                    )
+                },
             )
         }
     }
@@ -72,4 +83,10 @@ private fun ProfileCardPreview() {
             modifier = Modifier.padding(20.dp),
         )
     }
+}
+
+private fun <T, O> ComponentState<T>.transform(transform: (T) -> O): ComponentState<O> = when (this) {
+    is ComponentState.Empty -> ComponentState.Empty
+    is ComponentState.Loading -> ComponentState.Loading
+    is ComponentState.Loaded -> ComponentState.Loaded(transform(loadedValue))
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -175,7 +175,7 @@ class AvatarPickerViewModelTest {
                     email = email,
                     identityAvatars = identityAvatars.copy(selectedAvatarId = avatars.last().imageId),
                     error = false,
-                    profile = ComponentState.Loaded(profile),
+                    profile = ComponentState.Loaded(profile.copyAvatar(avatars.last())),
                     selectingAvatarId = null,
                 ),
                 awaitItem(),

--- a/gravatar-ui/api/gravatar-ui.api
+++ b/gravatar-ui/api/gravatar-ui.api
@@ -189,6 +189,7 @@ public final class com/gravatar/ui/components/atomic/AvatarKt {
 	public static final fun Avatar-DzVHIIc (Lcom/gravatar/restapi/models/Profile;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Avatar-DzVHIIc (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;Landroidx/compose/runtime/Composer;II)V
 	public static final fun AvatarWithComponentState (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;Landroidx/compose/runtime/Composer;II)V
+	public static final fun AvatarWithURLComponentState (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/gravatar/ui/components/atomic/ComposableSingletons$AboutMeKt {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -68,13 +68,7 @@ public fun Avatar(
     avatarQueryOptions: AvatarQueryOptions? = null,
 ) {
     when (state) {
-        is ComponentState.Loading -> {
-            Box(
-                modifier = modifier
-                    .size(size)
-                    .skeletonEffect(),
-            )
-        }
+        is ComponentState.Loading -> SkeletonAvatar(size = size, modifier = modifier)
 
         is ComponentState.Loaded -> {
             Avatar(
@@ -85,16 +79,55 @@ public fun Avatar(
             )
         }
 
-        ComponentState.Empty -> Avatar(
-            model = if (isNightModeEnabled()) {
-                R.drawable.empty_profile_avatar_dark
-            } else {
-                R.drawable.empty_profile_avatar
-            },
-            size = size,
-            modifier = modifier,
-        )
+        ComponentState.Empty -> EmptyAvatar(size = size, modifier = modifier)
     }
+}
+
+/**
+ * [Avatar] is a composable that displays a user's avatar given the avatar URL.
+ *
+ * @param state Avatar URL wrapped in ComponentState
+ * @param size The size of the avatar
+ * @param modifier Composable modifier
+ */
+@JvmName("AvatarWithURLComponentState")
+@Composable
+public fun Avatar(state: ComponentState<String>, size: Dp, modifier: Modifier = Modifier) {
+    when (state) {
+        is ComponentState.Loading -> SkeletonAvatar(size = size, modifier = modifier)
+
+        is ComponentState.Loaded -> {
+            Avatar(
+                model = state.loadedValue,
+                size = size,
+                modifier = modifier,
+            )
+        }
+
+        ComponentState.Empty -> EmptyAvatar(size = size, modifier = modifier)
+    }
+}
+
+@Composable
+private fun SkeletonAvatar(size: Dp, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .skeletonEffect(),
+    )
+}
+
+@Composable
+private fun EmptyAvatar(size: Dp, modifier: Modifier = Modifier) {
+    Avatar(
+        model = if (isNightModeEnabled()) {
+            R.drawable.empty_profile_avatar_dark
+        } else {
+            R.drawable.empty_profile_avatar
+        },
+        size = size,
+        modifier = modifier,
+    )
 }
 
 @Composable


### PR DESCRIPTION
Closes #258

### Description

As mentioned in the previous [PR](https://github.com/Automattic/Gravatar-SDK-Android/pull/260) the avatar in the ProfileCard is not updated instantly. That is because by default it loads the avatar based on the email hash and this doesn't change when a new avatar is selected. If the URL is static, it means cache is used so the Avatar won't update for some time. 

To overcome this, I've added a new `Avatar` component that uses the unique avatar URL. We get that URL for each avatar so when we select one we can update the Profile with such a URL.


https://github.com/user-attachments/assets/44412c06-4c8a-421b-80a7-11c801a284d5

### Testing Steps

**Important Note**: The backend is currently returning the wrong format for the `updated date` field. As a workaround, you can apply this patch to comment that field from the Avatar object.
[Gravatar-Android-13-04-48.patch](https://github.com/user-attachments/files/16455284/Gravatar-Android-13-04-48.patch)

1. Make sure you have at least two avatars uploaded on Gravatar
2. Run the DemoApp 
3. Go to Avatar Update tab
4. Tap `Update Avatar` button
5. Follow the steps to log in (if necessary)
8. Select a different avatar
9. Confirm it was updated in the ProfileCard at the top of the bottom sheet