### PR TITLE
QuickEditor: Avatar picker height 

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -144,7 +144,7 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
             when {
                 uiState.isLoading -> Box(
                     modifier = Modifier
-                        .height(DEFAULT_PAGE_HEIGHT)
+                        .height(loadingSectionHeight)
                         .fillMaxWidth(),
                 ) {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
@@ -169,7 +169,10 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
                         onLocalImageSelected = { onEvent(AvatarPickerEvent.LocalImageSelected(it)) },
                         modifier = Modifier
                             .padding(horizontal = 16.dp)
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .onSizeChanged { size ->
+                                loadingSectionHeight = size.height.pxToDp(context)
+                            },
                     )
             }
             Spacer(modifier = Modifier.height(24.dp))

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -57,7 +57,9 @@ internal class AvatarPickerViewModel(
 
     private fun refresh() {
         fetchAvatars()
-        fetchProfile()
+        if (uiState.value.profile !is ComponentState.Loaded) {
+            fetchProfile()
+        }
     }
 
     private fun selectAvatar(avatar: Avatar) {

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -15,6 +15,7 @@ import com.gravatar.services.Result
 import com.gravatar.types.Email
 import com.gravatar.ui.components.ComponentState
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -382,6 +383,20 @@ class AvatarPickerViewModelTest {
         viewModel.actions.test {
             assertEquals(AvatarPickerAction.InvokeAuthFailed, awaitItem())
         }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `given profile loaded when refresh then fetch profile not called`() = runTest {
+        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
+        coEvery { avatarRepository.getAvatars(email) } returns Result.Failure(QuickEditorError.Unknown)
+        viewModel = initViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEvent(AvatarPickerEvent.Refresh)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { profileService.retrieveCatching(email) }
     }
 
     private fun initViewModel(handleExpiredSession: Boolean = true) =


### PR DESCRIPTION

### Description

It looks like I must have wrongly resolved some merge conflicts and the code that sets the height for the loading composable was removed. 

This PR fixes that in the first commit and additionally improves the refresh by skipping Profile data fetch if the data was loaded properly. 

### Testing Steps

1. Do not apply the patch, the parsing error helps with testing
2. Open the QE
3. Log in
4. See the error
5. Tap "Try again" 
6. Confirm the height of the bottom sheet stayed the same when showing the loading indicator
7. Confirm the profile was not fetched again. The skeleton view shouldn't be shown. 
