### PR TITLE
Remove backup rules from quickeditor manifest

### DIFF
--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -314,12 +314,12 @@ GravatarQuickEditor.logout(Email("{USER_EMAIL}"))
 #### Exclude Data Store files from Android backup (optional, but recommended)
 
 Data Store files are subject to Android backups. Encrypted files from the backup won't work when restored on a different device so we have to exclude those files.
-It is encouraged to add the below rules to your own files.
+It is encouraged to create those files or copy paste below rules to your own respective files.
 
 <details>
   <summary>Instructions</summary>
 
-In `AndroidManifest.xml` add those lines:
+In `AndroidManifest.xml` add the below lines. If you already have them, you can skip this step.
 
 ```xml
 <application
@@ -329,7 +329,7 @@ In `AndroidManifest.xml` add those lines:
         ...>
 ```
 
-Content of the [@xml/data_extraction_rules](https://github.com/Automattic/Gravatar-SDK-Android/blob/trunk/gravatar-quickeditor/src/main/res/xml/data_extraction_rules.xml)
+Create [@xml/data_extraction_rules](https://github.com/Automattic/Gravatar-SDK-Android/blob/trunk/gravatar-quickeditor/src/main/res/xml/data_extraction_rules.xml) or modify your file with the below rules.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -353,7 +353,7 @@ Content of the [@xml/data_extraction_rules](https://github.com/Automattic/Gravat
 </data-extraction-rules>
 ```
 
-Content of the [@xml/backup_rules](https://github.com/Automattic/Gravatar-SDK-Android/blob/trunk/gravatar-quickeditor/src/main/res/xml/backup_rules.xml)
+Create [@xml/backup_rules](https://github.com/Automattic/Gravatar-SDK-Android/blob/trunk/gravatar-quickeditor/src/main/res/xml/backup_rules.xml) or modify your file with the below rules.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -314,7 +314,7 @@ GravatarQuickEditor.logout(Email("{USER_EMAIL}"))
 #### Exclude Data Store files from Android backup (optional, but recommended)
 
 Data Store files are subject to Android backups. Encrypted files from the backup won't work when restored on a different device so we have to exclude those files.
-If your app has backup rules configured, those that are provided in the SDK won't be used so you have to copy them to your files.
+It is encouraged to add the below rules to your own files.
 
 <details>
   <summary>Instructions</summary>

--- a/gravatar-quickeditor/src/main/AndroidManifest.xml
+++ b/gravatar-quickeditor/src/main/AndroidManifest.xml
@@ -4,10 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application
-        android:allowBackup="true"
-        android:dataExtractionRules="@xml/data_extraction_rules"
-        android:fullBackupContent="@xml/backup_rules">
+    <application>
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
@@ -20,8 +17,8 @@
         <provider
             android:name=".QuickEditorFileProvider"
             android:authorities="${applicationId}.com.quickeditor.fileprovider"
-            android:grantUriPermissions="true"
-            android:exported="false">
+            android:exported="false"
+            android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/quickeditor_filepaths" />


### PR DESCRIPTION
Closes #374 

### Description

Manifest merger failed when I tried to add QuickEditor in WP as they had their own backup rules applied. I'm not sure why the Merger ignores those rules in the Demo App (we also have them applied) but since this  optional I think it's okey to remove them from the manifest.

### Testing Steps

CI should be fine.