### PR TITLE
QuickEditor: Refreshing all info when no avatar selected and a new one is uploaded

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -146,18 +146,26 @@ internal class AvatarPickerViewModel(
             when (val result = avatarRepository.uploadAvatar(email, uri)) {
                 is GravatarResult.Success -> {
                     fileUtils.deleteFile(uri)
-                    _uiState.update { currentState ->
-                        val avatar = result.value
-                        currentState.copy(
-                            uploadingAvatar = null,
-                            emailAvatars = currentState.emailAvatars?.copy(
-                                avatars = buildList {
-                                    add(avatar)
-                                    addAll(currentState.emailAvatars.avatars.filter { it.imageId != avatar.imageId })
-                                },
-                            ),
-                            scrollToIndex = null,
-                        )
+                    val isAutoSelected = _uiState.value.emailAvatars?.selectedAvatarId == null
+                    if (isAutoSelected) {
+                        _uiState.update { AvatarPickerUiState(email, avatarPickerContentLayout) }
+                        refresh()
+                    } else {
+                        _uiState.update { currentState ->
+                            val avatar = result.value
+                            currentState.copy(
+                                uploadingAvatar = null,
+                                emailAvatars = currentState.emailAvatars?.copy(
+                                    avatars = buildList {
+                                        add(avatar)
+                                        addAll(
+                                            currentState.emailAvatars.avatars.filter { it.imageId != avatar.imageId },
+                                        )
+                                    },
+                                ),
+                                scrollToIndex = null,
+                            )
+                        }
                     }
                 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -155,6 +155,9 @@ internal class AvatarPickerViewModel(
                                 avatarUpdates = currentState.avatarUpdates.inc(),
                             )
                         }
+                        if (_uiState.value.emailAvatars?.selectedAvatarId != null) {
+                            _actions.send(AvatarPickerAction.AvatarSelected)
+                        }
                     } else {
                         _uiState.update { currentState ->
                             val avatar = result.value

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -148,8 +148,13 @@ internal class AvatarPickerViewModel(
                     fileUtils.deleteFile(uri)
                     val isAutoSelected = _uiState.value.emailAvatars?.selectedAvatarId == null
                     if (isAutoSelected) {
-                        _uiState.update { AvatarPickerUiState(email, avatarPickerContentLayout) }
-                        refresh()
+                        fetchAvatars(showLoading = false, scrollToSelected = true)
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                uploadingAvatar = null,
+                                avatarUpdates = currentState.avatarUpdates.inc(),
+                            )
+                        }
                     } else {
                         _uiState.update { currentState ->
                             val avatar = result.value
@@ -225,9 +230,9 @@ internal class AvatarPickerViewModel(
                     currentState.copy(
                         emailAvatars = emailAvatars,
                         scrollToIndex = if (scrollToSelected && emailAvatars.avatars.isNotEmpty()) {
-                            emailAvatars.avatars.indexOfFirst {
+                            emailAvatars.avatars.indexOfFirstOrNull {
                                 it.imageId == emailAvatars.selectedAvatarId
-                            }.coerceAtLeast(0)
+                            }
                         } else {
                             null
                         },
@@ -280,8 +285,7 @@ internal class AvatarPickerViewModelFactory(
     }
 }
 
-private fun <T> ComponentState<T>.copy(transform: T.() -> T): ComponentState<T> = when (this) {
-    is ComponentState.Loaded -> ComponentState.Loaded(loadedValue.transform())
-    is ComponentState.Loading -> this
-    is ComponentState.Empty -> this
+private inline fun <T> List<T>.indexOfFirstOrNull(predicate: (T) -> Boolean): Int? {
+    val index = indexOfFirst { predicate(it) }
+    return if (index == -1) null else index
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -519,7 +519,7 @@ class AvatarPickerViewModelTest {
     fun `given multiple failed uploads when upload successful then uiState is updated`() = runTest {
         val uriOne = mockk<Uri>()
         val uriTwo = mockk<Uri>()
-        val emailAvatarsCopy = emailAvatars.copy(avatars = emptyList(), selectedAvatarId = null)
+        val emailAvatarsCopy = emailAvatars.copy(avatars = listOf(createAvatar("3")), selectedAvatarId = "3")
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
@@ -558,7 +558,7 @@ class AvatarPickerViewModelTest {
             )
             assertEquals(
                 avatarPickerUiState.copy(
-                    emailAvatars = emailAvatarsCopy.copy(avatars = listOf(createAvatar("1"))),
+                    emailAvatars = emailAvatarsCopy.copy(avatars = listOf(createAvatar("1"), createAvatar("3"))),
                     uploadingAvatar = null,
                     scrollToIndex = null,
                 ),

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -778,6 +778,9 @@ class AvatarPickerViewModelTest {
                 awaitItem(),
             )
         }
+        viewModel.actions.test {
+            assertEquals(AvatarPickerAction.AvatarSelected, awaitItem())
+        }
     }
 
     private fun initViewModel(handleExpiredSession: Boolean = true) = AvatarPickerViewModel(


### PR DESCRIPTION
Closes #380 

### Description

When a new avatar is uploaded into a Gravatar account with no avatar selected, the backend automatically uses that image as the default avatar.

We need to reflect that in the QE UI. We can hardcode the changes in the code, modifying the uiState as required. However, if the backend behavior changes at some point, all previous versions of the QE will show the wrong status of the Gravatar account.

To mitigate that situation, we will refresh all data from the backend if an image is uploaded and no previous avatar is selected.

What do you think about this approach? Do you think it's worth it to refresh everything or assume the risk and modify the uiState locally, expecting the backend to do the same?

**Note:** I'll add some unit tests before merging if we decide to go this way.

### Testing Steps

1. Using an account with no avatar selected
2. Upload a new image using the QE
3. Verify you see, after reloading, the new image as the selected image.