### PR TITLE
Remove unnecessary dependency from gravatar-ui module

### DIFF
--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -113,7 +113,6 @@ dependencies {
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
-    implementation(libs.androidx.activity.compose)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }
 


### PR DESCRIPTION
### Description

`androidx-activity-compose` is not needed in `gravatar-ui` module

### Testing Steps

- Code review and CI should be enough