### PR TITLE
Rename Result to GravatarResult

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoGravatarApp.kt
@@ -68,8 +68,8 @@ import com.gravatar.demoapp.ui.model.SettingsState
 import com.gravatar.demoapp.ui.utils.prettyPrint
 import com.gravatar.restapi.models.Profile
 import com.gravatar.services.ErrorType
+import com.gravatar.services.GravatarResult
 import com.gravatar.services.ProfileService
-import com.gravatar.services.Result
 import com.gravatar.types.Email
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.components.ComponentState
@@ -259,13 +259,13 @@ private fun ProfileTab(modifier: Modifier = Modifier, onError: (String?, Throwab
                             error = ""
                             profileState = ComponentState.Loading
                             when (val result = profileService.retrieveCatching(Email(email))) {
-                                is Result.Success -> {
+                                is GravatarResult.Success -> {
                                     result.value.let {
                                         profileState = ComponentState.Loaded(it)
                                     }
                                 }
 
-                                is Result.Failure -> {
+                                is GravatarResult.Failure -> {
                                     when (result.error) {
                                         ErrorType.NotFound -> {
                                             profileState = ComponentState.Empty

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
@@ -25,8 +25,8 @@ import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
 import com.gravatar.restapi.models.Profile
+import com.gravatar.services.GravatarResult
 import com.gravatar.services.ProfileService
-import com.gravatar.services.Result
 import com.gravatar.types.Email
 import com.gravatar.ui.components.ComponentState
 import com.gravatar.ui.components.ProfileSummary
@@ -79,13 +79,13 @@ fun GravatarProfileSummary(emailAddress: String = "gravatar@automattic.com") {
     LaunchedEffect(emailAddress) {
         profileState = ComponentState.Loading
         when (val result = profileService.retrieveCatching(Email(emailAddress))) {
-            is Result.Success -> {
+            is GravatarResult.Success -> {
                 result.value.let {
                     profileState = ComponentState.Loaded(it)
                 }
             }
 
-            is Result.Failure -> {
+            is GravatarResult.Failure -> {
                 Log.e("Gravatar", result.error.toString())
                 profileState = ComponentState.Empty
             }

--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -97,13 +97,13 @@ fun GravatarProfileSummary(emailAddress: String = "gravatar@automattic.com") {
         profileState = ComponentState.Loading
         // Fetch the user profile
         when (val result = profileService.retrieve(Email(emailAddress))) {
-            is Result.Success -> {
+            is GravatarResult.Success -> {
                 // Update the profile state with the loaded profile
                 result.value.let {
                     profileState = ComponentState.Loaded(it)
                 }
             }
-            is Result.Failure -> {
+            is GravatarResult.Failure -> {
                 // An error can occur when a profile doesn't exist, if the phone is in airplane mode, etc.
                 // Here we log the error, but ideally we should show an error to the user.
                 Log.e("Gravatar", result.error.name)
@@ -165,13 +165,13 @@ fun GravatarProfileSummary(emailAddress: String = "gravatar@automattic.com") {
         profileState = ComponentState.Loading
         // Fetch the user profile
         when (val result = profileService.retrieve(Email(emailAddress))) {
-            is Result.Success -> {
+            is GravatarResult.Success -> {
                 // Update the profile state with the loaded profile
                 result.value.let {
                     profileState = ComponentState.Loaded(it)
                 }
             }
-            is Result.Failure -> {
+            is GravatarResult.Failure -> {
                 // An error can occur when a profile doesn't exist, if the phone is in airplane mode, etc.
                 // Here we log the error, but ideally we should show an error to the user.
                 Log.e("Gravatar", result.error.name)
@@ -197,12 +197,12 @@ For example, using the user's email:
 ```kotlin
 coroutineScope.launch {
     when (val profile = ProfileService().retrieve(Email("gravatar@automattic.com"))) {
-        is Result.Success -> {
+        is GravatarResult.Success -> {
             Log.d("Gravatar", "Profile: ${profile.value}")
             // Do something with the profile
         }
 
-        is Result.Failure -> {
+        is GravatarResult.Failure -> {
             Log.e("Gravatar", "Error: ${profile.error}")
             // Handle the error
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -14,8 +14,8 @@ import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.restapi.models.Profile
 import com.gravatar.services.ErrorType
+import com.gravatar.services.GravatarResult
 import com.gravatar.services.ProfileService
-import com.gravatar.services.Result
 import com.gravatar.types.Email
 import com.gravatar.ui.components.ComponentState
 import kotlinx.coroutines.channels.Channel
@@ -98,7 +98,7 @@ internal class AvatarPickerViewModel(
                     currentState.copy(selectingAvatarId = avatarId)
                 }
                 when (avatarRepository.selectAvatar(email, avatarId)) {
-                    is Result.Success -> {
+                    is GravatarResult.Success -> {
                         _uiState.update { currentState ->
                             currentState.copy(
                                 emailAvatars = currentState.emailAvatars?.copy(selectedAvatarId = avatarId),
@@ -109,7 +109,7 @@ internal class AvatarPickerViewModel(
                         _actions.send(AvatarPickerAction.AvatarSelected(avatar))
                     }
 
-                    is Result.Failure -> {
+                    is GravatarResult.Failure -> {
                         _uiState.update { currentState ->
                             currentState.copy(selectingAvatarId = null)
                         }
@@ -137,7 +137,7 @@ internal class AvatarPickerViewModel(
                 )
             }
             when (val result = avatarRepository.uploadAvatar(email, uri)) {
-                is Result.Success -> {
+                is GravatarResult.Success -> {
                     fileUtils.deleteFile(uri)
                     _uiState.update { currentState ->
                         val avatar = result.value
@@ -154,7 +154,7 @@ internal class AvatarPickerViewModel(
                     }
                 }
 
-                is Result.Failure -> {
+                is GravatarResult.Failure -> {
                     _uiState.update { currentState ->
                         currentState.copy(
                             uploadingAvatar = null,
@@ -175,13 +175,13 @@ internal class AvatarPickerViewModel(
         viewModelScope.launch {
             _uiState.update { currentState -> currentState.copy(profile = ComponentState.Loading) }
             when (val result = profileService.retrieveCatching(email)) {
-                is Result.Success -> {
+                is GravatarResult.Success -> {
                     _uiState.update { currentState ->
                         currentState.copy(profile = ComponentState.Loaded(result.value))
                     }
                 }
 
-                is Result.Failure -> {
+                is GravatarResult.Failure -> {
                     _uiState.update { currentState ->
                         currentState.copy(profile = null)
                     }
@@ -204,7 +204,7 @@ internal class AvatarPickerViewModel(
             _uiState.update { currentState -> currentState.copy(isLoading = true) }
         }
         when (val result = avatarRepository.getAvatars(email)) {
-            is Result.Success -> {
+            is GravatarResult.Success -> {
                 _uiState.update { currentState ->
                     val emailAvatars = result.value
                     currentState.copy(
@@ -222,7 +222,7 @@ internal class AvatarPickerViewModel(
                 }
             }
 
-            is Result.Failure -> {
+            is GravatarResult.Failure -> {
                 _uiState.update { currentState ->
                     currentState.copy(emailAvatars = null, isLoading = false, error = result.error.asSectionError)
                 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
@@ -6,8 +6,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.gravatar.quickeditor.QuickEditorContainer
 import com.gravatar.quickeditor.data.storage.TokenStorage
+import com.gravatar.services.GravatarResult
 import com.gravatar.services.ProfileService
-import com.gravatar.services.Result
 import com.gravatar.types.Email
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,7 +47,7 @@ internal class OAuthViewModel(
                 currentState.copy(status = OAuthStatus.Authorizing)
             }
             when (val result = profileService.checkAssociatedEmailCatching(token, email)) {
-                is Result.Success -> {
+                is GravatarResult.Success -> {
                     result.value.let {
                         if (it) {
                             tokenStorage.storeToken(email.hash().toString(), token)
@@ -60,7 +60,7 @@ internal class OAuthViewModel(
                     }
                 }
 
-                is Result.Failure -> {
+                is GravatarResult.Failure -> {
                     _uiState.update { currentState ->
                         currentState.copy(status = OAuthStatus.EmailAssociatedCheckError(token))
                     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -12,8 +12,8 @@ import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.restapi.models.Error
 import com.gravatar.services.ErrorType
+import com.gravatar.services.GravatarResult
 import com.gravatar.services.ProfileService
-import com.gravatar.services.Result
 import com.gravatar.types.Email
 import com.gravatar.ui.components.ComponentState
 import io.mockk.coEvery
@@ -61,14 +61,14 @@ class AvatarPickerViewModelTest {
 
     @Before
     fun setup() {
-        coEvery { profileService.retrieveCatching(email) } returns Result.Failure(ErrorType.Unknown)
-        coEvery { avatarRepository.getAvatars(email) } returns Result.Success(emailAvatars)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Failure(ErrorType.Unknown)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatars)
     }
 
     @Test
     fun `given view model initialization when avatars request succeed then uiState is updated`() = runTest {
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { avatarRepository.getAvatars(email) } returns Result.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
 
@@ -96,7 +96,7 @@ class AvatarPickerViewModelTest {
 
     @Test
     fun `given view model initialization when avatars request fails then uiState is updated`() = runTest {
-        coEvery { avatarRepository.getAvatars(email) } returns Result.Failure(QuickEditorError.Unknown)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
         viewModel = initViewModel()
 
@@ -118,7 +118,7 @@ class AvatarPickerViewModelTest {
 
     @Test
     fun `given view model initialization when fetch profile successful then uiState is updated`() = runTest {
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
 
         viewModel = initViewModel()
 
@@ -182,9 +182,9 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given avatar when selected successful then uiState is updated`() = runTest {
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { avatarRepository.getAvatars(email) } returns Result.Success(emailAvatarsCopy)
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
-        coEvery { avatarRepository.selectAvatar(any(), any()) } returns Result.Success(Unit)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+        coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
 
         viewModel = initViewModel()
 
@@ -225,9 +225,9 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given avatar when selected failure then uiState is updated`() = runTest {
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { avatarRepository.getAvatars(email) } returns Result.Success(emailAvatarsCopy)
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
-        coEvery { avatarRepository.selectAvatar(any(), any()) } returns Result.Failure(QuickEditorError.Unknown)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+        coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
         viewModel = initViewModel()
 
@@ -264,8 +264,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given avatar when reselected then nothing happens`() = runTest {
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
-        coEvery { avatarRepository.selectAvatar(any(), any()) } returns Result.Success(Unit)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+        coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
 
         viewModel = initViewModel()
 
@@ -301,10 +301,10 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         every { fileUtils.deleteFile(any()) } returns Unit
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val uploadedAvatar = createAvatar("3")
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns Result.Success(uploadedAvatar)
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
 
@@ -351,10 +351,10 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         every { fileUtils.deleteFile(any()) } returns Unit
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val uploadedAvatar = createAvatar("2")
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns Result.Success(uploadedAvatar)
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
 
@@ -406,10 +406,10 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         every { fileUtils.deleteFile(any()) } returns Unit
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns Result.Failure(invalidRequest)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
 
@@ -451,11 +451,11 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "2")
         every { fileUtils.deleteFile(any()) } returns Unit
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
-        } returns Result.Success(createAvatar("3"))
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
+        } returns GravatarResult.Success(createAvatar("3"))
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
 
@@ -485,11 +485,11 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "2")
         every { fileUtils.deleteFile(any()) } returns Unit
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
-        } returns Result.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
+        } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
 
@@ -520,9 +520,9 @@ class AvatarPickerViewModelTest {
         val uriTwo = mockk<Uri>()
         val emailAvatarsCopy = emailAvatars.copy(avatars = emptyList(), selectedAvatarId = null)
         every { fileUtils.deleteFile(any()) } returns Unit
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(emailAvatarsCopy)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns Result.Failure(invalidRequest)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriOne))
@@ -535,7 +535,7 @@ class AvatarPickerViewModelTest {
 
             coEvery {
                 avatarRepository.uploadAvatar(any(), any())
-            } returns Result.Success(createAvatar("1"))
+            } returns GravatarResult.Success(createAvatar("1"))
 
             viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriTwo))
             val avatarPickerUiState = AvatarPickerUiState(
@@ -582,9 +582,9 @@ class AvatarPickerViewModelTest {
     fun `given failed avatar upload when FailedAvatarTapped then UiState updated`() = runTest {
         val uri = mockk<Uri>()
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns Result.Failure(invalidRequest)
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(identityAvatarsCopy)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -604,11 +604,11 @@ class AvatarPickerViewModelTest {
     fun `given failed avatar upload dialog shown when FailedAvatarDismissed then UiState updated`() = runTest {
         val uri = mockk<Uri>()
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
-        } returns Result.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(identityAvatarsCopy)
+        } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -631,9 +631,9 @@ class AvatarPickerViewModelTest {
     fun `given failed avatar upload dialog shown when FailedAvatarDialogDismissed then UiState updated`() = runTest {
         val uri = mockk<Uri>()
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns Result.Failure(invalidRequest)
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(identityAvatarsCopy)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -656,11 +656,11 @@ class AvatarPickerViewModelTest {
     fun `given failed avatar upload dialog shown when ImageCropped then UiState updated`() = runTest {
         val uri = mockk<Uri>()
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
-        } returns Result.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns Result.Success(identityAvatarsCopy)
+        } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -683,8 +683,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given profile loaded when refresh then fetch profile not called`() = runTest {
-        coEvery { profileService.retrieveCatching(email) } returns Result.Success(profile)
-        coEvery { avatarRepository.getAvatars(email) } returns Result.Failure(QuickEditorError.Unknown)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Failure(QuickEditorError.Unknown)
         viewModel = initViewModel()
         advanceUntilIdle()
 

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
@@ -4,8 +4,8 @@ import app.cash.turbine.test
 import com.gravatar.quickeditor.data.storage.TokenStorage
 import com.gravatar.quickeditor.ui.CoroutineTestRule
 import com.gravatar.services.ErrorType
+import com.gravatar.services.GravatarResult
 import com.gravatar.services.ProfileService
-import com.gravatar.services.Result
 import com.gravatar.types.Email
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -46,7 +46,7 @@ class OAuthViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given oAuth params when token stored then email association checked sent`() = runTest {
-        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns Result.Success(true)
+        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns GravatarResult.Success(true)
 
         viewModel.tokenReceived(
             email,
@@ -59,7 +59,7 @@ class OAuthViewModelTest {
 
     @Test
     fun `given token when email associated then OAuthAction_AuthorizationSuccess sent`() = runTest {
-        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns Result.Success(true)
+        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns GravatarResult.Success(true)
 
         viewModel.tokenReceived(
             email,
@@ -75,7 +75,7 @@ class OAuthViewModelTest {
     @Test
     fun `given wrong email when restarting OAuth flow after email error then UiState_Status keeps the error state`() =
         runTest {
-            coEvery { profileService.checkAssociatedEmailCatching(any(), any()) } returns Result.Success(false)
+            coEvery { profileService.checkAssociatedEmailCatching(any(), any()) } returns GravatarResult.Success(false)
 
             viewModel.uiState.test {
                 assertEquals(OAuthUiState(OAuthStatus.LoginRequired), awaitItem())
@@ -89,7 +89,9 @@ class OAuthViewModelTest {
 
     @Test
     fun `given token when association check failed then UiState_Status updated`() = runTest {
-        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns Result.Failure(ErrorType.Unknown)
+        coEvery {
+            profileService.checkAssociatedEmailCatching(token, email)
+        } returns GravatarResult.Failure(ErrorType.Unknown)
 
         viewModel.uiState.test {
             expectMostRecentItem()
@@ -104,7 +106,9 @@ class OAuthViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given token when association check failed then token stored`() = runTest {
-        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns Result.Failure(ErrorType.Unknown)
+        coEvery {
+            profileService.checkAssociatedEmailCatching(token, email)
+        } returns GravatarResult.Failure(ErrorType.Unknown)
 
         viewModel.tokenReceived(
             email,
@@ -119,7 +123,7 @@ class OAuthViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given token when email associated then token stored sent`() = runTest {
-        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns Result.Success(true)
+        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns GravatarResult.Success(true)
 
         viewModel.tokenReceived(
             email,
@@ -133,7 +137,7 @@ class OAuthViewModelTest {
 
     @Test
     fun `given token when email not associated then UiState updated`() = runTest {
-        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns Result.Success(false)
+        coEvery { profileService.checkAssociatedEmailCatching(token, email) } returns GravatarResult.Success(false)
 
         viewModel.tokenReceived(
             email,

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -698,6 +698,32 @@ public abstract interface class com/gravatar/services/GravatarListener {
 	public abstract fun onSuccess (Ljava/lang/Object;)V
 }
 
+public abstract class com/gravatar/services/GravatarResult {
+	public final fun valueOrNull ()Ljava/lang/Object;
+}
+
+public final class com/gravatar/services/GravatarResult$Failure : com/gravatar/services/GravatarResult {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/gravatar/services/GravatarResult$Failure;
+	public static synthetic fun copy$default (Lcom/gravatar/services/GravatarResult$Failure;Ljava/lang/Object;ILjava/lang/Object;)Lcom/gravatar/services/GravatarResult$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/GravatarResult$Success : com/gravatar/services/GravatarResult {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/gravatar/services/GravatarResult$Success;
+	public static synthetic fun copy$default (Lcom/gravatar/services/GravatarResult$Success;Ljava/lang/Object;ILjava/lang/Object;)Lcom/gravatar/services/GravatarResult$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/services/HttpException : java/lang/RuntimeException {
 	public final fun getCode ()I
 	public fun getMessage ()Ljava/lang/String;
@@ -718,32 +744,6 @@ public final class com/gravatar/services/ProfileService {
 	public final fun retrieveCatching (Lcom/gravatar/types/Email;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieveCatching (Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieveCatching (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract class com/gravatar/services/Result {
-	public final fun valueOrNull ()Ljava/lang/Object;
-}
-
-public final class com/gravatar/services/Result$Failure : com/gravatar/services/Result {
-	public fun <init> (Ljava/lang/Object;)V
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;)Lcom/gravatar/services/Result$Failure;
-	public static synthetic fun copy$default (Lcom/gravatar/services/Result$Failure;Ljava/lang/Object;ILjava/lang/Object;)Lcom/gravatar/services/Result$Failure;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getError ()Ljava/lang/Object;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/gravatar/services/Result$Success : com/gravatar/services/Result {
-	public fun <init> (Ljava/lang/Object;)V
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;)Lcom/gravatar/services/Result$Success;
-	public static synthetic fun copy$default (Lcom/gravatar/services/Result$Success;Ljava/lang/Object;ILjava/lang/Object;)Lcom/gravatar/services/Result$Success;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/Object;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/gravatar/types/Email {

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -51,15 +51,17 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
 
     /**
      * Uploads an image to be used as Gravatar avatar.
-     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
      *
      * @param file The image file to upload
      * @param oauthToken The OAuth token to use for authentication
      * @return The result of the operation
      */
-    public suspend fun uploadCatching(file: File, oauthToken: String): Result<Avatar, ErrorType> = runCatchingRequest {
-        upload(file, oauthToken)
-    }
+    public suspend fun uploadCatching(file: File, oauthToken: String): GravatarResult<Avatar, ErrorType> =
+        runCatchingRequest {
+            upload(file, oauthToken)
+        }
 
     /**
      * Retrieves a list of available avatars for the authenticated user.
@@ -88,13 +90,14 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
 
     /**
      * Retrieves a list of available avatars for the authenticated user.
-     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
      *
      * @param oauthToken The OAuth token to use for authentication
      * @param hash The hash of the email to associate the avatars with
      * @return The list of avatars
      */
-    public suspend fun retrieveCatching(oauthToken: String, hash: Hash): Result<List<Avatar>, ErrorType> =
+    public suspend fun retrieveCatching(oauthToken: String, hash: Hash): GravatarResult<List<Avatar>, ErrorType> =
         runCatchingRequest {
             retrieve(oauthToken, hash)
         }
@@ -126,15 +129,19 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
 
     /**
      * Sets the avatar for the given email (hash).
-     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
      *
      * @param hash The hash of the email to set the avatar for
      * @param avatarId The ID of the avatar to set
      * @param oauthToken The OAuth token to use for authentication
      * @return The result of the operation
      */
-    public suspend fun setAvatarCatching(hash: String, avatarId: String, oauthToken: String): Result<Unit, ErrorType> =
-        runCatchingRequest {
-            setAvatar(hash, avatarId, oauthToken)
-        }
+    public suspend fun setAvatarCatching(
+        hash: String,
+        avatarId: String,
+        oauthToken: String,
+    ): GravatarResult<Unit, ErrorType> = runCatchingRequest {
+        setAvatar(hash, avatarId, oauthToken)
+    }
 }

--- a/gravatar/src/main/java/com/gravatar/services/GravatarResult.kt
+++ b/gravatar/src/main/java/com/gravatar/services/GravatarResult.kt
@@ -3,7 +3,7 @@ package com.gravatar.services
 /**
  * Class representing the result of a network operation.
  */
-public sealed class Result<T, E> {
+public sealed class GravatarResult<T, E> {
     /**
      * Represents a successful fetch operation.
      *
@@ -11,7 +11,7 @@ public sealed class Result<T, E> {
      * @param E The error type
      * @property value The fetched value
      */
-    public data class Success<T, E>(public val value: T) : Result<T, E>()
+    public data class Success<T, E>(public val value: T) : GravatarResult<T, E>()
 
     /**
      * Represents a failed fetch operation.
@@ -20,7 +20,7 @@ public sealed class Result<T, E> {
      * @param E The error type
      * @property error The error that occurred
      */
-    public data class Failure<T, E>(public val error: E) : Result<T, E>()
+    public data class Failure<T, E>(public val error: E) : GravatarResult<T, E>()
 
     /**
      * Shortcut function to ignore a failure.

--- a/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ProfileService.kt
@@ -49,14 +49,16 @@ public class ProfileService(private val okHttpClient: OkHttpClient? = null) {
 
     /**
      * Fetches a Gravatar profile for the given hash or username.
-     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
      *
      * @param hashOrUsername The hash or username to fetch the profile for
      * @return The fetched profile
      */
-    public suspend fun retrieveCatching(hashOrUsername: String): Result<Profile, ErrorType> = runCatchingRequest {
-        retrieve(hashOrUsername)
-    }
+    public suspend fun retrieveCatching(hashOrUsername: String): GravatarResult<Profile, ErrorType> =
+        runCatchingRequest {
+            retrieve(hashOrUsername)
+        }
 
     /**
      * Fetches a Gravatar profile for the given email address.
@@ -71,12 +73,13 @@ public class ProfileService(private val okHttpClient: OkHttpClient? = null) {
 
     /**
      * Fetches a Gravatar profile for the given email address.
-     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
      *
      * @param email The email address to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveCatching(email: Email): Result<Profile, ErrorType> = runCatchingRequest {
+    public suspend fun retrieveCatching(email: Email): GravatarResult<Profile, ErrorType> = runCatchingRequest {
         retrieve(email.hash())
     }
 
@@ -93,12 +96,13 @@ public class ProfileService(private val okHttpClient: OkHttpClient? = null) {
 
     /**
      * Fetches a Gravatar profile for the given hash.
-     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
      *
      * @param hash The hash to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveCatching(hash: Hash): Result<Profile, ErrorType> = runCatchingRequest {
+    public suspend fun retrieveCatching(hash: Hash): GravatarResult<Profile, ErrorType> = runCatchingRequest {
         retrieve(hash)
     }
 
@@ -115,14 +119,16 @@ public class ProfileService(private val okHttpClient: OkHttpClient? = null) {
 
     /**
      * Fetches a Gravatar profile for the given username.
-     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
      *
      * @param username The username to fetch the profile for
      * @return The fetched profiles
      */
-    public suspend fun retrieveByUsernameCatching(username: String): Result<Profile, ErrorType> = runCatchingRequest {
-        retrieveByUsername(username)
-    }
+    public suspend fun retrieveByUsernameCatching(username: String): GravatarResult<Profile, ErrorType> =
+        runCatchingRequest {
+            retrieveByUsername(username)
+        }
 
     /**
      * Checks if the given email address is associated with the already authorized Gravatar account.
@@ -151,14 +157,17 @@ public class ProfileService(private val okHttpClient: OkHttpClient? = null) {
 
     /**
      * Checks if the given email address is associated with the already authorized Gravatar account.
-     * This method will catch any exception that occurs during the execution and return it as a [Result.Failure].
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
      *
      * @param oauthToken The OAuth token to use for authentication
      * @param email The email address to check
      * @return True if the email is associated with the account, false otherwise
      */
-    public suspend fun checkAssociatedEmailCatching(oauthToken: String, email: Email): Result<Boolean, ErrorType> =
-        runCatchingRequest {
-            checkAssociatedEmail(oauthToken, email)
-        }
+    public suspend fun checkAssociatedEmailCatching(
+        oauthToken: String,
+        email: Email,
+    ): GravatarResult<Boolean, ErrorType> = runCatchingRequest {
+        checkAssociatedEmail(oauthToken, email)
+    }
 }

--- a/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
@@ -3,18 +3,18 @@ package com.gravatar.services
 import com.gravatar.di.container.GravatarSdkContainer
 import kotlinx.coroutines.CancellationException
 
-internal inline fun <T> runCatchingRequest(block: () -> T?): Result<T, ErrorType> {
+internal inline fun <T> runCatchingRequest(block: () -> T?): GravatarResult<T, ErrorType> {
     @Suppress("TooGenericExceptionCaught")
     return try {
         val result = block()
         if (result != null) {
-            Result.Success(result)
+            GravatarResult.Success(result)
         } else {
-            Result.Failure(ErrorType.NotFound)
+            GravatarResult.Failure(ErrorType.NotFound)
         }
     } catch (cancellationException: CancellationException) {
         throw cancellationException
     } catch (ex: Exception) {
-        Result.Failure(ex.errorType(GravatarSdkContainer.instance.moshi))
+        GravatarResult.Failure(ex.errorType(GravatarSdkContainer.instance.moshi))
     }
 }

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -95,7 +95,7 @@ class AvatarServiceTest {
             )
         }
 
-        assertTrue(response is Result.Success)
+        assertTrue(response is GravatarResult.Success)
     }
 
     @Test
@@ -120,7 +120,7 @@ class AvatarServiceTest {
             )
         }
 
-        assertEquals(ErrorType.Server, (response as Result.Failure).error)
+        assertEquals(ErrorType.Server, (response as GravatarResult.Failure).error)
     }
 
     @Test
@@ -163,7 +163,7 @@ class AvatarServiceTest {
 
         val response = avatarService.setAvatarCatching(hash, avatarId, oauthToken)
 
-        assertEquals(Unit, (response as Result.Success).value)
+        assertEquals(Unit, (response as GravatarResult.Success).value)
     }
 
     @Test
@@ -180,6 +180,6 @@ class AvatarServiceTest {
 
             val response = avatarService.setAvatarCatching(hash, avatarId, oauthToken)
 
-            assertEquals(ErrorType.Server, (response as Result.Failure).error)
+            assertEquals(ErrorType.Server, (response as GravatarResult.Failure).error)
         }
 }

--- a/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ProfileServiceTests.kt
@@ -44,7 +44,7 @@ class ProfileServiceTests {
         val loadProfileResponse = profileService.retrieveByUsernameCatching(username)
 
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
-        assertTrue(loadProfileResponse is Result.Success)
+        assertTrue(loadProfileResponse is GravatarResult.Success)
     }
 
     @Test
@@ -60,7 +60,7 @@ class ProfileServiceTests {
             val loadProfileResponse = profileService.retrieveByUsernameCatching(username)
 
             coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
-            assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
+            assertTrue((loadProfileResponse as GravatarResult.Failure).error == ErrorType.Unknown)
         }
 
     @Test
@@ -75,7 +75,7 @@ class ProfileServiceTests {
             val loadProfileResponse = profileService.retrieveByUsernameCatching(username)
 
             coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
-            assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
+            assertTrue((loadProfileResponse as GravatarResult.Failure).error == ErrorType.Unknown)
         }
 
     @Test
@@ -92,7 +92,7 @@ class ProfileServiceTests {
         val loadProfileResponse = profileService.retrieveCatching(usernameHash)
 
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(usernameHash.toString()) }
-        assertTrue(loadProfileResponse is Result.Success)
+        assertTrue(loadProfileResponse is GravatarResult.Success)
     }
 
     @Test
@@ -109,7 +109,7 @@ class ProfileServiceTests {
         val loadProfileResponse = profileService.retrieveCatching(usernameEmail)
 
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(usernameEmail.hash().toString()) }
-        assertTrue(loadProfileResponse is Result.Success)
+        assertTrue(loadProfileResponse is GravatarResult.Success)
     }
 
     @Test
@@ -120,7 +120,7 @@ class ProfileServiceTests {
         val loadProfileResponse = profileService.retrieveByUsernameCatching(username)
 
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(username) }
-        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
+        assertTrue((loadProfileResponse as GravatarResult.Failure).error == ErrorType.Unknown)
     }
 
     @Test
@@ -132,7 +132,7 @@ class ProfileServiceTests {
 
         val loadProfileResponse = profileService.retrieveCatching(usernameEmail)
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(usernameEmail.hash().toString()) }
-        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
+        assertTrue((loadProfileResponse as GravatarResult.Failure).error == ErrorType.Unknown)
     }
 
     @Test
@@ -144,7 +144,7 @@ class ProfileServiceTests {
 
         val loadProfileResponse = profileService.retrieveCatching(usernameHash)
         coVerify(exactly = 1) { containerRule.gravatarApiMock.getProfileById(usernameHash.toString()) }
-        assertTrue((loadProfileResponse as Result.Failure).error == ErrorType.Unknown)
+        assertTrue((loadProfileResponse as GravatarResult.Failure).error == ErrorType.Unknown)
     }
 
     @Test
@@ -160,7 +160,7 @@ class ProfileServiceTests {
             containerRule.gravatarApiMock.getProfileById(username)
         } returns mockResponse
 
-        assertEquals(ErrorType.NotFound, (profileService.retrieveCatching(username) as Result.Failure).error)
+        assertEquals(ErrorType.NotFound, (profileService.retrieveCatching(username) as GravatarResult.Failure).error)
     }
 
     // Throwing Exception Version of the methods
@@ -255,7 +255,14 @@ class ProfileServiceTests {
                 containerRule.gravatarApiMock.associatedEmail(usernameEmail.hash().toString())
             } returns mockResponse
 
-            assertTrue((profileService.checkAssociatedEmailCatching(oauthToken, usernameEmail) as Result.Success).value)
+            assertTrue(
+                (
+                    profileService.checkAssociatedEmailCatching(
+                        oauthToken,
+                        usernameEmail,
+                    ) as GravatarResult.Success
+                ).value,
+            )
         }
 
     @Test
@@ -275,7 +282,12 @@ class ProfileServiceTests {
             } returns mockResponse
 
             assertFalse(
-                (profileService.checkAssociatedEmailCatching(oauthToken, usernameEmail) as Result.Success).value,
+                (
+                    profileService.checkAssociatedEmailCatching(
+                        oauthToken,
+                        usernameEmail,
+                    ) as GravatarResult.Success
+                ).value,
             )
         }
 
@@ -295,7 +307,7 @@ class ProfileServiceTests {
             } returns mockResponse
 
             val result = profileService.checkAssociatedEmailCatching(oauthToken, usernameEmail)
-            assertTrue((result as Result.Failure).error == ErrorType.Unknown)
+            assertTrue((result as GravatarResult.Failure).error == ErrorType.Unknown)
         }
 
     @Test(expected = IllegalStateException::class)


### PR DESCRIPTION
Closes #296 

### Description

As per the discussion in #296 - the `Result` could be easily confused with `kotlin.Result` so we won't to rename it for less confusion and better autocompletion. 

### Testing Steps

CI should be fine. Check the docs.
