### PR TITLE
Do not use data class for AvatarQueryOptions

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -371,16 +371,16 @@ private fun AvatarTab(
                         onGravatarUrlChanged(
                             AvatarUrl(
                                 Email(settingsState.email),
-                                AvatarQueryOptions(
-                                    preferredSize = settingsState.size,
+                                AvatarQueryOptions {
+                                    preferredSize = settingsState.size
                                     defaultAvatarOption = if (settingsState.defaultAvatarImageEnabled) {
                                         settingsState.selectedDefaultAvatar
                                     } else {
                                         null
-                                    },
-                                    forceDefaultAvatar = if (settingsState.forceDefaultAvatar) true else null,
-                                    rating = if (settingsState.imageRatingEnabled) settingsState.imageRating else null,
-                                ),
+                                    }
+                                    forceDefaultAvatar = if (settingsState.forceDefaultAvatar) true else null
+                                    rating = if (settingsState.imageRatingEnabled) settingsState.imageRating else null
+                                },
                             ).url().toString(),
                         )
                     } catch (e: Exception) {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -35,13 +35,16 @@ public fun Avatar(
     modifier: Modifier = Modifier,
     avatarQueryOptions: AvatarQueryOptions? = null,
 ) {
-    val preferredSize = with(LocalDensity.current) { size.roundToPx() }
+    val sizePx = with(LocalDensity.current) { size.roundToPx() }
     Avatar(
         model = profile.avatarUrl(
             // Override the preferredSize
-            avatarQueryOptions?.copy(
-                preferredSize = preferredSize,
-            ) ?: AvatarQueryOptions(preferredSize = preferredSize),
+            AvatarQueryOptions {
+                preferredSize = sizePx
+                rating = avatarQueryOptions?.rating
+                forceDefaultAvatar = avatarQueryOptions?.forceDefaultAvatar
+                defaultAvatarOption = avatarQueryOptions?.defaultAvatarOption
+            },
         ).url().toString(),
         size = size,
         modifier = modifier,

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -1,13 +1,5 @@
 public final class com/gravatar/AvatarQueryOptions {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Integer;Lcom/gravatar/DefaultAvatarOption;Lcom/gravatar/ImageRating;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/Integer;Lcom/gravatar/DefaultAvatarOption;Lcom/gravatar/ImageRating;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Integer;
-	public final fun component2 ()Lcom/gravatar/DefaultAvatarOption;
-	public final fun component3 ()Lcom/gravatar/ImageRating;
-	public final fun component4 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/Integer;Lcom/gravatar/DefaultAvatarOption;Lcom/gravatar/ImageRating;Ljava/lang/Boolean;)Lcom/gravatar/AvatarQueryOptions;
-	public static synthetic fun copy$default (Lcom/gravatar/AvatarQueryOptions;Ljava/lang/Integer;Lcom/gravatar/DefaultAvatarOption;Lcom/gravatar/ImageRating;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/gravatar/AvatarQueryOptions;
+	public synthetic fun <init> (Ljava/lang/Integer;Lcom/gravatar/DefaultAvatarOption;Lcom/gravatar/ImageRating;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefaultAvatarOption ()Lcom/gravatar/DefaultAvatarOption;
 	public final fun getForceDefaultAvatar ()Ljava/lang/Boolean;
@@ -15,6 +7,27 @@ public final class com/gravatar/AvatarQueryOptions {
 	public final fun getRating ()Lcom/gravatar/ImageRating;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/AvatarQueryOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lcom/gravatar/AvatarQueryOptions;
+	public final fun getDefaultAvatarOption ()Lcom/gravatar/DefaultAvatarOption;
+	public final fun getForceDefaultAvatar ()Ljava/lang/Boolean;
+	public final fun getPreferredSize ()Ljava/lang/Integer;
+	public final fun getRating ()Lcom/gravatar/ImageRating;
+	public final fun setDefaultAvatarOption (Lcom/gravatar/DefaultAvatarOption;)Lcom/gravatar/AvatarQueryOptions$Builder;
+	public final synthetic fun setDefaultAvatarOption (Lcom/gravatar/DefaultAvatarOption;)V
+	public final fun setForceDefaultAvatar (Ljava/lang/Boolean;)Lcom/gravatar/AvatarQueryOptions$Builder;
+	public final synthetic fun setForceDefaultAvatar (Ljava/lang/Boolean;)V
+	public final fun setPreferredSize (Ljava/lang/Integer;)Lcom/gravatar/AvatarQueryOptions$Builder;
+	public final synthetic fun setPreferredSize (Ljava/lang/Integer;)V
+	public final fun setRating (Lcom/gravatar/ImageRating;)Lcom/gravatar/AvatarQueryOptions$Builder;
+	public final synthetic fun setRating (Lcom/gravatar/ImageRating;)V
+}
+
+public final class com/gravatar/AvatarQueryOptionsKt {
+	public static final synthetic fun AvatarQueryOptions (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/AvatarQueryOptions;
 }
 
 public final class com/gravatar/AvatarUrl {

--- a/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
@@ -1,16 +1,107 @@
 package com.gravatar
 
+import java.util.Objects
+
 /**
- * Data class that represents the query options for an avatar.
+ * Class that represents the query options for an avatar.
  *
  * @property preferredSize Size of the avatar, must be between 1 and 2048. Optional: default to 80
  * @property defaultAvatarOption Default avatar image. Optional: default to Gravatar logo
  * @property rating Image rating. Optional: default to General, suitable for display on all websites with any audience
  * @property forceDefaultAvatar Force default avatar image. Optional: default to false
  */
-public data class AvatarQueryOptions(
+public class AvatarQueryOptions private constructor(
     public val preferredSize: Int? = null,
     public val defaultAvatarOption: DefaultAvatarOption? = null,
     public val rating: ImageRating? = null,
     public val forceDefaultAvatar: Boolean? = null,
-)
+) {
+    override fun hashCode(): Int {
+        return Objects.hash(
+            preferredSize,
+            defaultAvatarOption,
+            rating,
+            forceDefaultAvatar,
+        )
+    }
+
+    override fun toString(): String {
+        return "AvatarQueryOptions(preferredSize=$preferredSize, defaultAvatarOption=$defaultAvatarOption, " +
+            "rating=$rating, forceDefaultAvatar=$forceDefaultAvatar)"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is AvatarQueryOptions && other.preferredSize == preferredSize &&
+            other.defaultAvatarOption == defaultAvatarOption && other.rating == rating &&
+            other.forceDefaultAvatar == forceDefaultAvatar
+    }
+
+    /**
+     * Builder for [AvatarQueryOptions].
+     */
+    public class Builder {
+        /**
+         * Size of the avatar, must be between 1 and 2048. Optional: default to 80
+         */
+        @set:JvmSynthetic // Hide 'void' setter from Java
+        public var preferredSize: Int? = null
+
+        /**
+         * Default avatar image. Optional: default to Gravatar logo
+         */
+        @set:JvmSynthetic
+        public var defaultAvatarOption: DefaultAvatarOption? = null
+
+        /**
+         * Image rating. Optional: default to General, suitable for display on all websites with any audience
+         */
+        @set:JvmSynthetic
+        public var rating: ImageRating? = null
+
+        /**
+         * Force default avatar image. Optional: default to false
+         */
+        @set:JvmSynthetic
+        public var forceDefaultAvatar: Boolean? = null
+
+        /**
+         * Set the size of the avatar.
+         */
+        public fun setPreferredSize(preferredSize: Int?): Builder = apply { this.preferredSize = preferredSize }
+
+        /**
+         * Set the default avatar image.
+         */
+        public fun setDefaultAvatarOption(defaultAvatarOption: DefaultAvatarOption?): Builder =
+            apply { this.defaultAvatarOption = defaultAvatarOption }
+
+        /**
+         * Set the image rating.
+         */
+        public fun setRating(rating: ImageRating?): Builder = apply { this.rating = rating }
+
+        /**
+         * Set whether to force the default avatar image.
+         */
+        public fun setForceDefaultAvatar(forceDefaultAvatar: Boolean?): Builder =
+            apply { this.forceDefaultAvatar = forceDefaultAvatar }
+
+        /**
+         * Builds the [AvatarQueryOptions] instance.
+         */
+        public fun build(): AvatarQueryOptions = AvatarQueryOptions(
+            preferredSize = preferredSize,
+            defaultAvatarOption = defaultAvatarOption,
+            rating = rating,
+            forceDefaultAvatar = forceDefaultAvatar,
+        )
+    }
+}
+
+/**
+ * Creates a new [AvatarQueryOptions] instance.
+ */
+@JvmSynthetic // Hide from Java callers who should use Builder.
+public fun AvatarQueryOptions(initializer: AvatarQueryOptions.Builder.() -> Unit): AvatarQueryOptions {
+    return AvatarQueryOptions.Builder().apply(initializer).build()
+}

--- a/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
+++ b/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
@@ -27,7 +27,10 @@ class AvatarUrlTest {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
                 "?s=1000",
-            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(preferredSize = 1000)).url().toString(),
+            AvatarUrl(
+                Email("example@example.com"),
+                AvatarQueryOptions { preferredSize = 1000 },
+            ).url().toString(),
         )
     }
 
@@ -38,7 +41,7 @@ class AvatarUrlTest {
                 "?d=monsterid",
             AvatarUrl(
                 Email("example@example.com"),
-                AvatarQueryOptions(defaultAvatarOption = MonsterId),
+                AvatarQueryOptions { defaultAvatarOption = MonsterId },
             ).url().toString(),
         )
     }
@@ -50,7 +53,13 @@ class AvatarUrlTest {
                 "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                     "970a1e66?d=identicon&s=42",
             ),
-            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(42, Identicon)).url(),
+            AvatarUrl(
+                Email("example@example.com"),
+                AvatarQueryOptions {
+                    preferredSize = 42
+                    defaultAvatarOption = Identicon
+                },
+            ).url(),
         )
     }
 
@@ -61,7 +70,15 @@ class AvatarUrlTest {
                 "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                     "970a1e66?d=robohash&s=42&r=x&f=y",
             ),
-            AvatarUrl(Email("example@example.com"), AvatarQueryOptions(42, RoboHash, X, true)).url(),
+            AvatarUrl(
+                Email("example@example.com"),
+                AvatarQueryOptions {
+                    preferredSize = 42
+                    defaultAvatarOption = RoboHash
+                    rating = X
+                    forceDefaultAvatar = true
+                },
+            ).url(),
         )
     }
 
@@ -88,12 +105,12 @@ class AvatarUrlTest {
                     "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66",
                 ),
-                AvatarQueryOptions(
-                    42,
-                    Identicon,
-                    ParentalGuidance,
-                    true,
-                ),
+                AvatarQueryOptions {
+                    preferredSize = 42
+                    defaultAvatarOption = Identicon
+                    rating = ParentalGuidance
+                    forceDefaultAvatar = true
+                },
             ).url().toString(),
         )
     }
@@ -134,7 +151,10 @@ class AvatarUrlTest {
                     "https://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66?d=identicon&s=42",
                 ),
-                AvatarQueryOptions(42, Identicon),
+                AvatarQueryOptions {
+                    preferredSize = 42
+                    defaultAvatarOption = Identicon
+                },
             ).url().toString(),
         )
     }
@@ -149,7 +169,10 @@ class AvatarUrlTest {
                     "https://1.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
                         "970a1e66?d=identicon&s=42",
                 ),
-                AvatarQueryOptions(42, Identicon),
+                AvatarQueryOptions {
+                    preferredSize = 42
+                    defaultAvatarOption = Identicon
+                },
             ).url().toString(),
         )
     }
@@ -239,9 +262,9 @@ class AvatarUrlTest {
                 "?d=https%3A%2F%2Fexample.com%2F%3Fencoded%3Dtrue%26please%3Dyes",
             AvatarUrl(
                 Email("example@example.com"),
-                AvatarQueryOptions(
-                    defaultAvatarOption = CustomUrl("https://example.com/?encoded=true&please=yes"),
-                ),
+                AvatarQueryOptions {
+                    defaultAvatarOption = CustomUrl("https://example.com/?encoded=true&please=yes")
+                },
             ).url().toString(),
         )
     }
@@ -253,7 +276,9 @@ class AvatarUrlTest {
                 "?f=n",
             AvatarUrl(
                 Email("example@example.com"),
-                AvatarQueryOptions(forceDefaultAvatar = false),
+                AvatarQueryOptions {
+                    forceDefaultAvatar = false
+                },
             ).url().toString(),
         )
     }


### PR DESCRIPTION
Closes #302 

### Description

Using a `data class` in a public-facing API is problematic because we can't add more properties without introducing breaking changes. 

I'm changing the `AvatarQueryOptions` following the same patterns we used for API models. 

### Testing Steps
Run the demo app and test Avatar fetching.
