### PR TITLE
Parse the Error object from the error response body

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -267,13 +267,13 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
 
                                 is Result.Failure -> {
                                     when (result.error) {
-                                        ErrorType.NOT_FOUND -> {
+                                        ErrorType.NotFound -> {
                                             profileState = ComponentState.Empty
                                         }
 
                                         else -> {
-                                            onError(result.error.name, null)
-                                            error = result.error.name
+                                            onError(result.error.toString(), null)
+                                            error = result.error.toString()
                                         }
                                     }
                                 }

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
@@ -86,7 +86,7 @@ fun GravatarProfileSummary(emailAddress: String = "gravatar@automattic.com") {
             }
 
             is Result.Failure -> {
-                Log.e("Gravatar", result.error.name)
+                Log.e("Gravatar", result.error.toString())
                 profileState = ComponentState.Empty
             }
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthService.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/service/WordPressOAuthService.kt
@@ -29,12 +29,12 @@ internal class WordPressOAuthService(
             if (body != null) {
                 Result.Success(body.token)
             } else {
-                Result.Failure(ErrorType.UNKNOWN)
+                Result.Failure(ErrorType.Unknown)
             }
         } catch (cancellationException: CancellationException) {
             throw cancellationException
         } catch (ex: Exception) {
-            Result.Failure(ErrorType.SERVER)
+            Result.Failure(ErrorType.Server)
         }
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -206,7 +206,7 @@ private suspend fun AvatarPickerAction.handle(
 
         is AvatarPickerAction.AvatarUploadFailed -> {
             val result = snackState.showQESnackbar(
-                message = context.getString(R.string.avatar_upload_error),
+                message = this.message ?: context.getString(R.string.avatar_upload_error),
                 actionLabel = context.getString(R.string.avatar_upload_error_action),
                 snackbarType = SnackbarType.Error,
                 withDismissAction = true,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
@@ -7,7 +7,7 @@ import java.io.File
 internal sealed class AvatarPickerAction {
     data class AvatarSelected(val avatar: Avatar) : AvatarPickerAction()
 
-    data class AvatarUploadFailed(val imageUri: Uri) : AvatarPickerAction()
+    data class AvatarUploadFailed(val imageUri: Uri, val message: String?) : AvatarPickerAction()
 
     data class LaunchImageCropper(val imageUri: Uri, val tempFile: File) : AvatarPickerAction()
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -128,7 +128,15 @@ internal class AvatarPickerViewModel(
                             scrollToIndex = null,
                         )
                     }
-                    _actions.send(AvatarPickerAction.AvatarUploadFailed(uri))
+                    _actions.send(
+                        AvatarPickerAction.AvatarUploadFailed(
+                            uri,
+                            (
+                                (result.error as? QuickEditorError.Request)
+                                    ?.type as? ErrorType.InvalidRequest
+                            )?.error?.error,
+                        ),
+                    )
                 }
             }
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -195,13 +195,14 @@ internal class AvatarPickerViewModel(
             QuickEditorError.TokenNotFound -> SectionError.InvalidToken(handleExpiredSession)
             QuickEditorError.Unknown -> SectionError.Unknown
             is QuickEditorError.Request -> when (type) {
-                ErrorType.SERVER -> SectionError.ServerError
-                ErrorType.NETWORK -> SectionError.NoInternetConnection
-                ErrorType.UNAUTHORIZED -> SectionError.InvalidToken(handleExpiredSession)
-                ErrorType.NOT_FOUND,
-                ErrorType.RATE_LIMIT_EXCEEDED,
-                ErrorType.TIMEOUT,
-                ErrorType.UNKNOWN,
+                ErrorType.Server -> SectionError.ServerError
+                ErrorType.Network -> SectionError.NoInternetConnection
+                ErrorType.Unauthorized -> SectionError.InvalidToken(handleExpiredSession)
+                ErrorType.NotFound,
+                ErrorType.RateLimitExceeded,
+                ErrorType.Timeout,
+                ErrorType.Unknown,
+                is ErrorType.InvalidRequest,
                 -> SectionError.Unknown
             }
         }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -57,12 +57,12 @@ class AvatarRepositoryTest {
     fun `given token stored when get avatars fails then Failure result`() = runTest {
         coEvery { tokenStorage.getToken(any()) } returns "token"
 
-        coEvery { avatarService.retrieveCatching(any(), any()) } returns Result.Failure(ErrorType.SERVER)
+        coEvery { avatarService.retrieveCatching(any(), any()) } returns Result.Failure(ErrorType.Server)
 
         val result = avatarRepository.getAvatars(email)
 
         assertEquals(
-            Result.Failure<EmailAvatars, QuickEditorError>(QuickEditorError.Request(ErrorType.SERVER)),
+            Result.Failure<EmailAvatars, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)),
             result,
         )
     }
@@ -94,11 +94,11 @@ class AvatarRepositoryTest {
     @Test
     fun `given token stored when avatar selected fails then Failure result`() = runTest {
         coEvery { tokenStorage.getToken(any()) } returns "token"
-        coEvery { avatarService.setAvatarCatching(any(), any(), any()) } returns Result.Failure(ErrorType.UNKNOWN)
+        coEvery { avatarService.setAvatarCatching(any(), any(), any()) } returns Result.Failure(ErrorType.Unknown)
 
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
-        assertEquals(Result.Failure<String, QuickEditorError>(QuickEditorError.Request(ErrorType.UNKNOWN)), result)
+        assertEquals(Result.Failure<String, QuickEditorError>(QuickEditorError.Request(ErrorType.Unknown)), result)
     }
 
     @Test
@@ -146,11 +146,11 @@ class AvatarRepositoryTest {
             every { toFile() } returns file
         }
         coEvery { tokenStorage.getToken(any()) } returns "token"
-        coEvery { avatarService.uploadCatching(any(), any()) } returns Result.Failure(ErrorType.SERVER)
+        coEvery { avatarService.uploadCatching(any(), any()) } returns Result.Failure(ErrorType.Server)
 
         val result = avatarRepository.uploadAvatar(email, uri)
 
-        assertEquals(Result.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.SERVER)), result)
+        assertEquals(Result.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)), result)
     }
 
     private fun createAvatar(id: String, isSelected: Boolean = false) = Avatar {

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/service/WordPressOAuthServiceTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/service/WordPressOAuthServiceTest.kt
@@ -42,7 +42,7 @@ class WordPressOAuthServiceTest {
 
             val result = wordPressOAuthService.getAccessToken("code", "clientId", "clientSecret", "redirectUri")
 
-            assertEquals(Result.Failure<WordPressOAuthToken, ErrorType>(ErrorType.SERVER), result)
+            assertEquals(Result.Failure<WordPressOAuthToken, ErrorType>(ErrorType.Server), result)
         }
 
     @Test
@@ -57,7 +57,7 @@ class WordPressOAuthServiceTest {
 
         val result = wordPressOAuthService.getAccessToken("code", "clientId", "clientSecret", "redirectUri")
 
-        assertEquals(Result.Failure<WordPressOAuthToken, ErrorType>(ErrorType.UNKNOWN), result)
+        assertEquals(Result.Failure<WordPressOAuthToken, ErrorType>(ErrorType.Unknown), result)
     }
 
     @Test

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -48,7 +48,7 @@ class AvatarPickerViewModelTest {
 
     @Before
     fun setup() {
-        coEvery { profileService.retrieveCatching(email) } returns Result.Failure(ErrorType.UNKNOWN)
+        coEvery { profileService.retrieveCatching(email) } returns Result.Failure(ErrorType.Unknown)
         coEvery { avatarRepository.getAvatars(email) } returns Result.Success(emailAvatars)
     }
 
@@ -388,7 +388,7 @@ class AvatarPickerViewModelTest {
         coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
-        } returns Result.Failure(QuickEditorError.Request(ErrorType.SERVER))
+        } returns Result.Failure(QuickEditorError.Request(ErrorType.Server))
         coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
@@ -472,7 +472,7 @@ class AvatarPickerViewModelTest {
         coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
-        } returns Result.Failure(QuickEditorError.Request(ErrorType.SERVER))
+        } returns Result.Failure(QuickEditorError.Request(ErrorType.Server))
         coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -9,6 +9,7 @@ import com.gravatar.quickeditor.data.repository.AvatarRepository
 import com.gravatar.quickeditor.data.repository.EmailAvatars
 import com.gravatar.quickeditor.ui.CoroutineTestRule
 import com.gravatar.restapi.models.Avatar
+import com.gravatar.restapi.models.Error
 import com.gravatar.services.ErrorType
 import com.gravatar.services.ProfileService
 import com.gravatar.services.Result
@@ -384,11 +385,22 @@ class AvatarPickerViewModelTest {
     fun `given cropped image when upload failure then uiState is updated`() = runTest {
         val uri = mockk<Uri>()
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
+        val uploadErrorMessage = "Failed to upload avatar"
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
-        } returns Result.Failure(QuickEditorError.Request(ErrorType.Server))
+        } returns Result.Failure(
+            QuickEditorError.Request(
+                ErrorType.InvalidRequest(
+                    error = Error {
+                        code = "error"
+                        error = uploadErrorMessage
+                    },
+                ),
+            ),
+        )
+
         coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
@@ -425,7 +437,7 @@ class AvatarPickerViewModelTest {
             )
         }
         viewModel.actions.test {
-            assertEquals(AvatarPickerAction.AvatarUploadFailed(uri), awaitItem())
+            assertEquals(AvatarPickerAction.AvatarUploadFailed(uri, uploadErrorMessage), awaitItem())
         }
     }
 

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
@@ -75,7 +75,7 @@ class OAuthViewModelTest {
                 any(),
                 any(),
             )
-        } returns Result.Failure(ErrorType.UNKNOWN)
+        } returns Result.Failure(ErrorType.Unknown)
 
         viewModel.actions.test {
             skipItems(1) // skipping the StartOAuth action

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -613,17 +613,64 @@ public final class com/gravatar/services/AvatarService {
 	public final fun uploadCatching (Ljava/io/File;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/gravatar/services/ErrorType : java/lang/Enum {
-	public static final field NETWORK Lcom/gravatar/services/ErrorType;
-	public static final field NOT_FOUND Lcom/gravatar/services/ErrorType;
-	public static final field RATE_LIMIT_EXCEEDED Lcom/gravatar/services/ErrorType;
-	public static final field SERVER Lcom/gravatar/services/ErrorType;
-	public static final field TIMEOUT Lcom/gravatar/services/ErrorType;
-	public static final field UNAUTHORIZED Lcom/gravatar/services/ErrorType;
-	public static final field UNKNOWN Lcom/gravatar/services/ErrorType;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/gravatar/services/ErrorType;
-	public static fun values ()[Lcom/gravatar/services/ErrorType;
+public abstract class com/gravatar/services/ErrorType {
+}
+
+public final class com/gravatar/services/ErrorType$InvalidRequest : com/gravatar/services/ErrorType {
+	public fun <init> (Lcom/gravatar/restapi/models/Error;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Lcom/gravatar/restapi/models/Error;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/ErrorType$Network : com/gravatar/services/ErrorType {
+	public static final field INSTANCE Lcom/gravatar/services/ErrorType$Network;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/ErrorType$NotFound : com/gravatar/services/ErrorType {
+	public static final field INSTANCE Lcom/gravatar/services/ErrorType$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/ErrorType$RateLimitExceeded : com/gravatar/services/ErrorType {
+	public static final field INSTANCE Lcom/gravatar/services/ErrorType$RateLimitExceeded;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/ErrorType$Server : com/gravatar/services/ErrorType {
+	public static final field INSTANCE Lcom/gravatar/services/ErrorType$Server;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/ErrorType$Timeout : com/gravatar/services/ErrorType {
+	public static final field INSTANCE Lcom/gravatar/services/ErrorType$Timeout;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/ErrorType$Unauthorized : com/gravatar/services/ErrorType {
+	public static final field INSTANCE Lcom/gravatar/services/ErrorType$Unauthorized;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/ErrorType$Unknown : com/gravatar/services/ErrorType {
+	public static final field INSTANCE Lcom/gravatar/services/ErrorType$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/gravatar/services/GravatarListener {

--- a/gravatar/src/main/java/com/gravatar/HttpResponseCode.kt
+++ b/gravatar/src/main/java/com/gravatar/HttpResponseCode.kt
@@ -6,6 +6,7 @@ internal object HttpResponseCode {
     const val HTTP_NOT_FOUND = 404
     const val HTTP_TOO_MANY_REQUESTS = 429
     const val UNAUTHORIZED = 401
+    const val INVALID_REQUEST = 400
 
     private const val HTTP_INTERNAL_ERROR = 500
     private const val NETWORK_CONNECT_TIMEOUT_ERROR = 599

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -20,7 +20,7 @@ internal class GravatarSdkContainer private constructor() {
 
     private fun getRetrofitApiV3Builder() = Retrofit.Builder().baseUrl(GRAVATAR_API_BASE_URL_V3)
 
-    private val gson = GsonBuilder().setLenient()
+    val gson = GsonBuilder().setLenient()
         .create()
 
     val dispatcherMain: CoroutineDispatcher = Dispatchers.Main

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -1,49 +1,72 @@
 package com.gravatar.services
 
+import com.google.gson.Gson
 import com.gravatar.HttpResponseCode
+import com.gravatar.restapi.models.Error
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.util.Objects
 
-internal fun errorTypeFromHttpCode(code: Int): ErrorType = when (code) {
-    HttpResponseCode.HTTP_CLIENT_TIMEOUT -> ErrorType.TIMEOUT
-    HttpResponseCode.HTTP_NOT_FOUND -> ErrorType.NOT_FOUND
-    HttpResponseCode.HTTP_TOO_MANY_REQUESTS -> ErrorType.RATE_LIMIT_EXCEEDED
-    HttpResponseCode.UNAUTHORIZED -> ErrorType.UNAUTHORIZED
-    in HttpResponseCode.SERVER_ERRORS -> ErrorType.SERVER
-    else -> ErrorType.UNKNOWN
+internal fun HttpException.errorTypeFromHttpCode(gson: Gson): ErrorType = when (code) {
+    HttpResponseCode.HTTP_CLIENT_TIMEOUT -> ErrorType.Timeout
+    HttpResponseCode.HTTP_NOT_FOUND -> ErrorType.NotFound
+    HttpResponseCode.HTTP_TOO_MANY_REQUESTS -> ErrorType.RateLimitExceeded
+    HttpResponseCode.UNAUTHORIZED -> ErrorType.Unauthorized
+    HttpResponseCode.INVALID_REQUEST -> {
+        val error: Error? = runCatching {
+            gson.fromJson(rawErrorBody, Error::class.java)
+        }.getOrNull()
+        ErrorType.InvalidRequest(error)
+    }
+
+    in HttpResponseCode.SERVER_ERRORS -> ErrorType.Server
+    else -> ErrorType.Unknown
 }
 
-internal fun Throwable.errorType(): ErrorType {
+internal fun Throwable.errorType(gson: Gson): ErrorType {
     return when (this) {
-        is SocketTimeoutException -> ErrorType.TIMEOUT
-        is UnknownHostException -> ErrorType.NETWORK
-        is HttpException -> errorTypeFromHttpCode(code)
-        else -> ErrorType.UNKNOWN
+        is SocketTimeoutException -> ErrorType.Timeout
+        is UnknownHostException -> ErrorType.Network
+        is HttpException -> this.errorTypeFromHttpCode(gson)
+        else -> ErrorType.Unknown
     }
 }
 
 /**
  * Error types for Gravatar image upload
  */
-public enum class ErrorType {
+public sealed class ErrorType {
     /** server returned an error */
-    SERVER,
+    public data object Server : ErrorType()
 
     /** network request timed out */
-    TIMEOUT,
+    public data object Timeout : ErrorType()
 
     /** network is not available */
-    NETWORK,
+    public data object Network : ErrorType()
 
     /** User or hash not found */
-    NOT_FOUND,
+    public data object NotFound : ErrorType()
 
     /** User or hash not found */
-    RATE_LIMIT_EXCEEDED,
+    public data object RateLimitExceeded : ErrorType()
 
     /** User not authorized to perform given action **/
-    UNAUTHORIZED,
+    public data object Unauthorized : ErrorType()
 
     /** An unknown error occurred */
-    UNKNOWN,
+    public data object Unknown : ErrorType()
+
+    /**
+     * An error occurred while processing the request.
+     *
+     * @property error The detailed error that occurred, if returned from the server.
+     */
+    public class InvalidRequest(public val error: Error?) : ErrorType() {
+        override fun toString(): String = "InvalidRequest(error=$error)"
+
+        override fun equals(other: Any?): Boolean = other is InvalidRequest && error == other.error
+
+        override fun hashCode(): Int = Objects.hash(error)
+    }
 }

--- a/gravatar/src/main/java/com/gravatar/services/HttpException.kt
+++ b/gravatar/src/main/java/com/gravatar/services/HttpException.kt
@@ -9,6 +9,7 @@ import retrofit2.Response
  * [message] The HTTP status message.
  */
 public class HttpException internal constructor(response: Response<*>) : RuntimeException() {
+    internal val rawErrorBody: String? = response.errorBody()?.string()
     public val code: Int = response.code()
-    public override val message: String = "HTTP ${response.code()} ${response.errorBody()?.string()}"
+    public override val message: String = "HTTP ${response.code()} $rawErrorBody"
 }

--- a/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
@@ -1,5 +1,6 @@
 package com.gravatar.services
 
+import com.gravatar.di.container.GravatarSdkContainer
 import kotlinx.coroutines.CancellationException
 import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
 
@@ -10,12 +11,12 @@ internal inline fun <T> runCatchingRequest(block: () -> T?): Result<T, ErrorType
         if (result != null) {
             Result.Success(result)
         } else {
-            Result.Failure(ErrorType.NOT_FOUND)
+            Result.Failure(ErrorType.NotFound)
         }
     } catch (cancellationException: CancellationException) {
         throw cancellationException
     } catch (ex: Exception) {
-        Result.Failure(ex.errorType())
+        Result.Failure(ex.errorType(GravatarSdkContainer.instance.gson))
     }
 }
 

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -119,7 +119,7 @@ class AvatarServiceTest {
             )
         }
 
-        assertEquals(ErrorType.SERVER, (response as Result.Failure).error)
+        assertEquals(ErrorType.Server, (response as Result.Failure).error)
     }
 
     @Test
@@ -179,6 +179,6 @@ class AvatarServiceTest {
 
             val response = avatarService.setAvatarCatching(hash, avatarId, oauthToken)
 
-            assertEquals(ErrorType.SERVER, (response as Result.Failure).error)
+            assertEquals(ErrorType.Server, (response as Result.Failure).error)
         }
 }

--- a/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
@@ -1,34 +1,60 @@
 package com.gravatar.services
 
+import com.google.gson.Gson
 import com.gravatar.HttpResponseCode.HTTP_CLIENT_TIMEOUT
 import com.gravatar.HttpResponseCode.HTTP_NOT_FOUND
 import com.gravatar.HttpResponseCode.HTTP_TOO_MANY_REQUESTS
+import com.gravatar.HttpResponseCode.INVALID_REQUEST
 import com.gravatar.HttpResponseCode.SERVER_ERRORS
+import com.gravatar.restapi.models.Error
 import io.mockk.every
 import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
 import org.junit.Test
+import retrofit2.Response
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
 class ErrorTypeTest {
+    private val gson = Gson()
+
+    private val errorBody = """
+        {
+            "error": "Only square images are accepted",
+            "code": "uncropped_image"
+        }
+    """.trimIndent()
+
     private val httpCodeToErrorTypeRelation = mutableListOf(
-        HTTP_CLIENT_TIMEOUT to ErrorType.TIMEOUT,
-        HTTP_NOT_FOUND to ErrorType.NOT_FOUND,
-        HTTP_TOO_MANY_REQUESTS to ErrorType.RATE_LIMIT_EXCEEDED,
-        600 to ErrorType.UNKNOWN,
+        HTTP_CLIENT_TIMEOUT to ErrorType.Timeout,
+        HTTP_NOT_FOUND to ErrorType.NotFound,
+        HTTP_TOO_MANY_REQUESTS to ErrorType.RateLimitExceeded,
+        600 to ErrorType.Unknown,
+        INVALID_REQUEST to ErrorType.InvalidRequest(
+            error = Error {
+                code = "uncropped_image"
+                error = "Only square images are accepted"
+            },
+        ),
     ).apply {
         SERVER_ERRORS.forEach { code ->
-            add(code to ErrorType.SERVER)
+            add(code to ErrorType.Server)
         }
     }
 
     @Test
     fun `given an http code when converting to error type then correct type is returned`() {
         httpCodeToErrorTypeRelation.forEach { (code, expectedErrorType) ->
+            val response = mockk<Response<Unit>>(relaxed = true) {
+                every { code() } returns code
+                every { errorBody() } returns mockk {
+                    every { string() } returns errorBody
+                }
+            }
             // When
-            val errorType = errorTypeFromHttpCode(code)
+            val errorType = HttpException(response).errorTypeFromHttpCode(gson)
             // Then
-            assert(errorType == expectedErrorType)
+            assertEquals(expectedErrorType, errorType)
         }
     }
 
@@ -36,21 +62,23 @@ class ErrorTypeTest {
     fun `given an exception when converting to error type then correct type is returned`() {
         // Given
         val exceptionToErrorTypeRelation = mutableListOf(
-            SocketTimeoutException() to ErrorType.TIMEOUT,
-            UnknownHostException() to ErrorType.NETWORK,
-            Exception() to ErrorType.UNKNOWN,
+            SocketTimeoutException() to ErrorType.Timeout,
+            UnknownHostException() to ErrorType.Network,
+            Exception() to ErrorType.Unknown,
         ).apply {
             httpCodeToErrorTypeRelation.forEach { (code, errorType) ->
-                val exception = mockk<HttpException>(relaxed = true)
-                every { exception.code } returns code
+                val exception = mockk<HttpException>(relaxed = true) {
+                    every { this@mockk.code } returns code
+                    every { this@mockk.rawErrorBody } returns errorBody
+                }
                 add(exception to errorType)
             }
         }
         exceptionToErrorTypeRelation.forEach { (exception, expectedErrorType) ->
             // When
-            val errorType = exception.errorType()
+            val errorType = exception.errorType(gson)
             // Then
-            assert(errorType == expectedErrorType)
+            assertEquals(expectedErrorType, errorType)
         }
     }
 }

--- a/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
@@ -58,7 +58,7 @@ class ProfileServiceTests {
             val loadProfileResponse = profileService.retrieveByUsernameCatching(username)
 
             coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
-            assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.UNKNOWN)
+            assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
         }
 
     @Test
@@ -73,7 +73,7 @@ class ProfileServiceTests {
             val loadProfileResponse = profileService.retrieveByUsernameCatching(username)
 
             coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
-            assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.UNKNOWN)
+            assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
         }
 
     @Test
@@ -118,7 +118,7 @@ class ProfileServiceTests {
         val loadProfileResponse = profileService.retrieveByUsernameCatching(username)
 
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
-        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.UNKNOWN)
+        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
     }
 
     @Test
@@ -130,7 +130,7 @@ class ProfileServiceTests {
 
         val loadProfileResponse = profileService.retrieveCatching(usernameEmail)
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(usernameEmail.hash().toString()) }
-        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.UNKNOWN)
+        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
     }
 
     @Test
@@ -142,7 +142,7 @@ class ProfileServiceTests {
 
         val loadProfileResponse = profileService.retrieveCatching(usernameHash)
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(usernameHash.toString()) }
-        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.UNKNOWN)
+        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
     }
 
     @Test
@@ -158,7 +158,7 @@ class ProfileServiceTests {
             containerRule.gravatarApiMock.getProfileById(username)
         } returns mockResponse
 
-        assertEquals(ErrorType.NOT_FOUND, (profileService.retrieveCatching(username) as Result.Failure).error)
+        assertEquals(ErrorType.NotFound, (profileService.retrieveCatching(username) as Result.Failure).error)
     }
 
     // Throwing Exception Version of the methods


### PR DESCRIPTION
Closes #12 

### Description

With the recently updated OpenAPI spec, we can now parse the error body to the `Error` object type when the API request fails. 

To pass that error down we need to update the `ErrorType` to a sealed class instead of an enum.

This is required for this [PR](https://github.com/Automattic/Gravatar-SDK-Android/pull/282).

### Testing Steps

Smoke test the Demo app. Test avatar upload - you can either mock the response or modify this [line](https://github.com/Automattic/Gravatar-SDK-Android/blob/trunk/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/copperlauncher/UCropCropperLauncher.kt#L27) to change the aspect ratio.
