### PR TITLE
Don't remember cacheBuster on Avatar

### DIFF
--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/Avatar.kt
@@ -4,10 +4,6 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,7 +27,8 @@ import com.gravatar.ui.skeletonEffect
  * @param size The size of the avatar
  * @param modifier Composable modifier
  * @param avatarQueryOptions Options to customize the avatar query
- * @param forceRefresh While this is true, we'll force the refresh of the avatar in every recomposition
+ * @param forceRefresh While this is true, we'll force the refresh of the avatar in every recomposition.
+ *              When false, we'll use the default URL for that profile (without cache buster) to fetch the avatar.
  */
 @Composable
 public fun Avatar(
@@ -42,10 +39,10 @@ public fun Avatar(
     forceRefresh: Boolean = false,
 ) {
     val sizePx = with(LocalDensity.current) { size.roundToPx() }
-    var cacheBuster by rememberSaveable { mutableStateOf<String?>(null) }
-
-    if (forceRefresh) {
-        cacheBuster = System.currentTimeMillis().toString()
+    val cacheBuster = if (forceRefresh) {
+        System.currentTimeMillis().toString()
+    } else {
+        null
     }
 
     Avatar(


### PR DESCRIPTION
Closes #362

### Description

We were saving the `cacheBuster` value, including between configuration changes, which produced an infinite loop of recompositions. After thinking about this, when forceRefresh is `true`, we'll update the cache buster in every recomposition, so it doesn't make sense to remember the `cacheBuster`.

Also, when forceRefresh is `false`, as a developer, I would expect the component to use the default avatar URL for the given profile.

### Testing Steps

1. Open the QE
2. Change the device orientation (or follow the steps described [here](https://github.com/Automattic/Gravatar-SDK-Android/issues/362#issue-2572523808))
3. Verify the avatar is visible (you can also verify with the Network Inspector that is requested just one time)
