### PR TITLE
Downgrade kotlin to 1.9.25

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0" />
+    <option name="version" value="1.9.25" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ import org.jetbrains.dokka.versioning.VersioningPlugin
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.plugin.compose) apply false
     // Ktlint
     alias(libs.plugins.ktlint) apply false
     // Detekt

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -4,7 +4,6 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.plugin.compose)
     // Ktlint
     alias(libs.plugins.ktlint)
     // Detekt
@@ -90,13 +89,8 @@ android {
     buildFeatures {
         compose = true
     }
-    composeCompiler {
-        // Enable 'strong skipping'
-        // https://medium.com/androiddevelopers/jetpack-compose-strong-skipping-mode-explained-cbdb2aa4b900
-        enableStrongSkippingMode.set(true)
-        // Needed for Layout Inspector to be able to see all of the nodes in the component tree:
-        // https://issuetracker.google.com/issues/338842143
-        includeSourceInformation.set(true)
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
     detekt {
         config.setFrom("${project.rootDir}/config/detekt/detekt.yml")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 androidGradlePlugin = "8.5.1"
-kotlin = "2.0.0"
+kotlin = "1.9.25"
 ktlint = "12.1.0"
 detekt = "1.23.4"
 roborazzi = "1.26.0"
@@ -75,7 +75,6 @@ turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine
 
 [plugins]
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-plugin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
     id(libs.plugins.android.library.get().pluginId)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.publish.to.s3)
     // Ktlint
     alias(libs.plugins.ktlint)
@@ -50,10 +49,8 @@ android {
     buildFeatures {
         compose = true
     }
-    composeCompiler {
-        // Needed for Layout Inspector to be able to see all of the nodes in the component tree:
-        // https://issuetracker.google.com/issues/338842143
-        includeSourceInformation.set(true)
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
     tasks.withType<DokkaTaskPartial>().configureEach {
         dokkaSourceSets {

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
     id(libs.plugins.android.library.get().pluginId)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.publish.to.s3)
     // Ktlint
     alias(libs.plugins.ktlint)
@@ -50,10 +49,8 @@ android {
     buildFeatures {
         compose = true
     }
-    composeCompiler {
-        // Needed for Layout Inspector to be able to see all of the nodes in the component tree:
-        // https://issuetracker.google.com/issues/338842143
-        includeSourceInformation.set(true)
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
 
     tasks.withType<DokkaTaskPartial>().configureEach {

--- a/uitestutils/build.gradle.kts
+++ b/uitestutils/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id(libs.plugins.android.library.get().pluginId)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.plugin.compose)
 
     // Ktlint
     alias(libs.plugins.ktlint)
@@ -29,6 +28,9 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
     kotlinOptions {
         jvmTarget = "1.8"


### PR DESCRIPTION
Closes #297 
Closes #183 

### Description

As per the issue description: 

```
This will enforce that version for all library consumers. That might be a big blocker for other apps to use our SDK. Let's go back to the 1.+ version.

The PR to revert - https://github.com/Automattic/Gravatar-SDK-Android/pull/173
```

### Testing Steps

Smoke test the demo app.
