### PR TITLE
QuickEditor: Preventing Avatar in ProfileCard to recompose twice when QE is opened

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -145,7 +145,7 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
                     .fillMaxWidth()
                     .padding(bottom = 10.dp),
             )
-            key(uiState.emailAvatars?.selectedAvatarId) {
+            key(uiState.avatarUpdates) {
                 ProfileCard(
                     profile = uiState.profile,
                     modifier = Modifier.padding(horizontal = 16.dp),

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerUiState.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerUiState.kt
@@ -20,6 +20,7 @@ internal data class AvatarPickerUiState(
     val scrollToIndex: Int? = null,
     val failedUploads: Set<AvatarUploadFailure> = emptySet(),
     val failedUploadDialog: AvatarUploadFailure? = null,
+    val avatarUpdates: Int = 0,
 ) {
     val avatarsSectionUiState: AvatarsSectionUiState? = emailAvatars?.mapToUiModel()?.let {
         AvatarsSectionUiState(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -110,6 +110,7 @@ internal class AvatarPickerViewModel(
                             currentState.copy(
                                 emailAvatars = currentState.emailAvatars?.copy(selectedAvatarId = avatarId),
                                 selectingAvatarId = null,
+                                avatarUpdates = currentState.avatarUpdates.inc(),
                             )
                         }
                         _actions.send(AvatarPickerAction.AvatarSelected)

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -201,6 +201,7 @@ class AvatarPickerViewModelTest {
                 selectingAvatarId = avatars.last().imageId,
                 scrollToIndex = 0,
                 avatarPickerContentLayout = avatarPickerContentLayout,
+                avatarUpdates = 0,
             )
             assertEquals(
                 avatarPickerUiState,
@@ -211,6 +212,7 @@ class AvatarPickerViewModelTest {
                     emailAvatars = emailAvatarsCopy.copy(selectedAvatarId = avatars.last().imageId),
                     selectingAvatarId = null,
                     scrollToIndex = 0,
+                    avatarUpdates = 1,
                 ),
                 awaitItem(),
             )


### PR DESCRIPTION
Closes #357 

### Description

ProfileCard recomposition depended on both `uiState.emailAvatars?.selectedAvatarId` and `uiState.profile`. Therefore, when the bottom sheet was opened, we could load the avatar twice, creating a visual blink.

Depending on a different ui state that it's only updated when the avatar is updated should solve this issue.

### Testing Steps

1. Open the QE bottom sheet
2. Verify the Avatar in the ProfileCard is only loaded once (you don't see a blink)
3. Switch the selected image
4. Verify the Avatar is updated
