### PR TITLE
Declare uCrop activity in the :quickeditor module

### DIFF
--- a/gravatar-quickeditor/src/main/AndroidManifest.xml
+++ b/gravatar-quickeditor/src/main/AndroidManifest.xml
@@ -26,6 +26,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/quickeditor_filepaths" />
         </provider>
+
+        <!-- Lib activities-->
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:theme="@style/Theme.AppCompat.NoActionBar" />
     </application>
 
 </manifest>


### PR DESCRIPTION


### Description

This was removed from `:ui` module and I dodn't know that's why uCrop worked in the `:quickeditor` module.


### Testing Steps

Try to upload the photo via Quick Editor
