### PR TITLE
Quick Editor: Don't override OAuth mismatch error when the flow is restarted

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
@@ -36,9 +36,6 @@ internal class OAuthViewModel(
     fun startOAuth() {
         viewModelScope.launch {
             _actions.send(OAuthAction.StartOAuth)
-            _uiState.update { currentState ->
-                currentState.copy(status = OAuthStatus.LoginRequired)
-            }
         }
     }
 


### PR DESCRIPTION
Closes #335 

### Description
This PR updates #327 behavior as discussed [here](https://github.com/Automattic/Gravatar-SDK-Android/pull/327#discussion_r1776554195), and with the rest of the team, we want to keep the wrong email error when the OAuth flow is restarted.

### Testing Steps

**Note:** These testing steps assume you are not already logged in to the browser with any Gravatar account.
**Note 2:** You'll need two Gravatar accounts. Let's say accounts `A` and `B`.

1. Navigate to the `Avatar Update` tab in the `demo-app`
2. With your account `A` click on the `Update Avatar` button
3. Follow the OAuth process with the account `A`
4. You should see the **Avatars Picker**, tap `Done` button
5. Fill the `Gravatar E-Mail` with the account `B`
6. Click the `Update Avatar` button
7. You should see the OAuth approval screen, but with `A` account
8. Tap on the `Approve` button
9. QE bottom sheet should show the specific error for this case
10. Tap over the `Log in` button
11. You should see the OAuth approval screen, but with `A` account
12. Close the OAuth screen without performing any action
13. You should see the QE bottom sheet with the wrong email error