### PR TITLE
Add @JvmOverloads to AvatarUrl.url() function

### DIFF
--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -32,10 +32,13 @@ public final class com/gravatar/AvatarQueryOptionsKt {
 
 public final class com/gravatar/AvatarUrl {
 	public static final field Companion Lcom/gravatar/AvatarUrl$Companion;
+	public fun <init> (Lcom/gravatar/types/Email;)V
 	public fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/AvatarQueryOptions;)V
 	public synthetic fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/AvatarQueryOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/gravatar/types/Hash;)V
 	public fun <init> (Lcom/gravatar/types/Hash;Lcom/gravatar/AvatarQueryOptions;)V
 	public synthetic fun <init> (Lcom/gravatar/types/Hash;Lcom/gravatar/AvatarQueryOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/net/URL;)V
 	public fun <init> (Ljava/net/URL;Lcom/gravatar/AvatarQueryOptions;)V
 	public synthetic fun <init> (Ljava/net/URL;Lcom/gravatar/AvatarQueryOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAvatarQueryOptions ()Lcom/gravatar/AvatarQueryOptions;
@@ -43,6 +46,7 @@ public final class com/gravatar/AvatarUrl {
 	public final fun getHash ()Lcom/gravatar/types/Hash;
 	public final fun isAvatarUrl ()Z
 	public final fun setAvatarQueryOptions (Lcom/gravatar/AvatarQueryOptions;)V
+	public final fun url ()Ljava/net/URL;
 	public final fun url (Ljava/lang/String;)Ljava/net/URL;
 	public static synthetic fun url$default (Lcom/gravatar/AvatarUrl;Ljava/lang/String;ILjava/lang/Object;)Ljava/net/URL;
 }

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -58,6 +58,7 @@ public class AvatarUrl {
      * @param hash Gravatar hash
      * @param avatarQueryOptions Avatar query options
      */
+    @JvmOverloads
     public constructor(hash: Hash, avatarQueryOptions: AvatarQueryOptions? = null) {
         this.hash = hash
         this.avatarQueryOptions = avatarQueryOptions
@@ -70,6 +71,7 @@ public class AvatarUrl {
      * @param email Email address
      * @param avatarQueryOptions Avatar query options
      */
+    @JvmOverloads
     public constructor(
         email: Email,
         avatarQueryOptions: AvatarQueryOptions? = null,
@@ -81,6 +83,7 @@ public class AvatarUrl {
      * @param url Gravatar URL
      * @param avatarQueryOptions Avatar query options
      */
+    @JvmOverloads
     public constructor(url: URL, avatarQueryOptions: AvatarQueryOptions? = null) {
         this.hash = hashFromUrl(url)
         // Force the removal of query parameters as we can't be sure they are valid and won't interfere with

--- a/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
+++ b/gravatar/src/main/java/com/gravatar/AvatarUrl.kt
@@ -104,8 +104,10 @@ public class AvatarUrl {
     /**
      * Get the [URL] for the avatar.
      *
+     * @param cacheBuster Random string value to force a cache bust
      * @return [URL] for the avatar
      */
+    @JvmOverloads
     public fun url(cacheBuster: String? = null): URL {
         return URL(
             canonicalUrl.protocol,


### PR DESCRIPTION
Closes #375 

### Description

Improving Java interop. `cacheBuster` param was required in Java, and the `@JvmOverloads` annotation will create a separate `url()` function without any arguments and use a default null value.

### Testing Steps

One way to test it is to create a Java file and try to use it - That's what I did. 