### PR TITLE
Add sdk headers to all Gravatar REST API requests

### DIFF
--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -50,6 +50,14 @@ public final class com/gravatar/AvatarUrl {
 public final class com/gravatar/AvatarUrl$Companion {
 }
 
+public final class com/gravatar/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field SDK_VERSION Ljava/lang/String;
+	public fun <init> ()V
+}
+
 public abstract class com/gravatar/DefaultAvatarOption {
 	public final fun queryParam ()Ljava/lang/String;
 }

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -13,6 +13,10 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
+val sdkVersion = providers.exec {
+    commandLine("git", "describe", "--tags", "--abbrev=0")
+}.standardOutput.asText.get().trim()
+
 android {
     namespace = "com.gravatar"
     compileSdk = 34
@@ -22,7 +26,7 @@ android {
         minSdk = 21
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
-        buildConfigField("String", "SDK_VERSION", "\"1.1.0\"")
+        buildConfigField("String", "SDK_VERSION", "\"$sdkVersion\"")
     }
 
     buildTypes {

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -16,11 +16,13 @@ plugins {
 android {
     namespace = "com.gravatar"
     compileSdk = 34
+    buildFeatures.buildConfig = true
 
     defaultConfig {
         minSdk = 21
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+        buildConfigField("String", "SDK_VERSION", "\"1.1.0\"")
     }
 
     buildTypes {

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -2,9 +2,10 @@ package com.gravatar.di.container
 
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V3
 import com.gravatar.moshiadapers.URIJsonAdapter
+import com.gravatar.services.GravatarApi
 import com.gravatar.services.interceptors.AuthenticationInterceptor
 import com.gravatar.services.interceptors.AvatarUploadTimeoutInterceptor
-import com.gravatar.services.GravatarApi
+import com.gravatar.services.interceptors.SdkVersionInterceptor
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.CoroutineDispatcher
@@ -44,5 +45,6 @@ internal class GravatarSdkContainer private constructor() {
         .newBuilder()
         .addInterceptor(AuthenticationInterceptor(oauthToken))
         .addInterceptor(AvatarUploadTimeoutInterceptor())
+        .addInterceptor(SdkVersionInterceptor())
         .build()
 }

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -2,8 +2,8 @@ package com.gravatar.di.container
 
 import com.gravatar.GravatarConstants.GRAVATAR_API_BASE_URL_V3
 import com.gravatar.moshiadapers.URIJsonAdapter
-import com.gravatar.services.AuthenticationInterceptor
-import com.gravatar.services.AvatarUploadTimeoutInterceptor
+import com.gravatar.services.interceptors.AuthenticationInterceptor
+import com.gravatar.services.interceptors.AvatarUploadTimeoutInterceptor
 import com.gravatar.services.GravatarApi
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory

--- a/gravatar/src/main/java/com/gravatar/services/interceptors/AuthenticationInterceptor.kt
+++ b/gravatar/src/main/java/com/gravatar/services/interceptors/AuthenticationInterceptor.kt
@@ -1,9 +1,9 @@
-package com.gravatar.services
+package com.gravatar.services.interceptors
 
+import com.gravatar.di.container.GravatarSdkContainer
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
-import com.gravatar.di.container.GravatarSdkContainer.Companion.instance as GravatarSdkDI
 
 internal class AuthenticationInterceptor(private val oauthToken: String? = null) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -15,7 +15,7 @@ internal class AuthenticationInterceptor(private val oauthToken: String? = null)
     }
 
     private fun Request.Builder.addAuthorizationHeaderIfPresent(): Request.Builder {
-        return oauthToken?.let { addHeader(it) } ?: GravatarSdkDI.apiKey?.let { addHeader(it) } ?: this
+        return oauthToken?.let { addHeader(it) } ?: GravatarSdkContainer.instance.apiKey?.let { addHeader(it) } ?: this
     }
 
     private fun Request.Builder.addHeader(bearer: String) = addHeader("Authorization", "Bearer $bearer")

--- a/gravatar/src/main/java/com/gravatar/services/interceptors/AvatarUploadTimeoutInterceptor.kt
+++ b/gravatar/src/main/java/com/gravatar/services/interceptors/AvatarUploadTimeoutInterceptor.kt
@@ -1,4 +1,4 @@
-package com.gravatar.services
+package com.gravatar.services.interceptors
 
 import okhttp3.Interceptor
 import okhttp3.Response

--- a/gravatar/src/main/java/com/gravatar/services/interceptors/SdkVersionInterceptor.kt
+++ b/gravatar/src/main/java/com/gravatar/services/interceptors/SdkVersionInterceptor.kt
@@ -1,0 +1,16 @@
+package com.gravatar.services.interceptors
+
+import com.gravatar.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.Response
+
+internal class SdkVersionInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.proceed(
+            chain.request().newBuilder()
+                .addHeader("X-Platform", "Android")
+                .addHeader("X-SDK-Version", BuildConfig.SDK_VERSION)
+                .build(),
+        )
+    }
+}


### PR DESCRIPTION
Closes #349

### Description

To track the adoption of the SDK we want to be able to filter API request by those from the SDK. 

This PR adds the source `Android` and the version of the SDK.

I didn't want to hardcode the version and require us to update it manually so I've included this via `BuildConfig`. That means I had to enable this class to be generated and it's public so it's exposed. What do you think about this? Can we make it internal somehow? 

### Testing Steps
Run the demo app and inspect request headers. There should be two extra: `X-Platform: Android` and  `X-SDK-Version: 1.1.0`