### PR TITLE
Remove Java desugaring requirement

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -78,8 +78,6 @@ android {
         }
     }
     compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -102,8 +100,6 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.desugarJdk)
-
     // Demo App dependencies
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -44,35 +44,6 @@ dependencies {
 }
 ```
 
-### Enable desugaring
-
-The Gravatar SDK uses Java 8 features in it's core module, so you need to [enable desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) in each module depending on the SDK. You can do this by adding the following to your `build.gradle` file:
-
-```groovy
-android {
-    compileOptions {
-        // For AGP 4.1+
-        isCoreLibraryDesugaringEnabled = true
-        // For AGP 4.0
-        // coreLibraryDesugaringEnabled = true
-
-        // Sets Java compatibility to Java 8
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-}
-
-dependencies {
-    // For AGP 7.4+
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
-    // For AGP 7.3
-    // coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.3")
-    // For AGP 4.0 to 7.2
-    // coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.9")
-}
-
-```
-
 ### Store the Gravatar API key in your app
 
 There are many ways to store the Gravatar API key in your app. The best way to do this depends on your app's architecture and requirements and how you're already storing other sensitive information. Make sure to avoid hardcoding the API key in your app's code and make sure to avoid storing it in a public repository.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ openapi = "7.4.0"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
 ktx = "1.13.1"
-desugarJdk = "2.0.4"
 junit = "4.13.2"
 mockk = "1.13.9"
 appcompat = "1.7.0"
@@ -33,7 +32,6 @@ dataStore = "1.1.1-beta03"
 startup = "1.1.1"
 
 [libraries]
-desugarJdk = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdk" }
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 android-material = { group = "com.google.android.material", name = "material", version.ref = "material" }

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -31,8 +31,6 @@ android {
         }
     }
     compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -84,8 +82,6 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.desugarJdk)
-
     implementation(project(":gravatar"))
     implementation(project(":gravatar-ui"))
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -64,7 +64,6 @@ import com.gravatar.ui.components.ComponentState
 import com.yalantis.ucrop.UCrop
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.time.Instant
 
 @Composable
 internal fun AvatarPicker(
@@ -301,7 +300,7 @@ private fun AvatarPickerPreview() {
                             rating = "G"
                             altText = "alt"
                             isCropped = true
-                            updatedDate = Instant.now()
+                            updatedDate = null
                         },
                     ),
                     selectedAvatarId = "1",

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarsSection.kt
@@ -44,7 +44,6 @@ import com.gravatar.quickeditor.ui.avatarpicker.AvatarUi
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarsSectionUiState
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.ui.GravatarTheme
-import java.time.Instant
 
 @Composable
 internal fun AvatarsSection(
@@ -186,7 +185,7 @@ private fun AvatarSectionPreview() {
                             rating = "G"
                             altText = "alt"
                             isCropped = true
-                            updatedDate = Instant.now()
+                            updatedDate = null
                         },
                         isSelected = true,
                         isLoading = false,

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -23,7 +23,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
-import java.time.Instant
 
 class AvatarRepositoryTest {
     private val testDispatcher = StandardTestDispatcher()
@@ -181,7 +180,7 @@ class AvatarRepositoryTest {
         rating = "G"
         altText = "alt"
         isCropped = true
-        updatedDate = Instant.now()
+        updatedDate = ""
     }
 
     private fun createIdentity(imageIdentifier: String) = Identity {

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerTest.kt
@@ -9,7 +9,6 @@ import com.gravatar.ui.components.ComponentState
 import com.gravatar.uitestutils.RoborazziTest
 import org.junit.Test
 import org.robolectric.annotation.Config
-import java.time.Instant
 
 class AvatarPickerTest : RoborazziTest() {
     private val profile = defaultProfile(
@@ -33,7 +32,7 @@ class AvatarPickerTest : RoborazziTest() {
                             rating = "G"
                             altText = "alt"
                             isCropped = true
-                            updatedDate = Instant.now()
+                            updatedDate = ""
                         },
                         Avatar {
                             imageUrl = "/image/url2"
@@ -42,7 +41,7 @@ class AvatarPickerTest : RoborazziTest() {
                             rating = "G"
                             altText = "alt"
                             isCropped = true
-                            updatedDate = Instant.now()
+                            updatedDate = ""
                         },
                     ),
                     selectedAvatarId = "1",
@@ -68,7 +67,7 @@ class AvatarPickerTest : RoborazziTest() {
                             rating = "G"
                             altText = "alt"
                             isCropped = true
-                            updatedDate = Instant.now()
+                            updatedDate = ""
                         },
                         Avatar {
                             imageUrl = "/image/url2"
@@ -77,7 +76,7 @@ class AvatarPickerTest : RoborazziTest() {
                             rating = "G"
                             altText = "alt"
                             isCropped = true
-                            updatedDate = Instant.now()
+                            updatedDate = ""
                         },
                     ),
                     selectedAvatarId = "1",

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -28,7 +28,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
-import java.time.Instant
 
 class AvatarPickerViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
@@ -409,6 +408,6 @@ class AvatarPickerViewModelTest {
         rating = "G"
         altText = "alt"
         isCropped = true
-        updatedDate = Instant.now()
+        updatedDate = ""
     }
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/AvatarsSectionTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/AvatarsSectionTest.kt
@@ -7,7 +7,6 @@ import com.gravatar.restapi.models.Avatar
 import com.gravatar.uitestutils.RoborazziTest
 import org.junit.Test
 import org.robolectric.annotation.Config
-import java.time.Instant
 
 class AvatarsSectionTest : RoborazziTest() {
     @Test
@@ -73,7 +72,7 @@ private val avatars = listOf(
             rating = "G"
             altText = "alt"
             isCropped = true
-            updatedDate = Instant.now()
+            updatedDate = ""
         },
         isLoading = false,
         isSelected = true,
@@ -86,7 +85,7 @@ private val avatars = listOf(
             rating = "G"
             altText = "alt"
             isCropped = true
-            updatedDate = Instant.now()
+            updatedDate = ""
         },
         isLoading = false,
         isSelected = true,

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -31,8 +31,6 @@ android {
         }
     }
     compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -84,8 +82,6 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.desugarJdk)
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.android.material)

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -145,22 +145,22 @@ public final class com/gravatar/ProfileUrl {
 public final class com/gravatar/extensions/UserProfileExtensionsKt {
 	public static final fun avatarUrl (Lcom/gravatar/restapi/models/Profile;Lcom/gravatar/AvatarQueryOptions;)Lcom/gravatar/AvatarUrl;
 	public static synthetic fun avatarUrl$default (Lcom/gravatar/restapi/models/Profile;Lcom/gravatar/AvatarQueryOptions;ILjava/lang/Object;)Lcom/gravatar/AvatarUrl;
-	public static final fun defaultProfile (Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/gravatar/restapi/models/ProfilePayments;Lcom/gravatar/restapi/models/ProfileContactInfo;Ljava/util/List;Ljava/lang/Integer;Ljava/time/Instant;Ljava/time/Instant;)Lcom/gravatar/restapi/models/Profile;
-	public static synthetic fun defaultProfile$default (Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/gravatar/restapi/models/ProfilePayments;Lcom/gravatar/restapi/models/ProfileContactInfo;Ljava/util/List;Ljava/lang/Integer;Ljava/time/Instant;Ljava/time/Instant;ILjava/lang/Object;)Lcom/gravatar/restapi/models/Profile;
+	public static final fun defaultProfile (Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/gravatar/restapi/models/ProfilePayments;Lcom/gravatar/restapi/models/ProfileContactInfo;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lcom/gravatar/restapi/models/Profile;
+	public static synthetic fun defaultProfile$default (Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/gravatar/restapi/models/ProfilePayments;Lcom/gravatar/restapi/models/ProfileContactInfo;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/gravatar/restapi/models/Profile;
 	public static final fun formattedUserInfo (Lcom/gravatar/restapi/models/Profile;)Ljava/lang/String;
 	public static final fun hash (Lcom/gravatar/restapi/models/Profile;)Lcom/gravatar/types/Hash;
 	public static final fun profileUrl (Lcom/gravatar/restapi/models/Profile;)Lcom/gravatar/ProfileUrl;
 }
 
 public final class com/gravatar/restapi/models/Avatar {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILjava/lang/String;Ljava/time/Instant;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAltText ()Ljava/lang/String;
 	public final fun getFormat ()I
 	public final fun getImageId ()Ljava/lang/String;
 	public final fun getImageUrl ()Ljava/lang/String;
 	public final fun getRating ()Ljava/lang/String;
-	public final fun getUpdatedDate ()Ljava/time/Instant;
+	public final fun getUpdatedDate ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isCropped ()Z
 	public fun toString ()Ljava/lang/String;
@@ -174,7 +174,7 @@ public final class com/gravatar/restapi/models/Avatar$Builder {
 	public final fun getImageId ()Ljava/lang/String;
 	public final fun getImageUrl ()Ljava/lang/String;
 	public final fun getRating ()Ljava/lang/String;
-	public final fun getUpdatedDate ()Ljava/time/Instant;
+	public final fun getUpdatedDate ()Ljava/lang/String;
 	public final fun isCropped ()Ljava/lang/Boolean;
 	public final fun setAltText (Ljava/lang/String;)Lcom/gravatar/restapi/models/Avatar$Builder;
 	public final synthetic fun setAltText (Ljava/lang/String;)V
@@ -188,8 +188,8 @@ public final class com/gravatar/restapi/models/Avatar$Builder {
 	public final fun setIsCropped (Ljava/lang/Boolean;)Lcom/gravatar/restapi/models/Avatar$Builder;
 	public final fun setRating (Ljava/lang/String;)Lcom/gravatar/restapi/models/Avatar$Builder;
 	public final synthetic fun setRating (Ljava/lang/String;)V
-	public final fun setUpdatedDate (Ljava/time/Instant;)Lcom/gravatar/restapi/models/Avatar$Builder;
-	public final synthetic fun setUpdatedDate (Ljava/time/Instant;)V
+	public final fun setUpdatedDate (Ljava/lang/String;)Lcom/gravatar/restapi/models/Avatar$Builder;
+	public final synthetic fun setUpdatedDate (Ljava/lang/String;)V
 }
 
 public final class com/gravatar/restapi/models/AvatarKt {
@@ -337,7 +337,7 @@ public final class com/gravatar/restapi/models/LinkKt {
 }
 
 public final class com/gravatar/restapi/models/Profile {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Lcom/gravatar/restapi/models/ProfilePayments;Lcom/gravatar/restapi/models/ProfileContactInfo;Ljava/util/List;Ljava/lang/Integer;Ljava/time/Instant;Ljava/time/Instant;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Lcom/gravatar/restapi/models/ProfilePayments;Lcom/gravatar/restapi/models/ProfileContactInfo;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarAltText ()Ljava/lang/String;
 	public final fun getAvatarUrl ()Ljava/net/URI;
@@ -352,7 +352,7 @@ public final class com/gravatar/restapi/models/Profile {
 	public final fun getJobTitle ()Ljava/lang/String;
 	public final fun getLanguages ()Ljava/util/List;
 	public final fun getLastName ()Ljava/lang/String;
-	public final fun getLastProfileEdit ()Ljava/time/Instant;
+	public final fun getLastProfileEdit ()Ljava/lang/String;
 	public final fun getLinks ()Ljava/util/List;
 	public final fun getLocation ()Ljava/lang/String;
 	public final fun getNumberVerifiedAccounts ()Ljava/lang/Integer;
@@ -360,7 +360,7 @@ public final class com/gravatar/restapi/models/Profile {
 	public final fun getProfileUrl ()Ljava/net/URI;
 	public final fun getPronouns ()Ljava/lang/String;
 	public final fun getPronunciation ()Ljava/lang/String;
-	public final fun getRegistrationDate ()Ljava/time/Instant;
+	public final fun getRegistrationDate ()Ljava/lang/String;
 	public final fun getTimezone ()Ljava/lang/String;
 	public final fun getVerifiedAccounts ()Ljava/util/List;
 	public fun hashCode ()I
@@ -384,7 +384,7 @@ public final class com/gravatar/restapi/models/Profile$Builder {
 	public final fun getJobTitle ()Ljava/lang/String;
 	public final fun getLanguages ()Ljava/util/List;
 	public final fun getLastName ()Ljava/lang/String;
-	public final fun getLastProfileEdit ()Ljava/time/Instant;
+	public final fun getLastProfileEdit ()Ljava/lang/String;
 	public final fun getLinks ()Ljava/util/List;
 	public final fun getLocation ()Ljava/lang/String;
 	public final fun getNumberVerifiedAccounts ()Ljava/lang/Integer;
@@ -392,7 +392,7 @@ public final class com/gravatar/restapi/models/Profile$Builder {
 	public final fun getProfileUrl ()Ljava/net/URI;
 	public final fun getPronouns ()Ljava/lang/String;
 	public final fun getPronunciation ()Ljava/lang/String;
-	public final fun getRegistrationDate ()Ljava/time/Instant;
+	public final fun getRegistrationDate ()Ljava/lang/String;
 	public final fun getTimezone ()Ljava/lang/String;
 	public final fun getVerifiedAccounts ()Ljava/util/List;
 	public final fun isOrganization ()Ljava/lang/Boolean;
@@ -423,8 +423,8 @@ public final class com/gravatar/restapi/models/Profile$Builder {
 	public final synthetic fun setLanguages (Ljava/util/List;)V
 	public final fun setLastName (Ljava/lang/String;)Lcom/gravatar/restapi/models/Profile$Builder;
 	public final synthetic fun setLastName (Ljava/lang/String;)V
-	public final fun setLastProfileEdit (Ljava/time/Instant;)Lcom/gravatar/restapi/models/Profile$Builder;
-	public final synthetic fun setLastProfileEdit (Ljava/time/Instant;)V
+	public final fun setLastProfileEdit (Ljava/lang/String;)Lcom/gravatar/restapi/models/Profile$Builder;
+	public final synthetic fun setLastProfileEdit (Ljava/lang/String;)V
 	public final fun setLinks (Ljava/util/List;)Lcom/gravatar/restapi/models/Profile$Builder;
 	public final synthetic fun setLinks (Ljava/util/List;)V
 	public final fun setLocation (Ljava/lang/String;)Lcom/gravatar/restapi/models/Profile$Builder;
@@ -440,8 +440,8 @@ public final class com/gravatar/restapi/models/Profile$Builder {
 	public final synthetic fun setPronouns (Ljava/lang/String;)V
 	public final fun setPronunciation (Ljava/lang/String;)Lcom/gravatar/restapi/models/Profile$Builder;
 	public final synthetic fun setPronunciation (Ljava/lang/String;)V
-	public final fun setRegistrationDate (Ljava/time/Instant;)Lcom/gravatar/restapi/models/Profile$Builder;
-	public final synthetic fun setRegistrationDate (Ljava/time/Instant;)V
+	public final fun setRegistrationDate (Ljava/lang/String;)Lcom/gravatar/restapi/models/Profile$Builder;
+	public final synthetic fun setRegistrationDate (Ljava/lang/String;)V
 	public final fun setTimezone (Ljava/lang/String;)Lcom/gravatar/restapi/models/Profile$Builder;
 	public final synthetic fun setTimezone (Ljava/lang/String;)V
 	public final fun setVerifiedAccounts (Ljava/util/List;)Lcom/gravatar/restapi/models/Profile$Builder;

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -113,13 +113,13 @@ openApiGenerate {
     )
     importMappings.set(
         mapOf(
-            "DateTime" to "java.time.Instant",
+            "DateTime" to "String",
         ),
     )
 
     typeMappings.set(
         mapOf(
-            "DateTime" to "java.time.Instant",
+            "DateTime" to "String",
         ),
     )
 

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -33,8 +33,6 @@ android {
         }
     }
     compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -70,8 +68,6 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.desugarJdk)
-
     api(libs.okhttp)
     implementation(libs.retrofit)
     implementation(libs.retrofit.gson.converter)

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -1,9 +1,6 @@
 package com.gravatar.di.container
 
 import com.google.gson.GsonBuilder
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V1
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V3
 import com.gravatar.services.AuthenticationInterceptor
@@ -14,8 +11,6 @@ import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import java.lang.reflect.Type
-import java.time.Instant
 
 internal class GravatarSdkContainer private constructor() {
     companion object {
@@ -29,12 +24,6 @@ internal class GravatarSdkContainer private constructor() {
     private fun getRetrofitApiV3Builder() = Retrofit.Builder().baseUrl(GRAVATAR_API_BASE_URL_V3)
 
     private val gson = GsonBuilder().setLenient()
-        .registerTypeAdapter(
-            Instant::class.java,
-            JsonDeserializer { json: JsonElement, _: Type, _: JsonDeserializationContext ->
-                Instant.parse(json.asString) // Parses date-time strings as ISO 8601 - "2021-08-31T00:00:00Z"
-            },
-        )
         .create()
 
     val dispatcherMain: CoroutineDispatcher = Dispatchers.Main

--- a/gravatar/src/main/java/com/gravatar/extensions/UserProfileExtensions.kt
+++ b/gravatar/src/main/java/com/gravatar/extensions/UserProfileExtensions.kt
@@ -11,7 +11,6 @@ import com.gravatar.restapi.models.ProfilePayments
 import com.gravatar.restapi.models.VerifiedAccount
 import com.gravatar.types.Hash
 import java.net.URI
-import java.time.Instant
 
 /**
  * Get the hash for a user profile.
@@ -67,8 +66,8 @@ public fun defaultProfile(
     contactInfo: ProfileContactInfo? = null,
     gallery: List<GalleryImage>? = null,
     numberVerifiedAccounts: Int? = null,
-    lastProfileEdit: Instant? = null,
-    registrationDate: Instant? = null,
+    lastProfileEdit: String? = null,
+    registrationDate: String? = null,
 ): Profile = Profile {
     this.hash = hash
     this.displayName = displayName

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Avatar.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Avatar.kt
@@ -40,7 +40,7 @@ public class Avatar private constructor(
     public val rating: kotlin.String,
     // Date and time when the image was last updated.
     @SerializedName("updated_date")
-    public val updatedDate: java.time.Instant,
+    public val updatedDate: String,
     // Alternative text description of the image.
     @SerializedName("altText")
     public val altText: kotlin.String,
@@ -81,7 +81,7 @@ public class Avatar private constructor(
 
         // Date and time when the image was last updated.
         @set:JvmSynthetic // Hide 'void' setter from Java
-        public var updatedDate: java.time.Instant? = null
+        public var updatedDate: String? = null
 
         // Alternative text description of the image.
         @set:JvmSynthetic // Hide 'void' setter from Java
@@ -97,7 +97,7 @@ public class Avatar private constructor(
 
         public fun setRating(rating: kotlin.String?): Builder = apply { this.rating = rating }
 
-        public fun setUpdatedDate(updatedDate: java.time.Instant?): Builder = apply { this.updatedDate = updatedDate }
+        public fun setUpdatedDate(updatedDate: String?): Builder = apply { this.updatedDate = updatedDate }
 
         public fun setAltText(altText: kotlin.String?): Builder = apply { this.altText = altText }
 

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Profile.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Profile.kt
@@ -110,10 +110,10 @@ public class Profile private constructor(
     public val numberVerifiedAccounts: kotlin.Int? = null,
     // The date and time (UTC) the user last edited their profile. This is only provided in authenticated API requests.
     @SerializedName("last_profile_edit")
-    public val lastProfileEdit: java.time.Instant? = null,
+    public val lastProfileEdit: String? = null,
     // The date the user registered their account. This is only provided in authenticated API requests.
     @SerializedName("registration_date")
-    public val registrationDate: java.time.Instant? = null,
+    public val registrationDate: String? = null,
 ) {
     override fun toString(): String = "Profile(hash=$hash, displayName=$displayName, profileUrl=$profileUrl, avatarUrl=$avatarUrl, avatarAltText=$avatarAltText, location=$location, description=$description, jobTitle=$jobTitle, company=$company, verifiedAccounts=$verifiedAccounts, pronunciation=$pronunciation, pronouns=$pronouns, timezone=$timezone, languages=$languages, firstName=$firstName, lastName=$lastName, isOrganization=$isOrganization, links=$links, interests=$interests, payments=$payments, contactInfo=$contactInfo, gallery=$gallery, numberVerifiedAccounts=$numberVerifiedAccounts, lastProfileEdit=$lastProfileEdit, registrationDate=$registrationDate)"
 
@@ -239,11 +239,11 @@ public class Profile private constructor(
 
         // The date and time (UTC) the user last edited their profile. This is only provided in authenticated API requests.
         @set:JvmSynthetic // Hide 'void' setter from Java
-        public var lastProfileEdit: java.time.Instant? = null
+        public var lastProfileEdit: String? = null
 
         // The date the user registered their account. This is only provided in authenticated API requests.
         @set:JvmSynthetic // Hide 'void' setter from Java
-        public var registrationDate: java.time.Instant? = null
+        public var registrationDate: String? = null
 
         public fun setHash(hash: kotlin.String?): Builder = apply { this.hash = hash }
 
@@ -291,9 +291,9 @@ public class Profile private constructor(
 
         public fun setNumberVerifiedAccounts(numberVerifiedAccounts: kotlin.Int?): Builder = apply { this.numberVerifiedAccounts = numberVerifiedAccounts }
 
-        public fun setLastProfileEdit(lastProfileEdit: java.time.Instant?): Builder = apply { this.lastProfileEdit = lastProfileEdit }
+        public fun setLastProfileEdit(lastProfileEdit: String?): Builder = apply { this.lastProfileEdit = lastProfileEdit }
 
-        public fun setRegistrationDate(registrationDate: java.time.Instant?): Builder = apply { this.registrationDate = registrationDate }
+        public fun setRegistrationDate(registrationDate: String?): Builder = apply { this.registrationDate = registrationDate }
 
         public fun build(): Profile = Profile(hash!!, displayName!!, profileUrl!!, avatarUrl!!, avatarAltText!!, location!!, description!!, jobTitle!!, company!!, verifiedAccounts!!, pronunciation!!, pronouns!!, timezone, languages, firstName, lastName, isOrganization, links, interests, payments, contactInfo, gallery, numberVerifiedAccounts, lastProfileEdit, registrationDate)
     }


### PR DESCRIPTION
Closes #295 

### Description

We shouldn't force third-party devs to enable desugaring and we shouldn't force them to use particular `java.time`  as they might want to use something else. 

This PR removes the `java.time` classes from the generated API models and the desugaring. 

### Testing Steps
