### PR TITLE
QuickEditor: Error snackbar styling

### DIFF
--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -8,13 +8,11 @@ public final class com/gravatar/quickeditor/GravatarQuickEditor {
 
 public final class com/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$AvatarsSectionKt {
@@ -148,6 +146,13 @@ public final class com/gravatar/quickeditor/ui/editor/bottomsheet/ComposableSing
 
 public final class com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheetKt {
 	public static final fun GravatarQuickEditorBottomSheet (Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/material3/SheetState;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/gravatar/quickeditor/ui/extensions/ComposableSingletons$QESnackbarKt {
+	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/extensions/ComposableSingletons$QESnackbarKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/gravatar/quickeditor/ui/oauth/ComposableSingletons$OAuthPageKt {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -13,10 +13,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -46,6 +42,9 @@ import com.gravatar.quickeditor.ui.copperlauncher.CropperLauncher
 import com.gravatar.quickeditor.ui.copperlauncher.UCropCropperLauncher
 import com.gravatar.quickeditor.ui.editor.AvatarUpdateResult
 import com.gravatar.quickeditor.ui.editor.bottomsheet.DEFAULT_PAGE_HEIGHT
+import com.gravatar.quickeditor.ui.extensions.QESnackbarHost
+import com.gravatar.quickeditor.ui.extensions.SnackbarType
+import com.gravatar.quickeditor.ui.extensions.showQESnackbar
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.types.Email
 import com.gravatar.ui.GravatarTheme
@@ -82,10 +81,9 @@ internal fun AvatarPicker(
                     when (action) {
                         is AvatarPickerAction.AvatarSelected -> {
                             onAvatarSelected(AvatarUpdateResult(action.avatar.fullUrl.toUri()))
-                            snackState.showSnackbar(
+                            snackState.showQESnackbar(
                                 message = context.getString(R.string.avatar_selected_confirmation),
-                                actionLabel = context.getString(R.string.avatar_selected_confirmation_action),
-                                duration = SnackbarDuration.Long,
+                                withDismissAction = true,
                             )
                         }
 
@@ -105,17 +103,11 @@ internal fun AvatarPicker(
                 onAvatarSelected = viewModel::selectAvatar,
                 onLocalImageSelected = viewModel::localImageSelected,
             )
-            SnackbarHost(
+            QESnackbarHost(
                 modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(20.dp),
+                    .align(Alignment.BottomStart),
                 hostState = snackState,
-            ) { snackbarData ->
-                Snackbar(
-                    actionColor = MaterialTheme.colorScheme.inverseOnSurface,
-                    snackbarData = snackbarData,
-                )
-            }
+            )
         }
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -89,6 +90,19 @@ internal fun AvatarPicker(
 
                         is AvatarPickerAction.LaunchImageCropper -> {
                             cropperLauncher.launch(uCropLauncher, action.imageUri, action.tempFile, context)
+                        }
+
+                        is AvatarPickerAction.AvatarUploadFailed -> {
+                            val result = snackState.showQESnackbar(
+                                message = context.getString(R.string.avatar_upload_error),
+                                actionLabel = context.getString(R.string.avatar_upload_error_action),
+                                snackbarType = SnackbarType.Error,
+                                withDismissAction = true,
+                            )
+                            when (result) {
+                                SnackbarResult.Dismissed -> Unit
+                                SnackbarResult.ActionPerformed -> viewModel.uploadAvatar(action.imageUri)
+                            }
                         }
                     }
                 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
@@ -10,4 +10,6 @@ internal sealed class AvatarPickerAction {
     data class AvatarUploadFailed(val imageUri: Uri) : AvatarPickerAction()
 
     data class LaunchImageCropper(val imageUri: Uri, val tempFile: File) : AvatarPickerAction()
+
+    data object AvatarSelectionFailed : AvatarPickerAction()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
@@ -7,5 +7,7 @@ import java.io.File
 internal sealed class AvatarPickerAction {
     data class AvatarSelected(val avatar: Avatar) : AvatarPickerAction()
 
+    data class AvatarUploadFailed(val imageUri: Uri) : AvatarPickerAction()
+
     data class LaunchImageCropper(val imageUri: Uri, val tempFile: File) : AvatarPickerAction()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -62,7 +62,7 @@ internal class AvatarPickerViewModel(
                         _uiState.update { currentState ->
                             currentState.copy(selectingAvatarId = null)
                         }
-                        // display error snack
+                        _actions.send(AvatarPickerAction.AvatarSelectionFailed)
                     }
                 }
             }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -90,10 +90,10 @@ internal class AvatarPickerViewModel(
                 }
 
                 is Result.Failure -> {
-                    fileUtils.deleteFile(uri) // Once we have better UI for errors we will keep the file for retries
                     _uiState.update { currentState ->
                         currentState.copy(uploadingAvatar = null)
                     }
+                    _actions.send(AvatarPickerAction.AvatarUploadFailed(uri))
                 }
             }
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/extensions/QESnackbar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/extensions/QESnackbar.kt
@@ -1,0 +1,81 @@
+package com.gravatar.quickeditor.ui.extensions
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.SnackbarVisuals
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+internal data class QESnackbarVisuals(
+    val snackbarType: SnackbarType,
+    override val actionLabel: String?,
+    override val duration: SnackbarDuration,
+    override val message: String,
+    override val withDismissAction: Boolean,
+) : SnackbarVisuals
+
+@Composable
+internal fun QESnackbarHost(hostState: SnackbarHostState, modifier: Modifier = Modifier) {
+    SnackbarHost(
+        modifier = modifier
+            .padding(20.dp),
+        hostState = hostState,
+    ) { snackbarData ->
+        val qeSnackbarVisuals = snackbarData.visuals as? QESnackbarVisuals
+        val containerColor =
+            qeSnackbarVisuals?.snackbarType?.containerColor ?: MaterialTheme.colorScheme.inverseSurface
+        val contentColor =
+            qeSnackbarVisuals?.snackbarType?.contentColor ?: MaterialTheme.colorScheme.inverseOnSurface
+        Snackbar(
+            snackbarData = snackbarData,
+            containerColor = containerColor,
+            dismissActionContentColor = contentColor,
+            actionContentColor = contentColor,
+            contentColor = contentColor,
+            actionColor = contentColor,
+        )
+    }
+}
+
+internal suspend fun SnackbarHostState.showQESnackbar(
+    message: String,
+    actionLabel: String? = null,
+    withDismissAction: Boolean = false,
+    snackbarType: SnackbarType = SnackbarType.Info,
+    duration: SnackbarDuration =
+        if (actionLabel == null) SnackbarDuration.Short else SnackbarDuration.Indefinite,
+): SnackbarResult {
+    return showSnackbar(
+        QESnackbarVisuals(
+            message = message,
+            withDismissAction = withDismissAction,
+            actionLabel = actionLabel,
+            duration = duration,
+            snackbarType = snackbarType,
+        ),
+    )
+}
+
+internal val SnackbarType.containerColor: Color
+    @Composable get() = when (this) {
+        SnackbarType.Info -> MaterialTheme.colorScheme.inverseSurface
+        SnackbarType.Error -> MaterialTheme.colorScheme.errorContainer
+    }
+
+internal val SnackbarType.contentColor: Color
+    @Composable get() = when (this) {
+        SnackbarType.Info -> MaterialTheme.colorScheme.inverseOnSurface
+        SnackbarType.Error -> MaterialTheme.colorScheme.onErrorContainer
+    }
+
+internal enum class SnackbarType {
+    Info,
+    Error,
+}

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -7,7 +7,8 @@
     <string name="avatar_picker_title_empty_state">Let’s setup your avatar</string>
     <string name="avatar_picker_description">Choose or upload your favorite avatar images and connect them to your email address.</string>
     <string name="avatar_selected_confirmation">Avatar updated! May take a few minutes to appear everywhere.</string>
-    <string name="avatar_selected_confirmation_action">Got it</string>
+    <string name="avatar_upload_error">Ooops, there was an error uploading the image.</string>
+    <string name="avatar_upload_error_action">Retry</string>
     <string name="avatar_picker_upload_image">Upload image</string>
     <string name="avatar_picker_choose_a_photo">Choose a Photo</string>
     <string name="avatar_picker_take_photo">Take Photo</string>

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
     <string name="avatar_picker_take_photo">Take Photo</string>
     <string name="photo_library_icon_description">Photo library</string>
     <string name="capture_photo_icon_description">Capture Photo</string>
+    <string name="avatar_selection_error">Ooops, there was an error selecting the avatar.</string>
 </resources>

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -239,7 +239,7 @@ class AvatarPickerViewModelTest {
             )
         }
         viewModel.actions.test {
-            expectNoEvents()
+            assertEquals(AvatarPickerAction.AvatarSelectionFailed, awaitItem())
         }
     }
 

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -368,7 +368,9 @@ class AvatarPickerViewModelTest {
                 awaitItem(),
             )
         }
-        verify { fileUtils.deleteFile(uri) }
+        viewModel.actions.test {
+            assertEquals(AvatarPickerAction.AvatarUploadFailed(uri), awaitItem())
+        }
     }
 
     private fun initViewModel() = AvatarPickerViewModel(email, profileService, avatarRepository, fileUtils)


### PR DESCRIPTION
Closes #268

### Description
This PR implements custom snakbard styling for two types: INFO and ERROR.

This is accomplished by creating a `QESnackbarVisuals` and passing it to the custom `QESnackbarHost`.

Additionally, two error snack bars are added: when upload fails and when selecting an avatar fails. 

**Upload failure**
https://github.com/user-attachments/assets/35b4d4c4-41fd-4d8d-8b7f-5ea7d2522c14

**Selection failure**
<img width="677" alt="Screenshot 2024-08-19 at 12 51 39" src="https://github.com/user-attachments/assets/6ed905b5-b50e-4e0f-a706-6f58b785ea3e">

### Testing Steps
**Important Note**: The backend is currently returning the wrong format for the `updated date` field. As a workaround, you can apply this patch to comment that field from the Avatar object.
[Gravatar-Android-13-04-48.patch](https://github.com/user-attachments/files/16455284/Gravatar-Android-13-04-48.patch)

2. Run the DemoApp 
3. Go to Avatar Update tab
4. Tap `Update Avatar` button
5. Follow the steps to log in (if necessary)
6. Upload an avatar (make sure to fake error response with a tool like [HTTP toolkit](https://httptoolkit.com/) or disable the network)
7. Confirm an error snackbar was shown
8. Tap retry (make sure this time the request is not mocked)
9. Confirm the image was uploaded
10. Tap the new avatar to select it (fake the response here so that it fails)
11. Confirm an error snackbar was shown 