### PR TITLE
QuickEditor: Specify the proper avatar size in the Avatar Sections

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
@@ -8,8 +8,11 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarUi
+import java.net.URL
 
 @Composable
 internal fun LazyAvatarRow(
@@ -30,6 +33,7 @@ internal fun LazyAvatarRow(
             Avatar(
                 avatar = avatarModel,
                 onAvatarSelected = { onAvatarSelected(avatarModel) },
+                size = avatarSize,
                 modifier = Modifier.size(avatarSize),
             )
         }
@@ -39,15 +43,18 @@ internal fun LazyAvatarRow(
 internal val avatarSize = 96.dp
 
 @Composable
-internal fun Avatar(avatar: AvatarUi, onAvatarSelected: (AvatarUi) -> Unit, modifier: Modifier) {
+internal fun Avatar(avatar: AvatarUi, size: Dp, onAvatarSelected: (AvatarUi) -> Unit, modifier: Modifier) {
     when (avatar) {
-        is AvatarUi.Uploaded -> SelectableAvatar(
-            imageUrl = avatar.avatar.imageUrl.toString(),
-            isSelected = avatar.isSelected,
-            loadingState = avatar.loadingState,
-            onAvatarClicked = { onAvatarSelected(avatar) },
-            modifier = modifier,
-        )
+        is AvatarUi.Uploaded -> {
+            val sizePx = with(LocalDensity.current) { size.roundToPx() }
+            SelectableAvatar(
+                imageUrl = avatar.imageUrlWithSize(sizePx),
+                isSelected = avatar.isSelected,
+                loadingState = avatar.loadingState,
+                onAvatarClicked = { onAvatarSelected(avatar) },
+                modifier = modifier,
+            )
+        }
 
         is AvatarUi.Local -> SelectableAvatar(
             imageUrl = avatar.uri.toString(),
@@ -58,6 +65,10 @@ internal fun Avatar(avatar: AvatarUi, onAvatarSelected: (AvatarUi) -> Unit, modi
         )
     }
 }
+
+private fun AvatarUi.Uploaded.imageUrlWithSize(sizePx: Int) = avatar.imageUrl.toURL()?.let { url ->
+    URL(url.protocol, url.host, url.path.plus("?size=$sizePx"))
+}.toString()
 
 private val AvatarUi.Uploaded.loadingState: AvatarLoadingState
     get() = if (isLoading) AvatarLoadingState.Loading else AvatarLoadingState.None

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/VerticalAvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/VerticalAvatarsSection.kt
@@ -129,6 +129,7 @@ internal fun VerticalAvatarsSection(
                         Avatar(
                             avatar = avatarModel,
                             onAvatarSelected = { onAvatarSelected(avatarModel) },
+                            size = avatarSize,
                             modifier = Modifier,
                         )
                     }


### PR DESCRIPTION
Closes #341

### Description

We should request the proper side for the images in the avatar list in the QE. This PR specifies the correct dimension using the `size` query parameter.

### Testing Steps

- Using a network inspector, open the QE and verify you can see the `/userimage` requests with the proper size. It should be different from 512 which is being returned by the backend in the URL.
<img width="316" alt="image" src="https://github.com/user-attachments/assets/501deebc-8447-4f99-b309-7891bf03d068">
