### PR TITLE
DemoApp: Make it easier to test the QE

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -60,6 +60,10 @@ android {
                 "DEMO_WORDPRESS_REDIRECT_URI",
                 "\"${properties["demo-app.wordpress.oauth.redirectUri"]?.toString() ?: ""}\"",
             )
+            manifestPlaceholders["DEMO_WORDPRESS_REDIRECT_URI_HOST"] =
+                properties["demo-app.wordpress.oauth.redirectUri"]?.toString()?.split("://")?.get(1) ?: ""
+            manifestPlaceholders["DEMO_WORDPRESS_REDIRECT_URI_SCHEME"] =
+                properties["demo-app.wordpress.oauth.redirectUri"]?.toString()?.split("://")?.first() ?: ""
         }
     }
 

--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -32,8 +32,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="authorization-callback"
-                    android:scheme="wp-oauth-test" />
+                    android:host="${DEMO_WORDPRESS_REDIRECT_URI_HOST}"
+                    android:scheme="${DEMO_WORDPRESS_REDIRECT_URI_SCHEME}" />
             </intent-filter>
         </activity>
         <activity
@@ -42,16 +42,16 @@
             android:label="Old good Activity"
             android:theme="@style/Theme.Gravatar"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
+<!--            <intent-filter>-->
+<!--                <action android:name="android.intent.action.VIEW" />-->
 
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
+<!--                <category android:name="android.intent.category.DEFAULT" />-->
+<!--                <category android:name="android.intent.category.BROWSABLE" />-->
 
-                <data
-                    android:host="authorization-callback"
-                    android:scheme="wp-oauth-test" />
-            </intent-filter>
+<!--                <data-->
+<!--                    android:host="${DEMO_WORDPRESS_REDIRECT_URI_HOST}"-->
+<!--                    android:scheme="${DEMO_WORDPRESS_REDIRECT_URI_SCHEME}" />-->
+<!--            </intent-filter>-->
         </activity>
         <provider
             android:name=".DemoFileProvider"

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -76,12 +76,14 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                 avatarUrl = avatarUrl,
             )
             Spacer(modifier = Modifier.height(20.dp))
-            Button(
-                onClick = {
-                    context.startActivity(Intent(context, QuickEditorTestActivity::class.java))
-                },
-            ) {
-                Text(text = "Test with Activity without Compose")
+            if (BuildConfig.DEBUG) {
+                Button(
+                    onClick = {
+                        context.startActivity(Intent(context, QuickEditorTestActivity::class.java))
+                    },
+                ) {
+                    Text(text = "Test with Activity without Compose")
+                }
             }
         }
 

--- a/demo-app/src/main/res/layout/activity_quick_editor_test.xml
+++ b/demo-app/src/main/res/layout/activity_quick_editor_test.xml
@@ -35,4 +35,13 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/profile_container" />
 
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Uncomment intent-filter in the AndroidManifest.xml file to test this Activity"
+        android:layout_margin="30dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION


### Description

We have two activities set up to handle redirecting URLs from the OAuth flow. This PR tries to clean this up a bit by:
1. Configuring the `intent-filter` based on `local.properties` file. The `redirect_uri` can be different for any dev yet we had it harcoded in the AndroidManifest.xml.
2. Commenting the `intent-filter` of the XML activity.
3. Showing the option to launch the XML activity only in DEBUG builds. This is handy for us to test but I don't think we need that if we push the release version to internal testers. 

### Testing Steps

1. Run the demo app and make sure the OAuth works.
2. You can run the release build to test that the button to launch the XML Activity is gone. To do that you need to configure the signing config of the release build. This works as a quick solution `signingConfig = signingConfigs.getByName("debug")`