### PR TITLE
QuickEditor: Use singleTask launchMode in demo app to support external browsers

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.Gravatar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION


### Description

@mlumeau  found a bug on devices without Chrome installed (or Firefox set as default? not sure). 

The problem was the `launchMode` in the demo app. `singleTop` didn't work when the OAuth flow would be open in a separate browser rather than a custom tab. `singleTask` solves this issue. 

### Testing Steps

@mlumeau  Can you share what is the setup of your device? I'm not sure you can uninstall Chrome so I guess you have a different browser set as default, right? 

1. Logout user
2. Tap `Update Avatar` and follow the OAuth flow
3. Confirm you are back at the QuickEditor
