### PR TITLE
QuickEditor: Compose performance

### DIFF
--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -1,0 +1,11 @@
+// Consider All :gravatar model&types classes stable
+com.gravatar.restapi.models.*
+com.gravatar.types.*
+
+kotlin.collections.*
+
+java.net.URL
+
+android.net.Uri
+
+com.gravatar.ui.components.ComponentState<*>

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -146,12 +146,16 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                 email = Email(userEmail)
             },
             authenticationMethod = authenticationMethod,
-            onAvatarSelected = { result ->
-                avatarUrl = result.avatarUri.toString()
+            onAvatarSelected = remember {
+                { result ->
+                    avatarUrl = result.avatarUri.toString()
+                }
             },
-            onDismiss = {
-                Toast.makeText(context, it.toString(), Toast.LENGTH_SHORT).show()
-                showBottomSheet = false
+            onDismiss = remember {
+                {
+                    Toast.makeText(context, it.toString(), Toast.LENGTH_SHORT).show()
+                    showBottomSheet = false
+                }
             },
         )
     }

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -36,6 +36,22 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        val composeReportsDir = "compose_reports"
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
+                "${project.rootDir}/compose_compiler_config.conf",
+        )
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
+        )
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
+        )
     }
     detekt {
         config.setFrom("${project.rootDir}/config/detekt/detekt.yml")

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
-        val composeReportsDir = "compose_reports"
+        val composeReportsDir = "reports/compose"
         freeCompilerArgs += listOf(
             "-P",
             "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -36,6 +36,22 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        val composeReportsDir = "compose_reports"
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
+                "${project.rootDir}/compose_compiler_config.conf",
+        )
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
+        )
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
+        )
     }
     detekt {
         config.setFrom("${project.rootDir}/config/detekt/detekt.yml")

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
-        val composeReportsDir = "compose_reports"
+        val composeReportsDir = "reports/compose"
         freeCompilerArgs += listOf(
             "-P",
             "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +


### PR DESCRIPTION
Closes #283

### Description

I've noticed we had more recompositions happening than necessary. The whole Comopse performance is quite complicated - there're a few blog posts about this, for example [this one](https://multithreaded.stitchfix.com/blog/2022/08/05/jetpack-compose-recomposition/).

**Lamda passed as params that by default are not stable.**

This was a problem only specifically in the Demo app, but I think it's still worth having it as documentation for other devs. 
Inside the QuickEditor module, we are using function refs, so we don't have a problem there.

The solution is simple - remember the lambda. Not a nice one though...

**Classes from external modules used as Composable params**

This is a problem even with the `:gravatar-ui` module. All our components rely on the models from the `:gravatar` module, so they are unstable. To solve this we can add a special configuration that marks certain classes as `Stable`. [Google docs](https://developer.android.com/develop/ui/compose/performance/stability/fix#configuration-file)

From what I've checked this works even if our SDK is used in a third-party app, although there might be differences when we test this in the Demo app, so we might have to double-check on that. 

In general, I think we should avoid having atomic components that take full models as parameters. For example the `DisplayName()` that takes profile. Some of the properties from the `Profile` can change but not necessarily the display name. So we have some extra work happening there.


### Testing Steps

You can compare the recompositions with the layout inspector between this and the trunk branch. 

You can also verify the `stability` of the classes by going to the `build/compose_reports` of each module. 
