### PR TITLE
Remove appname from GravatarQuickEditorParams

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -162,7 +162,6 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
         }
     }
     if (showBottomSheet) {
-        val applicationName = stringResource(id = R.string.app_name)
         val authenticationMethod = if (useToken) {
             AuthenticationMethod.Bearer(userToken)
         } else {

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -175,7 +175,6 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
         }
         GravatarQuickEditorBottomSheet(
             gravatarQuickEditorParams = GravatarQuickEditorParams {
-                appName = applicationName
                 email = Email(userEmail)
                 avatarPickerContentLayout = pickerContentLayout
             },

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
@@ -21,6 +21,7 @@ import com.gravatar.demoapp.BuildConfig
 import com.gravatar.demoapp.R
 import com.gravatar.quickeditor.GravatarQuickEditor
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
+import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
 import com.gravatar.restapi.models.Profile
@@ -49,8 +50,8 @@ class QuickEditorTestActivity : AppCompatActivity() {
             GravatarQuickEditor.show(
                 activity = this,
                 gravatarQuickEditorParams = GravatarQuickEditorParams {
-                    appName = getString(R.string.app_name)
                     email = Email(BuildConfig.DEMO_EMAIL)
+                    avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal
                 },
                 authenticationMethod = AuthenticationMethod.OAuth(
                     OAuthParams {

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -242,9 +242,8 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorDismiss
 
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams {
 	public static final field $stable I
-	public synthetic fun <init> (Ljava/lang/String;Lcom/gravatar/types/Email;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAppName ()Ljava/lang/String;
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
 	public fun hashCode ()I
@@ -255,11 +254,8 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$
 	public static final field $stable I
 	public fun <init> ()V
 	public final fun build ()Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
-	public final fun getAppName ()Ljava/lang/String;
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
-	public final fun setAppName (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
-	public final synthetic fun setAppName (Ljava/lang/String;)V
 	public final fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)V
 	public final fun setEmail (Lcom/gravatar/types/Email;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
@@ -6,35 +6,28 @@ import java.util.Objects
 /**
  * All non-auth params required to launch the Gravatar Quick Editor
  *
- * @property appName The appName of the app that is launching the Quick Editor
  * @property email The email of the user
  * @property avatarPickerContentLayout The layout direction used in the Avatar Picker.
  */
 public class GravatarQuickEditorParams private constructor(
-    public val appName: String,
     public val email: Email,
     public val avatarPickerContentLayout: AvatarPickerContentLayout,
 ) {
-    override fun toString(): String = "GravatarQuickEditorParams(appName='$appName', email='$email')"
+    override fun toString(): String =
+        "GravatarQuickEditorParams(email='$email', avatarPickerContentLayout=$avatarPickerContentLayout)"
 
-    override fun hashCode(): Int = Objects.hash(appName, email)
+    override fun hashCode(): Int = Objects.hash(email, avatarPickerContentLayout)
 
     override fun equals(other: Any?): Boolean {
         return other is GravatarQuickEditorParams &&
-            appName == other.appName &&
-            email == other.email
+            email == other.email &&
+            avatarPickerContentLayout == other.avatarPickerContentLayout
     }
 
     /**
      * A type-safe builder for the GravatarQuickEditorParams class.
      */
     public class Builder {
-        /**
-         *  The appName of the app that is launching the Quick Editor
-         */
-        @set:JvmSynthetic // Hide 'void' setter from Java
-        public var appName: String? = null
-
         /**
          * The email of the user
          */
@@ -54,11 +47,6 @@ public class GravatarQuickEditorParams private constructor(
             apply { this.avatarPickerContentLayout = avatarPickerContentLayout }
 
         /**
-         * Sets the appName
-         */
-        public fun setAppName(appName: String): Builder = apply { this.appName = appName }
-
-        /**
          * Sets the email
          */
         public fun setEmail(email: Email): Builder = apply { this.email = email }
@@ -67,7 +55,6 @@ public class GravatarQuickEditorParams private constructor(
          * Builds the GravatarQuickEditorParams object
          */
         public fun build(): GravatarQuickEditorParams = GravatarQuickEditorParams(
-            appName!!,
             email!!,
             avatarPickerContentLayout,
         )


### PR DESCRIPTION


### Description

The `appName` is not used now, so let's remove it. Additionally, I've noticed some overridden functions were incorrectly implemented so fixed those as well. 

### Testing Steps

CI should be enough.