### PR TITLE
Use release build type for demo app prototype

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,7 +70,7 @@ platform :android do
 
     gradle(
       task: ':demo-app:assemble',
-      build_type: 'debug'
+      build_type: 'release'
     )
 
     upload_path = upload_to_s3(


### PR DESCRIPTION


### Description

Use release build type for demo app prototype

### Testing Steps

Download the prototype build and check if there's the `Test with Activity without Compose` button. It should be hidden.