### PR TITLE
QuickEditor: Accept-Language header for Avatar requests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,8 @@ turbine = "1.1.0"
 dataStore = "1.1.1-beta03"
 startup = "1.1.1"
 moshi = "1.15.1"
+testCoreKtx = "1.6.1"
+mockwebserver = "4.12.0"
 
 [libraries]
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
@@ -49,6 +51,7 @@ androidx-browser = { group = "androidx.browser", name = "browser", version.ref =
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-startup = { group = "androidx.startup", name = "startup-runtime", version.ref = "startup" }
+androidx-test-core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "testCoreKtx" }
 security-crypto-datastore = { group = "io.github.osipxd", name = "security-crypto-datastore-preferences", version.ref = "dataStore" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 compose-ui = { module = "androidx.compose.ui:ui" }
@@ -73,6 +76,7 @@ roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", versi
 roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }
 roborazzi-junit-rule = { group = "io.github.takahirom.roborazzi", name = "roborazzi-junit-rule", version.ref = "roborazzi" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver"}
 
 
 [plugins]

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -127,6 +127,8 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
     testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core.ktx)
+    testImplementation(libs.mockwebserver)
     testImplementation(project(":uitestutils"))
 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
@@ -7,6 +7,7 @@ import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
+import com.gravatar.quickeditor.data.AcceptedLanguageInterceptor
 import com.gravatar.quickeditor.data.FileUtils
 import com.gravatar.quickeditor.data.datastore.createEncryptedFileWithFallbackReset
 import com.gravatar.quickeditor.data.repository.AvatarRepository
@@ -17,6 +18,7 @@ import com.gravatar.services.AvatarService
 import com.gravatar.services.ProfileService
 import io.github.osipxd.security.crypto.createEncrypted
 import kotlinx.coroutines.Dispatchers
+import okhttp3.OkHttpClient
 
 internal class QuickEditorContainer private constructor(
     private val context: Context,
@@ -48,6 +50,12 @@ internal class QuickEditorContainer private constructor(
         DataStoreTokenStorage(dataStore = dataStore, dispatcher = Dispatchers.IO)
     }
 
+    private val okHttpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(AcceptedLanguageInterceptor(context))
+            .build()
+    }
+
     private var useInMemoryTokenStorage = false
 
     public val inMemoryTokenStorage: InMemoryTokenStorage by lazy {
@@ -58,7 +66,7 @@ internal class QuickEditorContainer private constructor(
         get() = if (useInMemoryTokenStorage) inMemoryTokenStorage else dataStoreTokenStorage
 
     private val avatarService: AvatarService by lazy {
-        AvatarService()
+        AvatarService(okHttpClient)
     }
 
     val profileService: ProfileService by lazy {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptor.kt
@@ -1,0 +1,43 @@
+package com.gravatar.quickeditor.data
+
+import android.content.Context
+import androidx.core.app.LocaleManagerCompat
+import androidx.core.os.LocaleListCompat
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import java.util.Locale
+
+internal class AcceptedLanguageInterceptor(private val context: Context) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.proceed(
+            chain.request().newBuilder()
+                .addAcceptedLanguageHeader(context.languagesList.asLocaleList.acceptedLanguageHeader).build(),
+        )
+    }
+
+    private fun Request.Builder.addAcceptedLanguageHeader(languages: String) = addHeader("Accept-Language", languages)
+
+    private val List<Locale>.acceptedLanguageHeader: String
+        get() {
+            var weight = 1.0F
+            return map { it.language }.reduce { accumulator, language ->
+                weight -= 0.1F
+                "$accumulator,$language;q=$weight"
+            }
+        }
+
+    private val LocaleListCompat.asLocaleList: List<Locale>
+        get() = buildList {
+            if (this@asLocaleList.size() > 0) {
+                for (index in 0 until this@asLocaleList.size()) {
+                    add(this@asLocaleList.get(index))
+                }
+            }
+        }.filterNotNull()
+
+    private val Context.languagesList: LocaleListCompat
+        get() = LocaleManagerCompat.getApplicationLocales(this).takeIf { localeListCompat ->
+            localeListCompat.size() > 0
+        } ?: LocaleManagerCompat.getSystemLocales(this)
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptor.kt
@@ -6,6 +6,7 @@ import androidx.core.os.LocaleListCompat
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
+import java.math.BigDecimal
 import java.util.Locale
 
 internal class AcceptedLanguageInterceptor(private val context: Context) : Interceptor {
@@ -20,10 +21,10 @@ internal class AcceptedLanguageInterceptor(private val context: Context) : Inter
 
     private val List<Locale>.acceptedLanguageHeader: String
         get() {
-            var weight = 1.0F
+            var weight = BigDecimal(1)
             return map { it.language }.reduce { accumulator, language ->
-                weight -= 0.1F
-                "$accumulator,$language;q=$weight"
+                weight -= BigDecimal(0.1)
+                "$accumulator,$language;q=${weight.toFloat()}"
             }
         }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptor.kt
@@ -27,18 +27,18 @@ internal class AcceptedLanguageInterceptor(private val context: Context) : Inter
                 "$accumulator,$language;q=${weight.toFloat()}"
             }
         }
-
-    private val LocaleListCompat.asLocaleList: List<Locale>
-        get() = buildList {
-            if (this@asLocaleList.size() > 0) {
-                for (index in 0 until this@asLocaleList.size()) {
-                    add(this@asLocaleList.get(index))
-                }
-            }
-        }.filterNotNull()
-
-    private val Context.languagesList: LocaleListCompat
-        get() = LocaleManagerCompat.getApplicationLocales(this).takeIf { localeListCompat ->
-            localeListCompat.size() > 0
-        } ?: LocaleManagerCompat.getSystemLocales(this)
 }
+
+internal val LocaleListCompat.asLocaleList: List<Locale>
+    get() = buildList {
+        if (this@asLocaleList.size() > 0) {
+            for (index in 0 until this@asLocaleList.size()) {
+                add(this@asLocaleList.get(index))
+            }
+        }
+    }.filterNotNull()
+
+internal val Context.languagesList: LocaleListCompat
+    get() = LocaleManagerCompat.getApplicationLocales(this).takeIf { localeListCompat ->
+        localeListCompat.size() > 0
+    } ?: LocaleManagerCompat.getSystemLocales(this)

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptorTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptorTest.kt
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import retrofit2.Call
 import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
 import java.util.Locale
 
@@ -37,7 +37,7 @@ class AcceptedLanguageInterceptorTest {
 
         api = Retrofit.Builder()
             .baseUrl(mockWebServer.url("/"))
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create())
             .client(client)
             .build()
             .create(TestApi::class.java)

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptorTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptorTest.kt
@@ -1,0 +1,78 @@
+package com.gravatar.quickeditor.data
+
+import android.content.Context
+import androidx.core.os.LocaleListCompat
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockkStatic
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+class AcceptedLanguageInterceptorTest {
+    private val mockWebServer = MockWebServer()
+
+    private lateinit var api: TestApi
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val testResponse = "\"name\""
+
+    @Before
+    fun setUp() {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AcceptedLanguageInterceptor(context))
+            .build()
+
+        api = Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/"))
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(client)
+            .build()
+            .create(TestApi::class.java)
+    }
+
+    @Test
+    fun `given one languages when intercepting then Accept-Language header set`() {
+        mockkStatic(Context::languagesList)
+        every { context.languagesList } returns LocaleListCompat.create(Locale.ENGLISH)
+        val successResponse = MockResponse().setBody(testResponse)
+        mockWebServer.enqueue(successResponse)
+
+        api.test().execute()
+
+        val request = mockWebServer.takeRequest()
+        val header = request.getHeader("Accept-Language")
+        assertEquals("en", header)
+    }
+
+    @Test
+    fun `given many languages when intercepting then Accept-Language header set`() {
+        mockkStatic(Context::languagesList)
+        every { context.languagesList } returns LocaleListCompat.create(Locale.ENGLISH, Locale.FRENCH, Locale.GERMANY)
+        val successResponse = MockResponse().setBody(testResponse)
+        mockWebServer.enqueue(successResponse)
+
+        api.test().execute()
+
+        val request = mockWebServer.takeRequest()
+        val header = request.getHeader("Accept-Language")
+        assertEquals("en,fr;q=0.9,de;q=0.8", header)
+    }
+}
+
+private interface TestApi {
+    @GET("/test")
+    fun test(): Call<String>
+}

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -20,7 +20,7 @@ internal class GravatarSdkContainer private constructor() {
         }
     }
 
-    val moshi = Moshi.Builder()
+    internal val moshi = Moshi.Builder()
         .add(KotlinJsonAdapterFactory())
         .add(URIJsonAdapter())
         .build()
@@ -35,12 +35,12 @@ internal class GravatarSdkContainer private constructor() {
 
     fun getGravatarV3Service(okHttpClient: OkHttpClient? = null, oauthToken: String? = null): GravatarApi {
         return getRetrofitApiV3Builder().apply {
-            client(okHttpClient ?: buildOkHttpClient(oauthToken))
+            client(okHttpClient.buildOkHttpClient(oauthToken))
         }.addConverterFactory(MoshiConverterFactory.create(moshi))
             .build().create(GravatarApi::class.java)
     }
 
-    private fun buildOkHttpClient(oauthToken: String?) = OkHttpClient()
+    private fun OkHttpClient?.buildOkHttpClient(oauthToken: String?) = (this ?: OkHttpClient())
         .newBuilder()
         .addInterceptor(AuthenticationInterceptor(oauthToken))
         .addInterceptor(AvatarUploadTimeoutInterceptor())

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -14,6 +14,9 @@ import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as Grav
 
 /**
  * Service for managing Gravatar avatars.
+ *
+ * @param okHttpClient The OkHttp client to use for making network requests.
+ * This client will be extended with Gravatar interceptors to set either API key or OAuth token.
  */
 public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
     private companion object {

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -11,6 +11,9 @@ import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as Grav
 
 /**
  * Service for managing Gravatar profiles.
+ *
+ * @param okHttpClient The OkHttp client to use for making network requests.
+ * This client will be extended with Gravatar interceptors to set either API key or OAuth token.
  */
 public class ProfileService(private val okHttpClient: OkHttpClient? = null) {
     private companion object {


### PR DESCRIPTION
Closes #311

### Description

I've taken a different approach than those discussed in #311. Instead of providing a specific option to set the languages when configuring the `Gravatar` object, I've decided to reuse what we currently offer - passing an `OkHttpClient` with an already specified interceptor.

To achieve that I had to modify how we use the provided `OkHttpClient` - instead of just using it and ignoring Gravatar interceptors, I'm using it as a base and putting our interceptors on top of it. 

I feel like this solution solves issues we had with previous suggestions:
- We don't need any extra dependencies in the `:gravatar` module
- Users don't have to implement custom language providers etc. 
- We can set the language header per service whenever needed, same for third-party devs using QE, we won't override their configs as they will have different `OkHttpClients`. 

### Testing Steps

Run QE while monitoring the network. Check the headers for `/me/avatars` endpoint. 
