### PR TITLE
QuickEditor: Upload image from the gallery

### DIFF
--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -9,16 +9,21 @@ public final class com/gravatar/quickeditor/GravatarQuickEditor {
 public final class com/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
-	public static field lambda-4 Lkotlin/jvm/functions/Function2;
-	public static field lambda-5 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-4$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-5$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$AvatarsSectionKt {
+	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/components/ComposableSingletons$AvatarsSectionKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$EmailLabelKt {

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.retrofit)
     implementation(libs.retrofit.gson.converter)
+    implementation(libs.ucrop)
 
     // Jetpack Compose
     implementation(platform(libs.compose.bom))

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.GsonBuilder
+import com.gravatar.quickeditor.data.FileUtils
 import com.gravatar.quickeditor.data.repository.AvatarRepository
 import com.gravatar.quickeditor.data.service.WordPressOAuthApi
 import com.gravatar.quickeditor.data.service.WordPressOAuthService
@@ -58,6 +59,10 @@ internal class QuickEditorContainer private constructor(
 
     private val identityService: IdentityService by lazy {
         IdentityService()
+    }
+
+    val fileUtils: FileUtils by lazy {
+        FileUtils(context)
     }
 
     val avatarRepository: AvatarRepository by lazy {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/FileUtils.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/FileUtils.kt
@@ -1,0 +1,19 @@
+package com.gravatar.quickeditor.data
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toFile
+import java.io.File
+
+internal class FileUtils(
+    private val context: Context,
+) {
+    fun createTempFile(): File {
+        return File(context.cacheDir, "gravatar_${System.currentTimeMillis()}")
+    }
+
+    fun deleteFile(uri: Uri) {
+        val toFile = uri.toFile()
+        toFile.delete()
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/models/QuickEditorError.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/models/QuickEditorError.kt
@@ -6,4 +6,6 @@ internal sealed class QuickEditorError {
     data object Unknown : QuickEditorError()
 
     data object Server : QuickEditorError()
+
+    data object AvatarUploadFailed : QuickEditorError()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -11,10 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
@@ -27,23 +23,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -52,10 +38,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gravatar.extensions.defaultProfile
 import com.gravatar.quickeditor.R
 import com.gravatar.quickeditor.data.repository.IdentityAvatars
+import com.gravatar.quickeditor.ui.components.AvatarsSection
 import com.gravatar.quickeditor.ui.components.EmailLabel
-import com.gravatar.quickeditor.ui.components.MediaPickerPopup
 import com.gravatar.quickeditor.ui.components.ProfileCard
-import com.gravatar.quickeditor.ui.components.SelectableAvatar
 import com.gravatar.quickeditor.ui.editor.AvatarUpdateResult
 import com.gravatar.quickeditor.ui.editor.bottomsheet.DEFAULT_PAGE_HEIGHT
 import com.gravatar.restapi.models.Avatar
@@ -154,75 +139,23 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onAvatarSelected: (Avata
     }
 }
 
-@Composable
-private fun AvatarsSection(
-    avatars: List<AvatarUi>,
-    onAvatarSelected: (Avatar) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var popupVisible by rememberSaveable { mutableStateOf(false) }
-    var popupYOffset by rememberSaveable { mutableIntStateOf(0) }
-    Box(
-        modifier = modifier
-            .border(
-                width = 1.dp,
-                color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                shape = RoundedCornerShape(8.dp),
-            )
-            .padding(16.dp),
-    ) {
-        Column {
-            Text(
-                text = stringResource(id = R.string.avatar_picker_title),
-                fontSize = 22.sp,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = stringResource(R.string.avatar_picker_description),
-                fontSize = 15.sp,
-                color = MaterialTheme.colorScheme.tertiary,
-                modifier = Modifier.padding(top = 4.dp),
-            )
+private const val UCROP_COMPRESSION_QUALITY = 100
 
-            LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(vertical = 24.dp)) {
-                items(items = avatars, key = { it.avatarId }) { avatarModel ->
-                    when (avatarModel) {
-                        is AvatarUi.Uploaded -> SelectableAvatar(
-                            imageUrl = avatarModel.avatar.fullUrl,
-                            isSelected = avatarModel.isSelected,
-                            isLoading = avatarModel.isLoading,
-                            onAvatarClicked = {
-                                onAvatarSelected(avatarModel.avatar)
-                            },
-                            modifier = Modifier.size(96.dp),
-                        )
-                    }
-                }
-            }
-            Button(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .onPlaced { layoutCoordinates -> popupYOffset = layoutCoordinates.size.height },
-                onClick = { popupVisible = true },
-                shape = RoundedCornerShape(4.dp),
-                contentPadding = PaddingValues(14.dp),
-            ) {
-                Text(
-                    text = stringResource(R.string.avatar_picker_upload_image),
-                    style = MaterialTheme.typography.titleMedium,
-                )
-            }
-        }
-        if (popupVisible) {
-            MediaPickerPopup(
-                alignment = Alignment.BottomCenter,
-                onDismissRequest = { popupVisible = false },
-                offset = IntOffset(0, -popupYOffset - 30),
-                onChoosePhotoClick = { popupVisible = false },
-                onTakePhotoClick = { popupVisible = false },
-            )
-        }
+private fun ActivityResultLauncher<Intent>.launchAvatarCrop(image: Uri, tempFile: File, context: Context) {
+    val options = UCrop.Options().apply {
+        setToolbarColor(Color.BLACK)
+        setStatusBarColor(Color.BLACK)
+        setToolbarWidgetColor(Color.WHITE)
+        setAllowedGestures(UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.NONE)
+        setCompressionQuality(UCROP_COMPRESSION_QUALITY)
+        setCircleDimmedLayer(true)
     }
+    launch(
+        UCrop.of(image, Uri.fromFile(tempFile))
+            .withAspectRatio(1f, 1f)
+            .withOptions(options)
+            .getIntent(context),
+    )
 }
 
 @Composable
@@ -271,31 +204,7 @@ private fun AvatarPickerLoadingPreview() {
                 identityAvatars = null,
             ),
             onAvatarSelected = { },
-        )
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-private fun AvatarSectionPreview() {
-    GravatarTheme {
-        AvatarsSection(
-            onAvatarSelected = { },
-            avatars = listOf(
-                AvatarUi.Uploaded(
-                    avatar = Avatar {
-                        imageUrl = "/image/url"
-                        format = 0
-                        imageId = "1"
-                        rating = "G"
-                        altText = "alt"
-                        isCropped = true
-                        updatedDate = Instant.now()
-                    },
-                    isSelected = true,
-                    isLoading = false,
-                ),
-            ),
+            onLocalImageSelected = { },
         )
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -1,11 +1,7 @@
 package com.gravatar.quickeditor.ui.avatarpicker
 
-import android.content.Context
-import android.content.Intent
-import android.graphics.Color
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,6 +40,8 @@ import com.gravatar.quickeditor.data.repository.IdentityAvatars
 import com.gravatar.quickeditor.ui.components.AvatarsSection
 import com.gravatar.quickeditor.ui.components.EmailLabel
 import com.gravatar.quickeditor.ui.components.ProfileCard
+import com.gravatar.quickeditor.ui.copperlauncher.CropperLauncher
+import com.gravatar.quickeditor.ui.copperlauncher.UCropCropperLauncher
 import com.gravatar.quickeditor.ui.editor.AvatarUpdateResult
 import com.gravatar.quickeditor.ui.editor.bottomsheet.DEFAULT_PAGE_HEIGHT
 import com.gravatar.restapi.models.Avatar
@@ -51,10 +49,8 @@ import com.gravatar.types.Email
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.components.ComponentState
 import com.yalantis.ucrop.UCrop
-import com.yalantis.ucrop.UCropActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.File
 import java.time.Instant
 
 @Composable
@@ -62,6 +58,7 @@ internal fun AvatarPicker(
     email: Email,
     onAvatarSelected: (AvatarUpdateResult) -> Unit,
     viewModel: AvatarPickerViewModel = viewModel(factory = AvatarPickerViewModelFactory(email)),
+    cropperLauncher: CropperLauncher = UCropCropperLauncher(),
 ) {
     val snackState = remember { SnackbarHostState() }
     val lifecycle = LocalLifecycleOwner.current.lifecycle
@@ -91,7 +88,7 @@ internal fun AvatarPicker(
                         }
 
                         is AvatarPickerAction.LaunchImageCropper -> {
-                            uCropLauncher.launchAvatarCrop(action.imageUri, action.tempFile, context)
+                            cropperLauncher.launch(uCropLauncher, action.imageUri, action.tempFile, context)
                         }
                     }
                 }
@@ -161,25 +158,6 @@ internal fun AvatarPicker(
             Spacer(modifier = Modifier.height(24.dp))
         }
     }
-}
-
-private const val UCROP_COMPRESSION_QUALITY = 100
-
-private fun ActivityResultLauncher<Intent>.launchAvatarCrop(image: Uri, tempFile: File, context: Context) {
-    val options = UCrop.Options().apply {
-        setToolbarColor(Color.BLACK)
-        setStatusBarColor(Color.BLACK)
-        setToolbarWidgetColor(Color.WHITE)
-        setAllowedGestures(UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.NONE)
-        setCompressionQuality(UCROP_COMPRESSION_QUALITY)
-        setCircleDimmedLayer(true)
-    }
-    launch(
-        UCrop.of(image, Uri.fromFile(tempFile))
-            .withAspectRatio(1f, 1f)
-            .withOptions(options)
-            .getIntent(context),
-    )
 }
 
 @Composable

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
@@ -1,7 +1,11 @@
 package com.gravatar.quickeditor.ui.avatarpicker
 
+import android.net.Uri
 import com.gravatar.restapi.models.Avatar
+import java.io.File
 
 internal sealed class AvatarPickerAction {
     data class AvatarSelected(val avatar: Avatar) : AvatarPickerAction()
+
+    data class LaunchImageCropper(val imageUri: Uri, val tempFile: File) : AvatarPickerAction()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarsSection.kt
@@ -1,0 +1,170 @@
+package com.gravatar.quickeditor.ui.components
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.gravatar.quickeditor.R
+import com.gravatar.quickeditor.ui.avatarpicker.AvatarUi
+import com.gravatar.quickeditor.ui.avatarpicker.AvatarsSectionUiState
+import com.gravatar.quickeditor.ui.avatarpicker.fullUrl
+import com.gravatar.restapi.models.Avatar
+import com.gravatar.ui.GravatarTheme
+import java.time.Instant
+
+@Composable
+internal fun AvatarsSection(
+    state: AvatarsSectionUiState,
+    onAvatarSelected: (Avatar) -> Unit,
+    onLocalImageSelected: (Uri) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var popupVisible by rememberSaveable { mutableStateOf(false) }
+    var popupYOffset by rememberSaveable { mutableIntStateOf(0) }
+    val listState = rememberLazyListState()
+
+    val pickMedia = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+        uri?.let { onLocalImageSelected(it) }
+    }
+
+    LaunchedEffect(state.scrollToIndex) {
+        state.scrollToIndex?.let { listState.scrollToItem(it) }
+    }
+
+    Box(
+        modifier = modifier
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .padding(16.dp),
+    ) {
+        Column {
+            Text(
+                text = stringResource(id = R.string.avatar_picker_title),
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = stringResource(R.string.avatar_picker_description),
+                fontSize = 15.sp,
+                color = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(vertical = 24.dp),
+                state = listState,
+            ) {
+                items(items = state.avatars, key = { it.avatarId }) { avatarModel ->
+                    when (avatarModel) {
+                        is AvatarUi.Uploaded -> SelectableAvatar(
+                            imageUrl = avatarModel.avatar.fullUrl,
+                            isSelected = avatarModel.isSelected,
+                            isLoading = avatarModel.isLoading,
+                            onAvatarClicked = {
+                                onAvatarSelected(avatarModel.avatar)
+                            },
+                            modifier = Modifier.size(96.dp),
+                        )
+
+                        is AvatarUi.Local -> LocalAvatar(
+                            imageUri = avatarModel.uri.toString(),
+                            isLoading = true,
+                            modifier = Modifier.size(96.dp),
+                        )
+                    }
+                }
+            }
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onPlaced { layoutCoordinates -> popupYOffset = layoutCoordinates.size.height },
+                onClick = { popupVisible = true },
+                shape = RoundedCornerShape(4.dp),
+                contentPadding = PaddingValues(14.dp),
+                enabled = state.uploadButtonEnabled,
+            ) {
+                Text(
+                    text = stringResource(R.string.avatar_picker_upload_image),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        }
+        if (popupVisible) {
+            MediaPickerPopup(
+                alignment = Alignment.BottomCenter,
+                onDismissRequest = { popupVisible = false },
+                offset = IntOffset(0, -popupYOffset - 30),
+                onChoosePhotoClick = {
+                    popupVisible = false
+                    pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                },
+                onTakePhotoClick = { popupVisible = false },
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun AvatarSectionPreview() {
+    GravatarTheme {
+        AvatarsSection(
+            state = AvatarsSectionUiState(
+                avatars = listOf(
+                    AvatarUi.Uploaded(
+                        avatar = Avatar {
+                            imageUrl = "/image/url"
+                            format = 0
+                            imageId = "1"
+                            rating = "G"
+                            altText = "alt"
+                            isCropped = true
+                            updatedDate = Instant.now()
+                        },
+                        isSelected = true,
+                        isLoading = false,
+                    ),
+                ),
+                scrollToIndex = null,
+                uploadButtonEnabled = true,
+            ),
+            onAvatarSelected = { },
+            onLocalImageSelected = { },
+        )
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LocalAvatar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LocalAvatar.kt
@@ -1,0 +1,38 @@
+package com.gravatar.quickeditor.ui.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun LocalAvatar(imageUri: String, isLoading: Boolean, modifier: Modifier = Modifier) {
+    SelectableAvatar(
+        imageUrl = imageUri,
+        isSelected = false,
+        isLoading = isLoading,
+        onAvatarClicked = { },
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun LocalAvatarPreview() {
+    LocalAvatar(
+        "https://gravatar.com/avatar/fd2188b818f15e629f7b62896b5c6075?s=250",
+        isLoading = false,
+        Modifier.size(150.dp),
+    )
+}
+
+@Preview
+@Composable
+private fun LocalAvatarLoadingPreview() {
+    LocalAvatar(
+        "https://gravatar.com/avatar/fd2188b818f15e629f7b62896b5c6075?s=250",
+        isLoading = true,
+        Modifier.size(150.dp),
+    )
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/SelectableAvatar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/SelectableAvatar.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -20,7 +19,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.gravatar.quickeditor.R
-import com.gravatar.ui.GravatarTheme
 
 @Composable
 internal fun SelectableAvatar(
@@ -31,43 +29,43 @@ internal fun SelectableAvatar(
     modifier: Modifier = Modifier,
 ) {
     val cornerRadius = 8.dp
-    GravatarTheme {
-        Box(modifier = modifier) {
-            AsyncImage(
-                model = imageUrl,
-                contentDescription = stringResource(id = R.string.selectable_avatar_content_description),
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(RoundedCornerShape(cornerRadius))
-                    .then(
-                        if (isSelected) {
-                            Modifier.border(4.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(cornerRadius))
-                        } else {
-                            Modifier.border(
-                                1.dp,
-                                MaterialTheme.colorScheme.surfaceDim,
-                                RoundedCornerShape(cornerRadius),
-                            )
-                        },
-                    )
-                    .clickable {
-                        onAvatarClicked()
+    Box(modifier = modifier) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = stringResource(id = R.string.selectable_avatar_content_description),
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(cornerRadius))
+                .then(
+                    if (isSelected) {
+                        Modifier.border(4.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(cornerRadius))
+                    } else {
+                        Modifier.border(
+                            1.dp,
+                            MaterialTheme.colorScheme.surfaceDim,
+                            RoundedCornerShape(cornerRadius),
+                        )
                     },
-            )
-            if (isLoading) {
-                Box(
-                    modifier = modifier
-                        .fillMaxSize()
-                        .background(
-                            color = Color.Black.copy(alpha = 0.3f),
-                            shape = RoundedCornerShape(cornerRadius),
-                        ),
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.Center).size(20.dp),
-                        strokeWidth = 2.dp,
-                    )
-                }
+                )
+                .clickable {
+                    onAvatarClicked()
+                },
+        )
+        if (isLoading) {
+            Box(
+                modifier = modifier
+                    .fillMaxSize()
+                    .background(
+                        color = Color.Black.copy(alpha = 0.3f),
+                        shape = RoundedCornerShape(cornerRadius),
+                    ),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(20.dp),
+                    strokeWidth = 2.dp,
+                )
             }
         }
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/copperlauncher/CropperLauncher.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/copperlauncher/CropperLauncher.kt
@@ -1,0 +1,11 @@
+package com.gravatar.quickeditor.ui.copperlauncher
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import java.io.File
+
+internal interface CropperLauncher {
+    fun launch(launcher: ActivityResultLauncher<Intent>, image: Uri, tempFile: File, context: Context)
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/copperlauncher/UCropCropperLauncher.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/copperlauncher/UCropCropperLauncher.kt
@@ -1,0 +1,28 @@
+package com.gravatar.quickeditor.ui.copperlauncher
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import com.yalantis.ucrop.UCrop
+import com.yalantis.ucrop.UCropActivity
+import java.io.File
+
+private const val UCROP_COMPRESSION_QUALITY = 100
+
+internal class UCropCropperLauncher : CropperLauncher {
+    override fun launch(launcher: ActivityResultLauncher<Intent>, image: Uri, tempFile: File, context: Context) {
+        val options = UCrop.Options().apply {
+            setToolbarColor(Color.BLACK)
+            setStatusBarColor(Color.BLACK)
+            setToolbarWidgetColor(Color.WHITE)
+            setAllowedGestures(UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.NONE)
+            setCompressionQuality(UCROP_COMPRESSION_QUALITY)
+            setCircleDimmedLayer(true)
+        }
+        launcher.launch(
+            UCrop.of(image, Uri.fromFile(tempFile)).withAspectRatio(1f, 1f).withOptions(options).getIntent(context),
+        )
+    }
+}

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -1,5 +1,7 @@
 package com.gravatar.quickeditor.data.repository
 
+import android.net.Uri
+import androidx.core.net.toFile
 import com.gravatar.quickeditor.data.models.QuickEditorError
 import com.gravatar.quickeditor.data.storage.TokenStorage
 import com.gravatar.quickeditor.ui.CoroutineTestRule
@@ -11,13 +13,16 @@ import com.gravatar.services.IdentityService
 import com.gravatar.services.Result
 import com.gravatar.types.Email
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.io.File
 import java.time.Instant
 
 class AvatarRepositoryTest {
@@ -119,6 +124,47 @@ class AvatarRepositoryTest {
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
         assertEquals(Result.Success<Unit, QuickEditorError>(Unit), result)
+    }
+
+    @Test
+    fun `given token not stored when avatar upload then Failure result`() = runTest {
+        val uri = mockk<Uri>()
+        coEvery { tokenStorage.getToken(any()) } returns null
+        coEvery { avatarService.uploadCatching(any(), any()) } returns Result.Success(Unit)
+
+        val result = avatarRepository.uploadAvatar(email, uri)
+
+        assertEquals(Result.Failure<Unit, QuickEditorError>(QuickEditorError.TokenNotFound), result)
+    }
+
+    @Test
+    fun `given token stored when avatar upload succeeds then Success result`() = runTest {
+        mockkStatic("androidx.core.net.UriKt")
+        val file = mockk<File>()
+        val uri = mockk<Uri> {
+            every { toFile() } returns file
+        }
+        coEvery { tokenStorage.getToken(any()) } returns "token"
+        coEvery { avatarService.uploadCatching(any(), any()) } returns Result.Success(Unit)
+
+        val result = avatarRepository.uploadAvatar(email, uri)
+
+        assertEquals(Result.Success<Unit, QuickEditorError>(Unit), result)
+    }
+
+    @Test
+    fun `given token stored when avatar upload fails then Failure result`() = runTest {
+        mockkStatic("androidx.core.net.UriKt")
+        val file = mockk<File>()
+        val uri = mockk<Uri> {
+            every { toFile() } returns file
+        }
+        coEvery { tokenStorage.getToken(any()) } returns "token"
+        coEvery { avatarService.uploadCatching(any(), any()) } returns Result.Failure(ErrorType.SERVER)
+
+        val result = avatarRepository.uploadAvatar(email, uri)
+
+        assertEquals(Result.Failure<Unit, QuickEditorError>(QuickEditorError.AvatarUploadFailed), result)
     }
 
     private fun createAvatar(id: String) = Avatar {

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerTest.kt
@@ -48,6 +48,7 @@ class AvatarPickerTest : RoborazziTest() {
                     selectedAvatarId = "1",
                 ),
             ),
+            onLocalImageSelected = { },
             onAvatarSelected = {},
         )
     }
@@ -84,6 +85,7 @@ class AvatarPickerTest : RoborazziTest() {
                 ),
             ),
             onAvatarSelected = {},
+            onLocalImageSelected = { },
         )
     }
 }


### PR DESCRIPTION
Closes #226

### Description

This PR adds an option to pick an image from the phone gallery and upload it to the server after cropping. 

For the image picking I went with the latest recommended solution from Google - [Photo Picker](https://developer.android.com/training/data-storage/shared/photopicker).
For the cropping, I used the UCrop library as we did already for the WordPress picker. 

I've mimicked the web by disabling the `Upload image` button while the avatar is being uploaded to the web.


https://github.com/user-attachments/assets/9b5df0cd-2504-4929-a79c-e46da2e081c7



### Testing Steps
**Important Note**: The backend is currently returning the wrong format for the `updated date` field. As a workaround, you can apply this patch to comment that field from the Avatar object.
[Gravatar-Android-13-04-48.patch](https://github.com/user-attachments/files/16455284/Gravatar-Android-13-04-48.patch)

1. Make sure you have at least two avatars uploaded on Gravatar
2. Run the DemoApp 
3. Go to Avatar Update tab
4. Tap `Update Avatar` button
5. Follow the steps to log in (if necessary)
8. Tap the `Upload Image` button
9. Tap the `Choose a Photo`
10. Pick a photo from the gallery
11. Crop if you want and confirm
12. Confirm you see the photo in the list with the progress indicator
13. Confirm the photo was uploaded and can be selected
