### PR TITLE
Migrate the ModalBottomSheet to Compose Unstyled

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ startup = "1.1.1"
 moshi = "1.15.1"
 testCoreKtx = "1.6.1"
 mockwebserver = "4.12.0"
-composablesCore = "1.14.0"
+composablesCore = "1.15.0"
 
 [libraries]
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ startup = "1.1.1"
 moshi = "1.15.1"
 testCoreKtx = "1.6.1"
 mockwebserver = "4.12.0"
+composablesCore = "1.14.0"
 
 [libraries]
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
@@ -76,7 +77,8 @@ roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", versi
 roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }
 roborazzi-junit-rule = { group = "io.github.takahirom.roborazzi", name = "roborazzi-junit-rule", version.ref = "roborazzi" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver"}
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
+composables-core = {group = "com.composables", name = "core", version.ref = "composablesCore" }
 
 
 [plugins]

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -94,13 +94,6 @@ public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$Q
 	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$QEDragHandleKt {
-	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/components/ComposableSingletons$QEDragHandleKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
-}
-
 public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$QESectionMessageKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/components/ComposableSingletons$QESectionMessageKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
@@ -257,13 +250,6 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$
 
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParamsKt {
 	public static final synthetic fun GravatarQuickEditorParams (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
-}
-
-public final class com/gravatar/quickeditor/ui/editor/bottomsheet/ComposableSingletons$GravatarQuickEditorBottomSheetKt {
-	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/editor/bottomsheet/ComposableSingletons$GravatarQuickEditorBottomSheetKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheetKt {

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -121,6 +121,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.compose.adaptive)
     debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.composables.core)
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk.android)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/QEDragHandle.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/QEDragHandle.kt
@@ -1,28 +1,26 @@
 package com.gravatar.quickeditor.ui.components
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.composables.core.BottomSheetScope
+import com.composables.core.DragIndication
 
 @Composable
-internal fun QEDragHandle(modifier: Modifier = Modifier) {
-    Surface(
+internal fun BottomSheetScope.QEDragHandle(modifier: Modifier = Modifier) {
+    DragIndication(
         modifier = modifier
-            .padding(top = 10.dp),
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-    ) {
-        Box(
-            Modifier
-                .size(
-                    width = 32.dp,
-                    height = 4.dp,
-                ),
-        )
-    }
+            .padding(top = 10.dp)
+            .background(
+                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                MaterialTheme.shapes.extraLarge,
+            )
+            .width(32.dp)
+            .height(4.dp),
+    )
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.gravatar.quickeditor.ui.editor.bottomsheet
 
+import android.graphics.Color
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -23,7 +24,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.window.core.layout.WindowHeightSizeClass
+import com.composables.core.LocalModalWindow
 import com.composables.core.ModalBottomSheet
 import com.composables.core.ModalBottomSheetState
 import com.composables.core.Scrim
@@ -141,6 +144,11 @@ private fun GravatarModalBottomSheet(
                             .asPaddingValues(),
                     ),
             ) {
+                val window = LocalModalWindow.current
+                LaunchedEffect(Unit) {
+                    window.navigationBarColor = Color.TRANSPARENT
+                    WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars = true
+                }
                 Surface(
                     modifier = Modifier
                         .fillMaxWidth(),

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -3,6 +3,7 @@ package com.gravatar.quickeditor.ui.editor.bottomsheet
 import android.graphics.Color
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -145,9 +146,11 @@ private fun GravatarModalBottomSheet(
                     ),
             ) {
                 val window = LocalModalWindow.current
+                val isDarkTheme = isSystemInDarkTheme()
                 LaunchedEffect(Unit) {
                     window.navigationBarColor = Color.TRANSPARENT
-                    WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars = true
+                    WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
+                        !isDarkTheme
                 }
                 Surface(
                     modifier = Modifier

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
@@ -2,21 +2,18 @@ package com.gravatar.quickeditor.ui.editor.extensions
 
 import android.view.ViewGroup
 import androidx.activity.compose.BackHandler
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetValue
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
+import com.composables.core.SheetDetent.Companion.Hidden
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
+import com.gravatar.quickeditor.ui.editor.bottomsheet.rememberGravatarModalBottomSheetState
 import kotlinx.coroutines.launch
 
 internal fun addQuickEditorToView(
@@ -42,7 +39,6 @@ internal fun addQuickEditorToView(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun GravatarQuickEditorBottomSheetWrapper(
     parent: ViewGroup,
@@ -53,9 +49,10 @@ private fun GravatarQuickEditorBottomSheetWrapper(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    var isSheetOpened by remember { mutableStateOf(false) }
 
-    val modalBottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val modalBottomSheetState = rememberGravatarModalBottomSheetState(
+        avatarPickerContentLayout = gravatarQuickEditorParams.avatarPickerContentLayout,
+    )
 
     GravatarQuickEditorBottomSheet(
         gravatarQuickEditorParams = gravatarQuickEditorParams,
@@ -67,23 +64,15 @@ private fun GravatarQuickEditorBottomSheetWrapper(
 
     BackHandler {
         coroutineScope.launch {
-            modalBottomSheetState.hide()
+            modalBottomSheetState.currentDetent = Hidden
         }
-        onDismiss(GravatarQuickEditorDismissReason.Finished)
     }
 
-    LaunchedEffect(modalBottomSheetState.currentValue) {
-        when (modalBottomSheetState.currentValue) {
-            SheetValue.Hidden -> {
-                if (isSheetOpened) {
-                    parent.removeView(composeView)
-                } else {
-                    isSheetOpened = true
-                    modalBottomSheetState.show()
-                }
+    LaunchedEffect(modalBottomSheetState.currentDetent) {
+        when (modalBottomSheetState.currentDetent) {
+            Hidden -> {
+                parent.removeView(composeView)
             }
-
-            else -> Unit
         }
     }
 }


### PR DESCRIPTION
Closes #378

### Description

We want to stop relying on experimental Material3 components. We use two: `ModalBottomSheet` and `CenterAlignedTopBar`. This PR removes the first one and replaces it with the one from [Compose Unstyled library](https://github.com/composablehorizons/compose-unstyled). [Here are the docs for this component](https://composeunstyled.com/modal-bottom-sheet/). 

Known issue: 
~- I do have a problem with how the `Scrim` is drawn when in horizontal mode with a camera cutout. It seems like insets are applied and the scrim can't be drawn fully. This works fine on the emulator though.~ Reported [here](https://github.com/composablehorizons/compose-unstyled/issues/27)

EDIT: ALready fixed in 1.15.0


### Testing Steps

Smoke test the QE including the XML activity. Apart from the above-mentioned issue, there should be no visual differences. 