### PR TITLE
Demo app with secrets

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eu
 
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -eu
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_prototype_build

--- a/.configure
+++ b/.configure
@@ -3,7 +3,11 @@
   "branch": "trunk",
   "pinned_hash": "5655cd2466f1192ce01c1200045577412b8a89ba",
   "files_to_copy": [
-
+    {
+      "file": "android/Gravatar-SDK-Android/secrets.properties",
+      "destination": "secrets.properties",
+      "encrypt": true
+    }
   ],
   "file_dependencies": [
 

--- a/.configure
+++ b/.configure
@@ -1,0 +1,11 @@
+{
+  "project_name": "Gravatar-SDK-Android",
+  "branch": "trunk",
+  "pinned_hash": "5655cd2466f1192ce01c1200045577412b8a89ba",
+  "files_to_copy": [
+
+  ],
+  "file_dependencies": [
+
+  ]
+}

--- a/.configure-files/secrets.properties.enc
+++ b/.configure-files/secrets.properties.enc
@@ -1,0 +1,2 @@
+ñy»q›î(,dãÀ·ŽY@œNàƒldÅÆv~áúÿK¾€ü$O4œºL‚@Æ¶<þ»©Bá½œ :­ýÁ˜úöZVS>Ç½”Ú®cÎN(LŸ¤úÞè¾¯¾t‰%l­ÿ¶'–ñ`ƒe[«C[-ÝÜhë½²œAg‹QQE°Ð­ýšjåuqiÆD€‹Ÿ__79÷Y?PÞøìÙ#ÐÛîÉ·‡ô¸Š+ƒˆÉì\—#Â´…•î–³c)Lì„|U1“æ…#dû­
+ Z¾–âH™»’xà^:›<î

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ fastlane/.env
 .cxx
 local.properties
 .kotlin/
+
+secrets.properties

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -10,13 +10,12 @@ plugins {
     alias(libs.plugins.detekt)
 }
 
-fun localProperties(): Properties {
-    val localProperties = Properties()
-    val localPropertiesFile = rootProject.file("secrets.properties")
-    if (localPropertiesFile.exists()) {
-        localProperties.load(FileInputStream(localPropertiesFile))
-    }
-    return localProperties
+fun secretProperties(): Properties {
+    val properties = Properties()
+    rootProject.file("secrets.properties")
+        .takeIf { it.exists() }
+        ?.let { properties.load(FileInputStream(it)) }
+    return properties
 }
 
 android {
@@ -33,7 +32,7 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        localProperties().let { properties ->
+        secretProperties().let { properties ->
             buildConfigField(
                 "String",
                 "DEMO_EMAIL",

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 fun localProperties(): Properties {
     val localProperties = Properties()
-    val localPropertiesFile = rootProject.file("local.properties")
+    val localPropertiesFile = rootProject.file("secrets.properties")
     if (localPropertiesFile.exists()) {
         localProperties.load(FileInputStream(localPropertiesFile))
     }

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -15,6 +15,7 @@ fun secretProperties(): Properties {
     rootProject.file("secrets.properties")
         .takeIf { it.exists() }
         ?.let { properties.load(FileInputStream(it)) }
+        ?: logger.warn("Secret properties file not found. Quick Editor won't work properly.")
     return properties
 }
 


### PR DESCRIPTION
### Description

This PR adds support for `mobile-secrets` in order to provide OAuth secrets for the demo-app prototype build.

### Testing Steps

Install the app from the comment below and verify that Quick Editor works as expected.
