### PR TITLE
Replace Gson with Moshi

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,6 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-icons = { module = "androidx.compose.material:material-icons-extended" }
 compose-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive", version.ref = "materialAdaptive" }
-moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ navigationCompose = "2.8.1"
 turbine = "1.1.0"
 dataStore = "1.1.1-beta03"
 startup = "1.1.1"
+moshi = "1.15.1"
 
 [libraries]
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
@@ -56,8 +57,10 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-icons = { module = "androidx.compose.material:material-icons-extended" }
 compose-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive", version.ref = "materialAdaptive" }
+moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
+moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-retrofit-gson-converter = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+retrofit-moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 ucrop = { group = "com.github.yalantis", name = "ucrop", version.ref = "ucrop" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -101,6 +101,8 @@ dependencies {
     implementation(project(":gravatar"))
     implementation(project(":gravatar-ui"))
 
+    implementation(libs.moshi)
+    implementation(libs.moshi.kotlin)
     implementation(libs.androidx.browser)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.viewmodel.compose)
@@ -110,7 +112,7 @@ dependencies {
 
     implementation(libs.coil.compose)
     implementation(libs.retrofit)
-    implementation(libs.retrofit.gson.converter)
+    implementation(libs.retrofit.moshi.converter)
     implementation(libs.ucrop)
 
     // Jetpack Compose

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -101,8 +101,6 @@ dependencies {
     implementation(project(":gravatar"))
     implementation(project(":gravatar-ui"))
 
-    implementation(libs.moshi)
-    implementation(libs.moshi.kotlin)
     implementation(libs.androidx.browser)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.viewmodel.compose)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
@@ -15,8 +15,6 @@ import com.gravatar.quickeditor.data.storage.InMemoryTokenStorage
 import com.gravatar.quickeditor.data.storage.TokenStorage
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ProfileService
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.github.osipxd.security.crypto.createEncrypted
 import kotlinx.coroutines.Dispatchers
 
@@ -39,10 +37,6 @@ internal class QuickEditorContainer private constructor(
             return instance
         }
     }
-
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
 
     private val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.createEncrypted(
         corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
@@ -15,6 +15,8 @@ import com.gravatar.quickeditor.data.storage.InMemoryTokenStorage
 import com.gravatar.quickeditor.data.storage.TokenStorage
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ProfileService
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.github.osipxd.security.crypto.createEncrypted
 import kotlinx.coroutines.Dispatchers
 
@@ -37,6 +39,10 @@ internal class QuickEditorContainer private constructor(
             return instance
         }
     }
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
 
     private val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.createEncrypted(
         corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -69,8 +69,10 @@ android {
 
 dependencies {
     api(libs.okhttp)
+    implementation(libs.moshi)
+    implementation(libs.moshi.kotlin)
     implementation(libs.retrofit)
-    implementation(libs.retrofit.gson.converter)
+    implementation(libs.retrofit.moshi.converter)
     implementation(libs.kotlinx.coroutines)
 
     testImplementation(libs.junit)
@@ -105,7 +107,7 @@ openApiGenerate {
     configOptions.set(
         mapOf(
             "library" to "jvm-retrofit2",
-            "serializationLibrary" to "gson",
+            "serializationLibrary" to "moshi",
             "groupId" to "com.gravatar",
             "packageName" to "com.gravatar.restapi",
             "useCoroutines" to "true",

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -69,7 +69,6 @@ android {
 
 dependencies {
     api(libs.okhttp)
-    implementation(libs.moshi)
     implementation(libs.moshi.kotlin)
     implementation(libs.retrofit)
     implementation(libs.retrofit.moshi.converter)

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -1,15 +1,17 @@
 package com.gravatar.di.container
 
-import com.google.gson.GsonBuilder
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V3
+import com.gravatar.moshiadapers.URIJsonAdapter
 import com.gravatar.services.AuthenticationInterceptor
 import com.gravatar.services.AvatarUploadTimeoutInterceptor
 import com.gravatar.services.GravatarApi
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
 
 internal class GravatarSdkContainer private constructor() {
     companion object {
@@ -18,10 +20,12 @@ internal class GravatarSdkContainer private constructor() {
         }
     }
 
-    private fun getRetrofitApiV3Builder() = Retrofit.Builder().baseUrl(GRAVATAR_API_BASE_URL_V3)
+    val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .add(URIJsonAdapter())
+        .build()
 
-    val gson = GsonBuilder().setLenient()
-        .create()
+    private fun getRetrofitApiV3Builder() = Retrofit.Builder().baseUrl(GRAVATAR_API_BASE_URL_V3)
 
     val dispatcherMain: CoroutineDispatcher = Dispatchers.Main
     val dispatcherDefault = Dispatchers.Default
@@ -32,7 +36,7 @@ internal class GravatarSdkContainer private constructor() {
     fun getGravatarV3Service(okHttpClient: OkHttpClient? = null, oauthToken: String? = null): GravatarApi {
         return getRetrofitApiV3Builder().apply {
             client(okHttpClient ?: buildOkHttpClient(oauthToken))
-        }.addConverterFactory(GsonConverterFactory.create(gson))
+        }.addConverterFactory(MoshiConverterFactory.create(moshi))
             .build().create(GravatarApi::class.java)
     }
 

--- a/gravatar/src/main/java/com/gravatar/moshiadapers/URIJsonAdapter.kt
+++ b/gravatar/src/main/java/com/gravatar/moshiadapers/URIJsonAdapter.kt
@@ -1,0 +1,17 @@
+package com.gravatar.moshiadapers
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.net.URI
+
+internal class URIJsonAdapter {
+    @ToJson
+    public fun toJson(uri: URI): String {
+        return uri.toString()
+    }
+
+    @FromJson
+    public fun fromJson(uriString: String): URI {
+        return URI(uriString)
+    }
+}

--- a/gravatar/src/main/java/com/gravatar/restapi/models/AssociatedEmail200Response.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/AssociatedEmail200Response.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -18,7 +18,7 @@ import java.util.Objects
 
 public class AssociatedEmail200Response private constructor(
     // Whether the email is associated with a Gravatar account.
-    @SerializedName("associated")
+    @Json(name = "associated")
     public val associated: kotlin.Boolean,
 ) {
     override fun toString(): String = "AssociatedEmail200Response(associated=$associated)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Avatar.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Avatar.kt
@@ -7,7 +7,8 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -23,22 +24,22 @@ import java.util.Objects
 
 public class Avatar private constructor(
     // Unique identifier for the image.
-    @SerializedName("image_id")
+    @Json(name = "image_id")
     public val imageId: kotlin.String,
     // Image URL
-    @SerializedName("image_url")
+    @Json(name = "image_url")
     public val imageUrl: java.net.URI,
     // Rating associated with the image.
-    @SerializedName("rating")
+    @Json(name = "rating")
     public val rating: Avatar.Rating,
     // Date and time when the image was last updated.
-    @SerializedName("updated_date")
+    @Json(name = "updated_date")
     public val updatedDate: String,
     // Alternative text description of the image.
-    @SerializedName("alt_text")
+    @Json(name = "alt_text")
     public val altText: kotlin.String,
     // Whether the image is currently selected as the provided selected email's avatar.
-    @SerializedName("selected")
+    @Json(name = "selected")
     public val selected: kotlin.Boolean? = null,
 ) {
     /**
@@ -46,17 +47,18 @@ public class Avatar private constructor(
      *
      * Values: G,PG,R,X
      */
+    @JsonClass(generateAdapter = false)
     public enum class Rating(public val value: kotlin.String) {
-        @SerializedName(value = "G")
+        @Json(name = "G")
         G("G"),
 
-        @SerializedName(value = "PG")
+        @Json(name = "PG")
         PG("PG"),
 
-        @SerializedName(value = "R")
+        @Json(name = "R")
         R("R"),
 
-        @SerializedName(value = "X")
+        @Json(name = "X")
         X("X"),
     }
 

--- a/gravatar/src/main/java/com/gravatar/restapi/models/CryptoWalletAddress.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/CryptoWalletAddress.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -19,10 +19,10 @@ import java.util.Objects
 
 public class CryptoWalletAddress private constructor(
     // The label for the crypto currency.
-    @SerializedName("label")
+    @Json(name = "label")
     public val label: kotlin.String,
     // The wallet address for the crypto currency.
-    @SerializedName("address")
+    @Json(name = "address")
     public val address: kotlin.String,
 ) {
     override fun toString(): String = "CryptoWalletAddress(label=$label, address=$address)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Error.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Error.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -19,10 +19,10 @@ import java.util.Objects
 
 public class Error private constructor(
     // The error message
-    @SerializedName("error")
+    @Json(name = "error")
     public val error: kotlin.String,
     // The error code for the error message
-    @SerializedName("code")
+    @Json(name = "code")
     public val code: kotlin.String,
 ) {
     override fun toString(): String = "Error(error=$error, code=$code)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/GalleryImage.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/GalleryImage.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -19,10 +19,10 @@ import java.util.Objects
 
 public class GalleryImage private constructor(
     // The URL to the image.
-    @SerializedName("url")
+    @Json(name = "url")
     public val url: java.net.URI,
     // The image alt text.
-    @SerializedName("alt_text")
+    @Json(name = "alt_text")
     public val altText: kotlin.String? = null,
 ) {
     override fun toString(): String = "GalleryImage(url=$url, altText=$altText)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Interest.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Interest.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -19,10 +19,10 @@ import java.util.Objects
 
 public class Interest private constructor(
     // The unique identifier for the interest.
-    @SerializedName("id")
+    @Json(name = "id")
     public val id: kotlin.Int,
     // The name of the interest.
-    @SerializedName("name")
+    @Json(name = "name")
     public val name: kotlin.String,
 ) {
     override fun toString(): String = "Interest(id=$id, name=$name)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Language.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Language.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -21,16 +21,16 @@ import java.util.Objects
 
 public class Language private constructor(
     // The language code.
-    @SerializedName("code")
+    @Json(name = "code")
     public val code: kotlin.String,
     // The language name.
-    @SerializedName("name")
+    @Json(name = "name")
     public val name: kotlin.String,
     // Whether the language is the user's primary language.
-    @SerializedName("is_primary")
+    @Json(name = "is_primary")
     public val isPrimary: kotlin.Boolean,
     // The order of the language in the user's profile.
-    @SerializedName("order")
+    @Json(name = "order")
     public val order: kotlin.Int,
 ) {
     override fun toString(): String = "Language(code=$code, name=$name, isPrimary=$isPrimary, order=$order)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Link.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Link.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -19,10 +19,10 @@ import java.util.Objects
 
 public class Link private constructor(
     // The label for the link.
-    @SerializedName("label")
+    @Json(name = "label")
     public val label: kotlin.String,
     // The URL to the link.
-    @SerializedName("url")
+    @Json(name = "url")
     public val url: java.net.URI,
 ) {
     override fun toString(): String = "Link(label=$label, url=$url)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Profile.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Profile.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -42,77 +42,77 @@ import java.util.Objects
 
 public class Profile private constructor(
     // The SHA256 hash of the user's primary email address.
-    @SerializedName("hash")
+    @Json(name = "hash")
     public val hash: kotlin.String,
     // The user's display name. This is the name that is displayed on their profile.
-    @SerializedName("display_name")
+    @Json(name = "display_name")
     public val displayName: kotlin.String,
     // The full URL for the user's profile.
-    @SerializedName("profile_url")
+    @Json(name = "profile_url")
     public val profileUrl: java.net.URI,
     // The URL for the user's avatar image if it has been set.
-    @SerializedName("avatar_url")
+    @Json(name = "avatar_url")
     public val avatarUrl: java.net.URI,
     // The alt text for the user's avatar image if it has been set.
-    @SerializedName("avatar_alt_text")
+    @Json(name = "avatar_alt_text")
     public val avatarAltText: kotlin.String,
     // The user's location.
-    @SerializedName("location")
+    @Json(name = "location")
     public val location: kotlin.String,
     // The about section on a user's profile.
-    @SerializedName("description")
+    @Json(name = "description")
     public val description: kotlin.String,
     // The user's job title.
-    @SerializedName("job_title")
+    @Json(name = "job_title")
     public val jobTitle: kotlin.String,
     // The user's current company's name.
-    @SerializedName("company")
+    @Json(name = "company")
     public val company: kotlin.String,
     // A list of verified accounts the user has added to their profile. This is limited to a max of 4 in unauthenticated requests.
-    @SerializedName("verified_accounts")
+    @Json(name = "verified_accounts")
     public val verifiedAccounts: kotlin.collections.List<VerifiedAccount>,
     // The phonetic pronunciation of the user's name.
-    @SerializedName("pronunciation")
+    @Json(name = "pronunciation")
     public val pronunciation: kotlin.String,
     // The pronouns the user uses.
-    @SerializedName("pronouns")
+    @Json(name = "pronouns")
     public val pronouns: kotlin.String,
     // The timezone the user has. This is only provided in authenticated API requests.
-    @SerializedName("timezone")
+    @Json(name = "timezone")
     public val timezone: kotlin.String? = null,
     // The languages the user knows. This is only provided in authenticated API requests.
-    @SerializedName("languages")
+    @Json(name = "languages")
     public val languages: kotlin.collections.List<Language>? = null,
     // User's first name. This is only provided in authenticated API requests.
-    @SerializedName("first_name")
+    @Json(name = "first_name")
     public val firstName: kotlin.String? = null,
     // User's last name. This is only provided in authenticated API requests.
-    @SerializedName("last_name")
+    @Json(name = "last_name")
     public val lastName: kotlin.String? = null,
     // Whether user is an organization. This is only provided in authenticated API requests.
-    @SerializedName("is_organization")
+    @Json(name = "is_organization")
     public val isOrganization: kotlin.Boolean? = null,
     // A list of links the user has added to their profile. This is only provided in authenticated API requests.
-    @SerializedName("links")
+    @Json(name = "links")
     public val links: kotlin.collections.List<Link>? = null,
     // A list of interests the user has added to their profile. This is only provided in authenticated API requests.
-    @SerializedName("interests")
+    @Json(name = "interests")
     public val interests: kotlin.collections.List<Interest>? = null,
-    @SerializedName("payments")
+    @Json(name = "payments")
     public val payments: ProfilePayments? = null,
-    @SerializedName("contact_info")
+    @Json(name = "contact_info")
     public val contactInfo: ProfileContactInfo? = null,
     // Additional images a user has uploaded. This is only provided in authenticated API requests.
-    @SerializedName("gallery")
+    @Json(name = "gallery")
     public val gallery: kotlin.collections.List<GalleryImage>? = null,
     // The number of verified accounts the user has added to their profile. This count includes verified accounts the user is hiding from their profile. This is only provided in authenticated API requests.
-    @SerializedName("number_verified_accounts")
+    @Json(name = "number_verified_accounts")
     public val numberVerifiedAccounts: kotlin.Int? = null,
     // The date and time (UTC) the user last edited their profile. This is only provided in authenticated API requests.
-    @SerializedName("last_profile_edit")
+    @Json(name = "last_profile_edit")
     public val lastProfileEdit: String? = null,
     // The date the user registered their account. This is only provided in authenticated API requests.
-    @SerializedName("registration_date")
+    @Json(name = "registration_date")
     public val registrationDate: String? = null,
 ) {
     override fun toString(): String = "Profile(hash=$hash, displayName=$displayName, profileUrl=$profileUrl, avatarUrl=$avatarUrl, avatarAltText=$avatarAltText, location=$location, description=$description, jobTitle=$jobTitle, company=$company, verifiedAccounts=$verifiedAccounts, pronunciation=$pronunciation, pronouns=$pronouns, timezone=$timezone, languages=$languages, firstName=$firstName, lastName=$lastName, isOrganization=$isOrganization, links=$links, interests=$interests, payments=$payments, contactInfo=$contactInfo, gallery=$gallery, numberVerifiedAccounts=$numberVerifiedAccounts, lastProfileEdit=$lastProfileEdit, registrationDate=$registrationDate)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/ProfileContactInfo.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/ProfileContactInfo.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -23,22 +23,22 @@ import java.util.Objects
 
 public class ProfileContactInfo private constructor(
     // The user's home phone number.
-    @SerializedName("home_phone")
+    @Json(name = "home_phone")
     public val homePhone: kotlin.String? = null,
     // The user's work phone number.
-    @SerializedName("work_phone")
+    @Json(name = "work_phone")
     public val workPhone: kotlin.String? = null,
     // The user's cell phone number.
-    @SerializedName("cell_phone")
+    @Json(name = "cell_phone")
     public val cellPhone: kotlin.String? = null,
     // The user's email address as provided on the contact section of the profile. Might differ from their account emails.
-    @SerializedName("email")
+    @Json(name = "email")
     public val email: kotlin.String? = null,
     // The URL to the user's contact form.
-    @SerializedName("contact_form")
+    @Json(name = "contact_form")
     public val contactForm: java.net.URI? = null,
     // The URL to the user's calendar.
-    @SerializedName("calendar")
+    @Json(name = "calendar")
     public val calendar: java.net.URI? = null,
 ) {
     override fun toString(): String = "ProfileContactInfo(homePhone=$homePhone, workPhone=$workPhone, cellPhone=$cellPhone, email=$email, contactForm=$contactForm, calendar=$calendar)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/ProfilePayments.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/ProfilePayments.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -19,10 +19,10 @@ import java.util.Objects
 
 public class ProfilePayments private constructor(
     // A list of payment URLs the user has added to their profile.
-    @SerializedName("links")
+    @Json(name = "links")
     public val links: kotlin.collections.List<Link>,
     // A list of crypto currencies the user accepts.
-    @SerializedName("crypto_wallets")
+    @Json(name = "crypto_wallets")
     public val cryptoWallets: kotlin.collections.List<CryptoWalletAddress>,
 ) {
     override fun toString(): String = "ProfilePayments(links=$links, cryptoWallets=$cryptoWallets)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/SetEmailAvatarRequest.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/SetEmailAvatarRequest.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -18,7 +18,7 @@ import java.util.Objects
 
 public class SetEmailAvatarRequest private constructor(
     // The email SHA256 hash to set the avatar for.
-    @SerializedName("email_hash")
+    @Json(name = "email_hash")
     public val emailHash: kotlin.String,
 ) {
     override fun toString(): String = "SetEmailAvatarRequest(emailHash=$emailHash)"

--- a/gravatar/src/main/java/com/gravatar/restapi/models/VerifiedAccount.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/VerifiedAccount.kt
@@ -7,7 +7,7 @@
  */
 package com.gravatar.restapi.models
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.util.Objects
 
 /**
@@ -21,16 +21,16 @@ import java.util.Objects
 
 public class VerifiedAccount private constructor(
     // The type of the service.
-    @SerializedName("service_type")
+    @Json(name = "service_type")
     public val serviceType: kotlin.String,
     // The name of the service.
-    @SerializedName("service_label")
+    @Json(name = "service_label")
     public val serviceLabel: kotlin.String,
     // The URL to the service's icon.
-    @SerializedName("service_icon")
+    @Json(name = "service_icon")
     public val serviceIcon: java.net.URI,
     // The URL to the user's profile on the service.
-    @SerializedName("url")
+    @Json(name = "url")
     public val url: java.net.URI,
 ) {
     override fun toString(): String = "VerifiedAccount(serviceType=$serviceType, serviceLabel=$serviceLabel, serviceIcon=$serviceIcon, url=$url)"

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -14,7 +14,7 @@ internal fun HttpException.errorTypeFromHttpCode(moshi: Moshi): ErrorType = when
     HttpResponseCode.UNAUTHORIZED -> ErrorType.Unauthorized
     HttpResponseCode.INVALID_REQUEST -> {
         val error: Error? = runCatching {
-            moshi.adapter(Error::class.java).fromJson(rawErrorBody)
+            rawErrorBody?.let { moshi.adapter(Error::class.java).fromJson(it) }
         }.getOrNull()
         ErrorType.InvalidRequest(error)
     }

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -1,20 +1,20 @@
 package com.gravatar.services
 
-import com.google.gson.Gson
 import com.gravatar.HttpResponseCode
 import com.gravatar.restapi.models.Error
+import com.squareup.moshi.Moshi
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.Objects
 
-internal fun HttpException.errorTypeFromHttpCode(gson: Gson): ErrorType = when (code) {
+internal fun HttpException.errorTypeFromHttpCode(moshi: Moshi): ErrorType = when (code) {
     HttpResponseCode.HTTP_CLIENT_TIMEOUT -> ErrorType.Timeout
     HttpResponseCode.HTTP_NOT_FOUND -> ErrorType.NotFound
     HttpResponseCode.HTTP_TOO_MANY_REQUESTS -> ErrorType.RateLimitExceeded
     HttpResponseCode.UNAUTHORIZED -> ErrorType.Unauthorized
     HttpResponseCode.INVALID_REQUEST -> {
         val error: Error? = runCatching {
-            gson.fromJson(rawErrorBody, Error::class.java)
+            moshi.adapter(Error::class.java).fromJson(rawErrorBody)
         }.getOrNull()
         ErrorType.InvalidRequest(error)
     }
@@ -23,11 +23,11 @@ internal fun HttpException.errorTypeFromHttpCode(gson: Gson): ErrorType = when (
     else -> ErrorType.Unknown
 }
 
-internal fun Throwable.errorType(gson: Gson): ErrorType {
+internal fun Throwable.errorType(moshi: Moshi): ErrorType {
     return when (this) {
         is SocketTimeoutException -> ErrorType.Timeout
         is UnknownHostException -> ErrorType.Network
-        is HttpException -> this.errorTypeFromHttpCode(gson)
+        is HttpException -> this.errorTypeFromHttpCode(moshi)
         else -> ErrorType.Unknown
     }
 }

--- a/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
@@ -15,6 +15,6 @@ internal inline fun <T> runCatchingRequest(block: () -> T?): Result<T, ErrorType
     } catch (cancellationException: CancellationException) {
         throw cancellationException
     } catch (ex: Exception) {
-        Result.Failure(ex.errorType(GravatarSdkContainer.instance.gson))
+        Result.Failure(ex.errorType(GravatarSdkContainer.instance.moshi))
     }
 }

--- a/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
@@ -1,12 +1,12 @@
 package com.gravatar.services
 
-import com.google.gson.Gson
 import com.gravatar.HttpResponseCode.HTTP_CLIENT_TIMEOUT
 import com.gravatar.HttpResponseCode.HTTP_NOT_FOUND
 import com.gravatar.HttpResponseCode.HTTP_TOO_MANY_REQUESTS
 import com.gravatar.HttpResponseCode.INVALID_REQUEST
 import com.gravatar.HttpResponseCode.SERVER_ERRORS
 import com.gravatar.restapi.models.Error
+import com.squareup.moshi.Moshi
 import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
@@ -16,7 +16,7 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
 class ErrorTypeTest {
-    private val gson = Gson()
+    private val moshi = Moshi.Builder().build()
 
     private val errorBody = """
         {
@@ -52,7 +52,7 @@ class ErrorTypeTest {
                 }
             }
             // When
-            val errorType = HttpException(response).errorTypeFromHttpCode(gson)
+            val errorType = HttpException(response).errorTypeFromHttpCode(moshi)
             // Then
             assertEquals(expectedErrorType, errorType)
         }
@@ -76,7 +76,7 @@ class ErrorTypeTest {
         }
         exceptionToErrorTypeRelation.forEach { (exception, expectedErrorType) ->
             // When
-            val errorType = exception.errorType(gson)
+            val errorType = exception.errorType(moshi)
             // Then
             assertEquals(expectedErrorType, errorType)
         }

--- a/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
@@ -7,6 +7,7 @@ import com.gravatar.HttpResponseCode.INVALID_REQUEST
 import com.gravatar.HttpResponseCode.SERVER_ERRORS
 import com.gravatar.restapi.models.Error
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
@@ -16,7 +17,9 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
 class ErrorTypeTest {
-    private val moshi = Moshi.Builder().build()
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
 
     private val errorBody = """
         {


### PR DESCRIPTION
Closes #177

### Description

The Gson library we use for Json parsing is old and doesn't work well with Kotlin. I think we can safely call this a legacy code in our fairly new code base, so I think it's best to replace it with something more modern.

OpenAPI generator supports Gson, Jackson, Moshi, and Kotlin Serialization. 

Jackson is Java-first as Gson, so I didn't consider it at all.

Kotlin Serialization was my first initial pick but after trying to implement it I came to the conclusion that it may not be the best pick for an SDK:
1. It requires enabling the plugin in the app-level `build.gradle`. This would require some extra work for third-party devs to do something that's our internal implementation.
2. You can't set serializers for custom types like `URI` globally. [There are different ways to handle it](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#specifying-serializers-for-a-file) but each requires updates to the way models are generated (modifying .mustache templates) or exposing type aliases that again should be our implementation detail. 

Moshi it is then!  There are two options Reflection or Codegen. The latter requires ksp/kapt enabled and I'm worried this could cause potential conflict with third-party apps so I decided to use reflection for our SDK. 

### Testing Steps

Smoke test the Demo app including the QE.
