### PR TITLE
Add X-Source header to Gravatar REST API request

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/MainActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/MainActivity.kt
@@ -13,7 +13,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // Initialize the Gravatar SDK with the API key if it is available
-        BuildConfig.DEMO_GRAVATAR_API_KEY?.let { Gravatar.apiKey(it).context(this) }
+        BuildConfig.DEMO_GRAVATAR_API_KEY?.let { Gravatar.apiKey(it).context(applicationContext) }
 
         setContent {
             DemoGravatarApp()

--- a/demo-app/src/main/java/com/gravatar/demoapp/MainActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/MainActivity.kt
@@ -13,7 +13,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // Initialize the Gravatar SDK with the API key if it is available
-        BuildConfig.DEMO_GRAVATAR_API_KEY?.let { Gravatar.initialize(it) }
+        BuildConfig.DEMO_GRAVATAR_API_KEY?.let { Gravatar.apiKey(it).context(this) }
 
         setContent {
             DemoGravatarApp()

--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -63,7 +63,7 @@ android {
 Then you can access the API key in your app's code like this:
 
 ```kotlin
-Gravatar.initialize(BuildConfig.GRAVATAR_API_KEY)
+Gravatar.apiKey(BuildConfig.GRAVATAR_API_KEY).context(appContext)
 ```
 
 # Usage

--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -63,7 +63,8 @@ android {
 Then you can access the API key in your app's code like this:
 
 ```kotlin
-Gravatar.apiKey(BuildConfig.GRAVATAR_API_KEY).context(appContext)
+Gravatar.apiKey(BuildConfig.GRAVATAR_API_KEY)
+    .context(appContext) // Optional but highly encouraged.
 ```
 
 # Usage

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -136,7 +136,8 @@ public final class com/gravatar/DefaultAvatarOption$Wavatar : com/gravatar/Defau
 
 public final class com/gravatar/Gravatar {
 	public static final field INSTANCE Lcom/gravatar/Gravatar;
-	public final fun initialize (Ljava/lang/String;)V
+	public final fun apiKey (Ljava/lang/String;)Lcom/gravatar/Gravatar;
+	public final fun context (Landroid/content/Context;)Lcom/gravatar/Gravatar;
 }
 
 public final class com/gravatar/GravatarConstants {

--- a/gravatar/src/main/java/com/gravatar/Gravatar.kt
+++ b/gravatar/src/main/java/com/gravatar/Gravatar.kt
@@ -1,5 +1,7 @@
 package com.gravatar
 
+import android.content.Context
+import android.content.pm.PackageManager
 import com.gravatar.di.container.GravatarSdkContainer
 
 /**
@@ -9,9 +11,29 @@ public object Gravatar {
     /**
      * Initializes the Gravatar SDK with the given API key.
      *
-     * @param gravatarApiKey The API key to use when making requests to the Gravatar backend.
+     * @param apiKey The API key to use when making requests to the Gravatar backend.
      */
-    public fun initialize(gravatarApiKey: String) {
-        GravatarSdkContainer.instance.apiKey = gravatarApiKey
+    public fun apiKey(apiKey: String): Gravatar {
+        GravatarSdkContainer.instance.apiKey = apiKey
+        return this
+    }
+
+    /**
+     * Initializes the Gravatar SDK with the given context.
+     * The context is used to get the application name.
+     *
+     * @param context The context from the app.
+     */
+    public fun context(context: Context): Gravatar {
+        GravatarSdkContainer.instance.appName = getApplicationName(context)
+        return this
+    }
+
+    private fun getApplicationName(context: Context): String {
+        val applicationInfo = context.packageManager.getApplicationInfo(
+            context.packageName,
+            PackageManager.GET_META_DATA,
+        )
+        return context.packageManager.getApplicationLabel(applicationInfo).toString()
     }
 }

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -33,6 +33,7 @@ internal class GravatarSdkContainer private constructor() {
     val dispatcherIO = Dispatchers.IO
 
     var apiKey: String? = null
+    var appName: String? = null
 
     fun getGravatarV3Service(okHttpClient: OkHttpClient? = null, oauthToken: String? = null): GravatarApi {
         return getRetrofitApiV3Builder().apply {

--- a/gravatar/src/main/java/com/gravatar/services/interceptors/SdkVersionInterceptor.kt
+++ b/gravatar/src/main/java/com/gravatar/services/interceptors/SdkVersionInterceptor.kt
@@ -1,16 +1,18 @@
 package com.gravatar.services.interceptors
 
 import com.gravatar.BuildConfig
+import com.gravatar.di.container.GravatarSdkContainer
 import okhttp3.Interceptor
 import okhttp3.Response
 
 internal class SdkVersionInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         return chain.proceed(
-            chain.request().newBuilder()
-                .addHeader("X-Platform", "Android")
-                .addHeader("X-SDK-Version", BuildConfig.SDK_VERSION)
-                .build(),
+            chain.request().newBuilder().apply {
+                addHeader("X-Platform", "Android")
+                addHeader("X-SDK-Version", BuildConfig.SDK_VERSION)
+                GravatarSdkContainer.instance.appName?.let { addHeader("X-Source", it) }
+            }.build(),
         )
     }
 }

--- a/gravatar/src/test/java/com/gravatar/GravatarTest.kt
+++ b/gravatar/src/test/java/com/gravatar/GravatarTest.kt
@@ -1,6 +1,11 @@
 package com.gravatar
 
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
 import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Rule
 import org.junit.Test
 
@@ -12,8 +17,26 @@ class GravatarTest {
     fun `given an api key when initialize method is invoked with it then it should be set internally`() {
         val apiKey = "API_KEY"
 
-        Gravatar.initialize(apiKey)
+        Gravatar.apiKey(apiKey)
 
         coVerify(exactly = 1) { containerRule.gravatarSdkContainerMock.apiKey = apiKey }
+    }
+
+    @Test
+    fun `given a context when initialize method is invoked then the app name is extracted`() {
+        val appName = "Gravatar APP"
+        val packageName = "com.gravatar"
+        val context = mockk<Context>()
+        val packageManager = mockk<PackageManager>()
+        val applicationInfo = mockk<ApplicationInfo>()
+
+        every { context.packageManager } returns packageManager
+        every { context.packageName } returns packageName
+        every { packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA) } returns applicationInfo
+        every { packageManager.getApplicationLabel(applicationInfo) } returns appName
+
+        Gravatar.context(context)
+
+        coVerify(exactly = 1) { containerRule.gravatarSdkContainerMock.appName = appName }
     }
 }


### PR DESCRIPTION
Closes #360 

### Description

This is a follow-up of #353. 

Having the request's source can help understand how developers use the SDK and their needs.

If the app provides the SDK with the context through the `Gravatar` object, we'll use that context to extract the application's name and send it in the `X-Source` header. 

Currently, we only use the `Context` for that purpose; it's optional to provide it. When it's not provided, we won't send the header.

### Testing Steps

1. Navigate to the QE tab in the demo-app
2. Switch through different avatars (Any QE request should work).
3. With the `Network Inspector`, verify you can see the header
<img width="325" alt="image" src="https://github.com/user-attachments/assets/138a94a4-3883-4a7e-91fa-ebe472d76670">

4. In the demo-app code, remove the context from the initialization and run the demo-app
```
// Initialize the Gravatar SDK with the API key if it is available
BuildConfig.DEMO_GRAVATAR_API_KEY?.let { Gravatar.apiKey(it) }
``` 
5. Navigate to the QE tab in the demo-app
6. Switch through different avatars
7. With the `Network Inspector`, verify you CAN'T see the header
8. Everything else works as expected.
