### PR TITLE
Proguard rules for :gravatar module

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -68,7 +68,9 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            signingConfig = signingConfigs.findByName("debug")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/gravatar/consumer-rules.pro
+++ b/gravatar/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.gravatar.restapi.models.** { *; }


### PR DESCRIPTION
Closes #345

### Description

This PR provides pro guard rules that will be shipped with our SDK so that our code won't crash if `isMinifyEnabled` in third-party app is enabled.

### Testing Steps

Run the demo app with the release build type and try to test each tab. Ideally, test `trunk` first to confirm there was an issue (crash).