### PR TITLE
QuickEditor: ProfileCard using AvatarQueryOptions when requesting the Avatar

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/ProfileCard.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/ProfileCard.kt
@@ -17,8 +17,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.gravatar.AvatarQueryOptions
 import com.gravatar.extensions.defaultProfile
 import com.gravatar.restapi.models.Profile
 import com.gravatar.ui.GravatarTheme
@@ -37,10 +39,13 @@ internal fun ProfileCard(profile: ComponentState<Profile>?, modifier: Modifier =
                     .background(backgroundColor)
                     .padding(horizontal = 16.dp, vertical = 11.dp),
                 avatar = {
+                    val size = 72.dp
+                    val sizePx = with(LocalDensity.current) { size.roundToPx() }
                     Avatar(
-                        state = profile.transform { profileValue -> profileValue.avatarUrl.toString() },
-                        size = 72.dp,
+                        state = profile.transform { profileValue -> profileValue.avatarUrl },
+                        size = size,
                         modifier = Modifier.clip(CircleShape),
+                        avatarQueryOptions = AvatarQueryOptions { preferredSize = sizePx },
                     )
                 },
             )

--- a/gravatar-ui/api/gravatar-ui.api
+++ b/gravatar-ui/api/gravatar-ui.api
@@ -143,7 +143,7 @@ public final class com/gravatar/ui/components/atomic/AboutMeKt {
 public final class com/gravatar/ui/components/atomic/AvatarKt {
 	public static final fun Avatar-DzVHIIc (Lcom/gravatar/restapi/models/Profile;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Avatar-DzVHIIc (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;Landroidx/compose/runtime/Composer;II)V
-	public static final fun AvatarWithURLComponentState (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun AvatarWithURLComponentState (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/gravatar/ui/components/atomic/ComposableSingletons$AboutMeKt {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.gravatar.AvatarQueryOptions
+import com.gravatar.asQueryParameters
 import com.gravatar.extensions.avatarUrl
 import com.gravatar.extensions.defaultProfile
 import com.gravatar.restapi.models.Profile
@@ -19,6 +20,8 @@ import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.LoadingToLoadedProfileStatePreview
 import com.gravatar.ui.components.isNightModeEnabled
 import com.gravatar.ui.skeletonEffect
+import java.net.URI
+import java.net.URL
 
 /**
  * [Avatar] is a composable that displays a user's avatar.
@@ -88,16 +91,24 @@ public fun Avatar(
  * @param state Avatar URL wrapped in ComponentState
  * @param size The size of the avatar
  * @param modifier Composable modifier
+ * @param avatarQueryOptions Options to customize the avatar query
  */
 @JvmName("AvatarWithURLComponentState")
 @Composable
-public fun Avatar(state: ComponentState<String>, size: Dp, modifier: Modifier = Modifier) {
+public fun Avatar(
+    state: ComponentState<URI>,
+    size: Dp,
+    modifier: Modifier = Modifier,
+    avatarQueryOptions: AvatarQueryOptions? = null,
+) {
     when (state) {
         is ComponentState.Loading -> SkeletonAvatar(size = size, modifier = modifier)
 
         is ComponentState.Loaded -> {
             Avatar(
-                model = state.loadedValue,
+                model = state.loadedValue.toURL()?.let { url ->
+                    URL(url.protocol, url.host, url.path.plus(avatarQueryOptions.asQueryParameters()))
+                }.toString(),
                 size = size,
                 modifier = modifier,
             )

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -28,6 +28,7 @@ public final class com/gravatar/AvatarQueryOptions$Builder {
 
 public final class com/gravatar/AvatarQueryOptionsKt {
 	public static final synthetic fun AvatarQueryOptions (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/AvatarQueryOptions;
+	public static final fun asQueryParameters (Lcom/gravatar/AvatarQueryOptions;)Ljava/lang/String;
 }
 
 public final class com/gravatar/AvatarUrl {

--- a/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
@@ -107,6 +107,9 @@ public fun AvatarQueryOptions(initializer: AvatarQueryOptions.Builder.() -> Unit
     return AvatarQueryOptions.Builder().apply(initializer).build()
 }
 
+/**
+ * Function to convert the [AvatarQueryOptions] to a string with the query parameters.
+ */
 public fun AvatarQueryOptions?.asQueryParameters(): String {
     val queryList = mutableListOf<String>()
     this?.defaultAvatarOption?.let {

--- a/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarQueryOptions.kt
@@ -1,5 +1,6 @@
 package com.gravatar
 
+import java.net.URLEncoder
 import java.util.Objects
 
 /**
@@ -104,4 +105,21 @@ public class AvatarQueryOptions private constructor(
 @JvmSynthetic // Hide from Java callers who should use Builder.
 public fun AvatarQueryOptions(initializer: AvatarQueryOptions.Builder.() -> Unit): AvatarQueryOptions {
     return AvatarQueryOptions.Builder().apply(initializer).build()
+}
+
+public fun AvatarQueryOptions?.asQueryParameters(): String {
+    val queryList = mutableListOf<String>()
+    this?.defaultAvatarOption?.let {
+        queryList.add("default=${URLEncoder.encode(it.queryParam(), "UTF-8")}")
+    } // eg. default monster, "d=monsterid"
+    this?.preferredSize?.let {
+        queryList.add("size=$it")
+    } // eg. size 42, "s=42"
+    this?.rating?.let {
+        queryList.add("rating=${it.rating}")
+    } // eg. rated pg, "r=pg"
+    this?.forceDefaultAvatar?.let {
+        queryList.add("forcedefault=${if (it) "y" else "n"}")
+    } // eg. force yes, "f=y"
+    return if (queryList.isEmpty()) "" else queryList.joinToString("&", "?")
 }

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -4,7 +4,6 @@ import com.gravatar.GravatarConstants.GRAVATAR_WWW_BASE_HOST
 import com.gravatar.types.Email
 import com.gravatar.types.Hash
 import java.net.URL
-import java.net.URLEncoder
 import java.util.Locale
 
 /**
@@ -30,23 +29,6 @@ public class AvatarUrl {
             // Only keep the protocol, host and path
             return URL(url.protocol, url.host, url.path)
         }
-    }
-
-    private fun queryParameters(avatarQueryOptions: AvatarQueryOptions?): String {
-        val queryList = mutableListOf<String>()
-        avatarQueryOptions?.defaultAvatarOption?.let {
-            queryList.add("d=${URLEncoder.encode(it.queryParam(), "UTF-8")}")
-        } // eg. default monster, "d=monsterid"
-        avatarQueryOptions?.preferredSize?.let {
-            queryList.add("s=$it")
-        } // eg. size 42, "s=42"
-        avatarQueryOptions?.rating?.let {
-            queryList.add("r=${it.rating}")
-        } // eg. rated pg, "r=pg"
-        avatarQueryOptions?.forceDefaultAvatar?.let {
-            queryList.add("f=${if (it) "y" else "n"}")
-        } // eg. force yes, "f=y"
-        return if (queryList.isEmpty()) "" else queryList.joinToString("&", "?")
     }
 
     /**
@@ -107,7 +89,7 @@ public class AvatarUrl {
         return URL(
             canonicalUrl.protocol,
             canonicalUrl.host,
-            canonicalUrl.path.plus(queryParameters(avatarQueryOptions)),
+            canonicalUrl.path.plus(avatarQueryOptions.asQueryParameters()),
         )
     }
 }

--- a/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
+++ b/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
@@ -26,7 +26,7 @@ class AvatarUrlTest {
     fun `AvatarUrl created via an email address must set the size but no other query param if not set`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
-                "?s=1000",
+                "?size=1000",
             AvatarUrl(
                 Email("example@example.com"),
                 AvatarQueryOptions { preferredSize = 1000 },
@@ -38,7 +38,7 @@ class AvatarUrlTest {
     fun `AvatarUrl created via an email address must add default avatar but no other query param if not set`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
-                "?d=monsterid",
+                "?default=monsterid",
             AvatarUrl(
                 Email("example@example.com"),
                 AvatarQueryOptions { defaultAvatarOption = MonsterId },
@@ -51,7 +51,7 @@ class AvatarUrlTest {
         assertEquals(
             URL(
                 "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
-                    "970a1e66?d=identicon&s=42",
+                    "970a1e66?default=identicon&size=42",
             ),
             AvatarUrl(
                 Email("example@example.com"),
@@ -68,7 +68,7 @@ class AvatarUrlTest {
         assertEquals(
             URL(
                 "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
-                    "970a1e66?d=robohash&s=42&r=x&f=y",
+                    "970a1e66?default=robohash&size=42&rating=x&forcedefault=y",
             ),
             AvatarUrl(
                 Email("example@example.com"),
@@ -89,7 +89,7 @@ class AvatarUrlTest {
             AvatarUrl(
                 URL(
                     "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
-                        "970a1e66?d=identicon&s=42",
+                        "970a1e66?default=identicon&size=42",
                 ),
             ).url().toString(),
         )
@@ -99,7 +99,7 @@ class AvatarUrlTest {
     fun `AvatarUrl created via an URL must add all supported parameters`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
-                "?d=identicon&s=42&r=pg&f=y",
+                "?default=identicon&size=42&rating=pg&forcedefault=y",
             AvatarUrl(
                 URL(
                     "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
@@ -122,7 +122,7 @@ class AvatarUrlTest {
             AvatarUrl(
                 URL(
                     "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
-                        "970a1e66?d=identicon&s=42",
+                        "970a1e66?default=identicon&size=42",
                 ),
             ).url().toString(),
         )
@@ -135,7 +135,7 @@ class AvatarUrlTest {
             AvatarUrl(
                 URL(
                     "http://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
-                        "970a1e66?d=identicon",
+                        "970a1e66?default=identicon",
                 ),
             ).url().toString(),
         )
@@ -145,11 +145,11 @@ class AvatarUrlTest {
     fun `keep host on gravatar dot com urls and set parameters`() {
         assertEquals(
             "https://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
-                "?d=identicon&s=42",
+                "?default=identicon&size=42",
             AvatarUrl(
                 URL(
                     "https://gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
-                        "970a1e66?d=identicon&s=42",
+                        "970a1e66?default=identicon&size=42",
                 ),
                 AvatarQueryOptions {
                     preferredSize = 42
@@ -163,11 +163,11 @@ class AvatarUrlTest {
     fun `AvatarUrl created via an URL must keep gravatar host and set parameters`() {
         assertEquals(
             "https://1.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
-                "?d=identicon&s=42",
+                "?default=identicon&size=42",
             AvatarUrl(
                 URL(
                     "https://1.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe" +
-                        "970a1e66?d=identicon&s=42",
+                        "970a1e66?default=identicon&size=42",
                 ),
                 AvatarQueryOptions {
                     preferredSize = 42
@@ -259,7 +259,7 @@ class AvatarUrlTest {
     fun `AvatarUrl created via an email address supports custom url and encode them`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
-                "?d=https%3A%2F%2Fexample.com%2F%3Fencoded%3Dtrue%26please%3Dyes",
+                "?default=https%3A%2F%2Fexample.com%2F%3Fencoded%3Dtrue%26please%3Dyes",
             AvatarUrl(
                 Email("example@example.com"),
                 AvatarQueryOptions {
@@ -270,10 +270,10 @@ class AvatarUrlTest {
     }
 
     @Test
-    fun `force default avatar false must generate f=n`() {
+    fun `force default avatar false must generate forcedefault=n`() {
         assertEquals(
             "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
-                "?f=n",
+                "?forcedefault=n",
             AvatarUrl(
                 Email("example@example.com"),
                 AvatarQueryOptions {


### PR DESCRIPTION
Closes #281 

### Description

The Avatar component used by ProfileCard didn't allow AvatarQueryOptions to pass, so we completely relied on the `String` used to specify the URL.

`/userimage` endpoint only accepts `size=512` as a query parameter, while `/avatar` accepts both, `s=512` and `size=512`. To be more consistent, this PR migrates the query params to their long-form. 

Using the long form allow us to modify the `Avatar` composable to accept those AvatarQueryOptions when the URL is from `/userimage`.

### Testing Steps

1. Smoke test the `Avatar Tab` in the demo app. Everything should work as before, but use the "long" query parameters.
2. In the `Avatar Update Tab` with the Network Inspector opened, switch between different images. 
3. Verify the request contains the `size` param

<img width="1253" alt="image" src="https://github.com/user-attachments/assets/ce1d5a73-4096-4fce-ae65-059cc35a97e3">
