### PR TITLE
QuickEditor: ProfileCard using forceRefresh option for Avatar

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -146,10 +147,13 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
                     .fillMaxWidth()
                     .padding(bottom = 10.dp),
             )
-            ProfileCard(
-                profile = uiState.profile,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
+            key(uiState.emailAvatars?.selectedAvatarId) {
+                ProfileCard(
+                    profile = uiState.profile,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+
             val sectionModifier = Modifier.padding(top = 24.dp, bottom = 10.dp)
             when {
                 uiState.isLoading -> Box(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -12,7 +12,6 @@ import com.gravatar.quickeditor.data.repository.AvatarRepository
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.restapi.models.Avatar
-import com.gravatar.restapi.models.Profile
 import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import com.gravatar.services.ProfileService
@@ -103,7 +102,6 @@ internal class AvatarPickerViewModel(
                             currentState.copy(
                                 emailAvatars = currentState.emailAvatars?.copy(selectedAvatarId = avatarId),
                                 selectingAvatarId = null,
-                                profile = currentState.profile?.copy { copyAvatar(avatar) },
                             )
                         }
                         _actions.send(AvatarPickerAction.AvatarSelected(avatar))
@@ -262,38 +260,6 @@ internal class AvatarPickerViewModelFactory(
             avatarRepository = QuickEditorContainer.getInstance().avatarRepository,
             fileUtils = QuickEditorContainer.getInstance().fileUtils,
         ) as T
-    }
-}
-
-internal fun Profile.copyAvatar(avatar: Avatar): Profile {
-    return Profile {
-        hash = this@copyAvatar.hash
-        displayName = this@copyAvatar.displayName
-        profileUrl = this@copyAvatar.profileUrl
-        avatarUrl = avatar.imageUrl
-        avatarAltText = avatar.altText
-        location = this@copyAvatar.location
-        description = this@copyAvatar.description
-        jobTitle = this@copyAvatar.jobTitle
-        description = this@copyAvatar.description
-        jobTitle = this@copyAvatar.jobTitle
-        company = this@copyAvatar.company
-        verifiedAccounts = this@copyAvatar.verifiedAccounts
-        pronunciation = this@copyAvatar.pronunciation
-        pronouns = this@copyAvatar.pronouns
-        timezone = this@copyAvatar.timezone
-        languages = this@copyAvatar.languages
-        firstName = this@copyAvatar.firstName
-        lastName = this@copyAvatar.lastName
-        isOrganization = this@copyAvatar.isOrganization
-        links = this@copyAvatar.links
-        interests = this@copyAvatar.interests
-        payments = this@copyAvatar.payments
-        contactInfo = this@copyAvatar.contactInfo
-        gallery = this@copyAvatar.gallery
-        numberVerifiedAccounts = this@copyAvatar.numberVerifiedAccounts
-        lastProfileEdit = this@copyAvatar.lastProfileEdit
-        registrationDate = this@copyAvatar.registrationDate
     }
 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -18,6 +18,7 @@ import com.gravatar.services.ProfileService
 import com.gravatar.types.Email
 import com.gravatar.ui.components.ComponentState
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -33,6 +34,10 @@ internal class AvatarPickerViewModel(
     private val avatarRepository: AvatarRepository,
     private val fileUtils: FileUtils,
 ) : ViewModel() {
+    private companion object {
+        const val AVATAR_SWITCH_DELAY = 800L
+    }
+
     private val _uiState =
         MutableStateFlow(AvatarPickerUiState(email = email, avatarPickerContentLayout = avatarPickerContentLayout))
     val uiState: StateFlow<AvatarPickerUiState> = _uiState.asStateFlow()
@@ -98,6 +103,9 @@ internal class AvatarPickerViewModel(
                 }
                 when (avatarRepository.selectAvatar(email, avatarId)) {
                     is GravatarResult.Success -> {
+                        // Delay to wait until the server has updated the selected avatar before updating the UI
+                        // Hopefully, we can remove this delay soon
+                        delay(AVATAR_SWITCH_DELAY)
                         _uiState.update { currentState ->
                             currentState.copy(
                                 emailAvatars = currentState.emailAvatars?.copy(selectedAvatarId = avatarId),

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/ProfileCard.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/ProfileCard.kt
@@ -38,9 +38,10 @@ internal fun ProfileCard(profile: ComponentState<Profile>?, modifier: Modifier =
                     .padding(horizontal = 16.dp, vertical = 11.dp),
                 avatar = {
                     Avatar(
-                        state = profile.transform { profileValue -> profileValue.avatarUrl.toString() },
+                        state = profile,
                         size = 72.dp,
                         modifier = Modifier.clip(CircleShape),
+                        forceRefresh = true,
                     )
                 },
             )
@@ -83,10 +84,4 @@ private fun ProfileCardPreview() {
             modifier = Modifier.padding(20.dp),
         )
     }
-}
-
-private fun <T, O> ComponentState<T>.transform(transform: (T) -> O): ComponentState<O> = when (this) {
-    is ComponentState.Empty -> ComponentState.Empty
-    is ComponentState.Loading -> ComponentState.Loading
-    is ComponentState.Loaded -> ComponentState.Loaded(transform(loadedValue))
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -209,7 +209,6 @@ class AvatarPickerViewModelTest {
             assertEquals(
                 avatarPickerUiState.copy(
                     emailAvatars = emailAvatarsCopy.copy(selectedAvatarId = avatars.last().imageId),
-                    profile = ComponentState.Loaded(profile.copyAvatar(avatars.last())),
                     selectingAvatarId = null,
                     scrollToIndex = 0,
                 ),

--- a/gravatar-ui/api/gravatar-ui.api
+++ b/gravatar-ui/api/gravatar-ui.api
@@ -141,9 +141,8 @@ public final class com/gravatar/ui/components/atomic/AboutMeKt {
 }
 
 public final class com/gravatar/ui/components/atomic/AvatarKt {
-	public static final fun Avatar-DzVHIIc (Lcom/gravatar/restapi/models/Profile;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;Landroidx/compose/runtime/Composer;II)V
-	public static final fun Avatar-DzVHIIc (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;Landroidx/compose/runtime/Composer;II)V
-	public static final fun AvatarWithURLComponentState (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Avatar-EUb7tLY (Lcom/gravatar/restapi/models/Profile;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;ZLandroidx/compose/runtime/Composer;II)V
+	public static final fun Avatar-EUb7tLY (Lcom/gravatar/ui/components/ComponentState;FLandroidx/compose/ui/Modifier;Lcom/gravatar/AvatarQueryOptions;ZLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/gravatar/ui/components/atomic/ComposableSingletons$AboutMeKt {

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -43,7 +43,8 @@ public final class com/gravatar/AvatarUrl {
 	public final fun getHash ()Lcom/gravatar/types/Hash;
 	public final fun isAvatarUrl ()Z
 	public final fun setAvatarQueryOptions (Lcom/gravatar/AvatarQueryOptions;)V
-	public final fun url ()Ljava/net/URL;
+	public final fun url (Ljava/lang/String;)Ljava/net/URL;
+	public static synthetic fun url$default (Lcom/gravatar/AvatarUrl;Ljava/lang/String;ILjava/lang/Object;)Ljava/net/URL;
 }
 
 public final class com/gravatar/AvatarUrl$Companion {

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -32,7 +32,7 @@ public class AvatarUrl {
         }
     }
 
-    private fun queryParameters(avatarQueryOptions: AvatarQueryOptions?): String {
+    private fun queryParameters(avatarQueryOptions: AvatarQueryOptions?, cacheBuster: String?): String {
         val queryList = mutableListOf<String>()
         avatarQueryOptions?.defaultAvatarOption?.let {
             queryList.add("d=${URLEncoder.encode(it.queryParam(), "UTF-8")}")
@@ -46,6 +46,9 @@ public class AvatarUrl {
         avatarQueryOptions?.forceDefaultAvatar?.let {
             queryList.add("f=${if (it) "y" else "n"}")
         } // eg. force yes, "f=y"
+        cacheBuster?.let {
+            queryList.add("_=$it")
+        } // eg. cache buster, "cacheBuster=1234567890"
         return if (queryList.isEmpty()) "" else queryList.joinToString("&", "?")
     }
 
@@ -103,11 +106,11 @@ public class AvatarUrl {
      *
      * @return [URL] for the avatar
      */
-    public fun url(): URL {
+    public fun url(cacheBuster: String? = null): URL {
         return URL(
             canonicalUrl.protocol,
             canonicalUrl.host,
-            canonicalUrl.path.plus(queryParameters(avatarQueryOptions)),
+            canonicalUrl.path.plus(queryParameters(avatarQueryOptions, cacheBuster)),
         )
     }
 }

--- a/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
+++ b/gravatar/src/test/java/com/gravatar/AvatarUrlTest.kt
@@ -282,4 +282,15 @@ class AvatarUrlTest {
             ).url().toString(),
         )
     }
+
+    @Test
+    fun `when cacheBuster is informed them cacheBuster is added when generating the avatar url`() {
+        assertEquals(
+            "https://www.gravatar.com/avatar/31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66" +
+                "?_=cacheBuster",
+            AvatarUrl(
+                Email("example@example.com"),
+            ).url(cacheBuster = "cacheBuster").toString(),
+        )
+    }
 }


### PR DESCRIPTION
Closes #281 

### Description

This PR uses a different approach than #340 to solve #281.

As discussed [here](https://github.com/Automattic/Gravatar-SDK-Android/pull/340#discussion_r1784288363) we can implement a `forceRefresh` param in the `Avatar` composable.

With this approach, we don't need a new Avatar composable. In addition, we increase the versatility of our current component.

If `forceRefresh` is enabled, everytime the `Avatar` composable is recomposed we'll update the cache buster internally. When we switch off that flag, we'll continue using the last `cacheBuster` used.

On the QE side, as the profile does not change, we need to force the recomposition. In this case, we use the "key" with the selected image ID.

**Important:** To me, this approach looks better than #340 and also reduces the number of composables we need to maintain. However, the avatar is not always updated as expected because we request the new avatar too fast. We'll need to introduce a delay to postpone the recomposition a bit. You can reproduce it by switching between already uploaded avatars. Wdyt?

<details>
<summary> Without delay </summary>

https://github.com/user-attachments/assets/d299f9fb-2dee-41f1-9313-61e93d4ba529
</details>

<details>
<summary> With Delay </summary>

https://github.com/user-attachments/assets/0c948716-90e4-4c68-bd6b-2142164ed40e
</details>

### Testing Steps

1. Smoke test the `Avatar Tab` in the demo app. Everything should work as before.
2. In the `Avatar Update Tab` with the Network Inspector opened, switch between different images. 
3. Verify the request contains the `size` param and the `cacheBuster`

<img width="673" alt="image" src="https://github.com/user-attachments/assets/5f6cc826-eba5-47b1-9155-dda188a67439">

