### PR TITLE
QuickEditor: Handle Unauthorized error response code

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
@@ -12,4 +12,6 @@ internal sealed class AvatarPickerAction {
     data class LaunchImageCropper(val imageUri: Uri, val tempFile: File) : AvatarPickerAction()
 
     data object AvatarSelectionFailed : AvatarPickerAction()
+
+    data object LoginUser : AvatarPickerAction()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerEvent.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerEvent.kt
@@ -12,5 +12,5 @@ internal sealed class AvatarPickerEvent {
 
     data class ImageCropped(val uri: Uri) : AvatarPickerEvent()
 
-    data object LoginUser : AvatarPickerEvent()
+    data object LoginUserTapped : AvatarPickerEvent()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -46,8 +46,10 @@ internal class AvatarPickerViewModel(
             AvatarPickerEvent.Refresh -> refresh()
             is AvatarPickerEvent.AvatarSelected -> selectAvatar(event.avatar)
             is AvatarPickerEvent.ImageCropped -> uploadAvatar(event.uri)
-            AvatarPickerEvent.LoginUser -> {
-                // todo
+            AvatarPickerEvent.LoginUserTapped -> {
+                viewModelScope.launch {
+                    _actions.send(AvatarPickerAction.LoginUser)
+                }
             }
         }
     }
@@ -233,6 +235,7 @@ private val QuickEditorError.asSectionError: SectionError
         is QuickEditorError.Request -> when (type) {
             ErrorType.SERVER -> SectionError.ServerError
             ErrorType.NETWORK -> SectionError.NoInternetConnection
+            ErrorType.UNAUTHORIZED -> SectionError.InvalidToken
             ErrorType.NOT_FOUND,
             ErrorType.RATE_LIMIT_EXCEEDED,
             ErrorType.TIMEOUT,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -3,7 +3,6 @@ package com.gravatar.quickeditor.ui.editor
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -12,7 +11,6 @@ import com.gravatar.quickeditor.ui.navigation.QuickEditorPage
 import com.gravatar.quickeditor.ui.oauth.OAuthPage
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
 import com.gravatar.quickeditor.ui.splash.SplashPage
-import com.gravatar.types.Email
 
 /**
  * Raw composable component for the Quick Editor.
@@ -59,27 +57,11 @@ internal fun GravatarQuickEditorPage(
             )
         }
         composable(QuickEditorPage.EDITOR.name) {
-            AvatarPicker(gravatarQuickEditorParams.email, onAvatarSelected)
+            AvatarPicker(
+                email = gravatarQuickEditorParams.email,
+                onAvatarSelected = onAvatarSelected,
+                onSessionExpired = { navController.navigate(QuickEditorPage.OAUTH.name) },
+            )
         }
     }
-}
-
-@Preview
-@Composable
-private fun ProfileQuickEditorPagePreview() {
-    val oAuthParams = OAuthParams {
-        clientSecret = "clientSecret"
-        clientId = "clientId"
-        redirectUri = "redirectUri"
-    }
-    val gravatarQuickEditorParams = GravatarQuickEditorParams {
-        appName = "FancyMobileApp"
-        email = Email("email")
-    }
-    GravatarQuickEditorPage(
-        gravatarQuickEditorParams = gravatarQuickEditorParams,
-        oAuthParams = oAuthParams,
-        onAvatarSelected = {},
-        onDismiss = {},
-    )
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -373,6 +373,17 @@ class AvatarPickerViewModelTest {
         }
     }
 
+    @Test
+    fun `given view model when LoginUserTapped then LoginUser action sent`() = runTest {
+        viewModel = initViewModel()
+
+        viewModel.onEvent(AvatarPickerEvent.LoginUserTapped)
+
+        viewModel.actions.test {
+            assertEquals(AvatarPickerAction.LoginUser, awaitItem())
+        }
+    }
+
     private fun initViewModel() = AvatarPickerViewModel(email, profileService, avatarRepository, fileUtils)
 
     private fun createAvatar(id: String) = Avatar {

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -731,6 +731,7 @@ public final class com/gravatar/services/ErrorType : java/lang/Enum {
 	public static final field RATE_LIMIT_EXCEEDED Lcom/gravatar/services/ErrorType;
 	public static final field SERVER Lcom/gravatar/services/ErrorType;
 	public static final field TIMEOUT Lcom/gravatar/services/ErrorType;
+	public static final field UNAUTHORIZED Lcom/gravatar/services/ErrorType;
 	public static final field UNKNOWN Lcom/gravatar/services/ErrorType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/gravatar/services/ErrorType;

--- a/gravatar/src/main/java/com/gravatar/HttpResponseCode.kt
+++ b/gravatar/src/main/java/com/gravatar/HttpResponseCode.kt
@@ -5,6 +5,7 @@ internal object HttpResponseCode {
     const val HTTP_CLIENT_TIMEOUT = 408
     const val HTTP_NOT_FOUND = 404
     const val HTTP_TOO_MANY_REQUESTS = 429
+    const val UNAUTHORIZED = 401
 
     private const val HTTP_INTERNAL_ERROR = 500
     private const val NETWORK_CONNECT_TIMEOUT_ERROR = 599

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -8,6 +8,7 @@ internal fun errorTypeFromHttpCode(code: Int): ErrorType = when (code) {
     HttpResponseCode.HTTP_CLIENT_TIMEOUT -> ErrorType.TIMEOUT
     HttpResponseCode.HTTP_NOT_FOUND -> ErrorType.NOT_FOUND
     HttpResponseCode.HTTP_TOO_MANY_REQUESTS -> ErrorType.RATE_LIMIT_EXCEEDED
+    HttpResponseCode.UNAUTHORIZED -> ErrorType.UNAUTHORIZED
     in HttpResponseCode.SERVER_ERRORS -> ErrorType.SERVER
     else -> ErrorType.UNKNOWN
 }
@@ -39,6 +40,9 @@ public enum class ErrorType {
 
     /** User or hash not found */
     RATE_LIMIT_EXCEEDED,
+
+    /** User not authorized to perform given action **/
+    UNAUTHORIZED,
 
     /** An unknown error occurred */
     UNKNOWN,


### PR DESCRIPTION
Closes #277

### Description

This PR handled the 401 response code from the server when fetching user info. When received the `AvatarPicker` shows an error section with the `Session expired` info and a button to Log in again. Tapping on the button starts the OAuth flow.

<img width="692" alt="Screenshot 2024-08-22 at 09 41 22" src="https://github.com/user-attachments/assets/d590ef23-878d-426d-864e-b7df3b7e84cf">


### Testing Steps
**Important Note**: The backend is currently returning the wrong format for the `updated date` field. As a workaround, you can apply this patch to comment that field from the Avatar object.
[Gravatar-Android-13-04-48.patch](https://github.com/user-attachments/files/16455284/Gravatar-Android-13-04-48.patch)

1. Run the DemoApp 
3. Go to Avatar Update tab
4. Tap `Update Avatar` button
5. Follow the steps to log in (if necessary)
6. Enable request mocking (HTTP toolkit, charles or what ever tool you use)
7. Fake /avatars endpoint to return 401
8. Open the QE
9. Confirm you see the `Session expired` error section
10. Disable request mocking
11. Tap login 
12. Follow the steps 
13. Confirm you see the picker with avatar