### PR TITLE
Throwing GravatarException on noncatching service methods

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -264,7 +264,7 @@ internal class AvatarPickerViewModel(
                 ErrorType.NotFound,
                 ErrorType.RateLimitExceeded,
                 ErrorType.Timeout,
-                ErrorType.Unknown,
+                is ErrorType.Unknown,
                 is ErrorType.InvalidRequest,
                 -> SectionError.Unknown
             }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -97,12 +97,12 @@ class AvatarRepositoryTest {
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
             avatarService.setAvatarCatching(any(), any(), any())
-        } returns GravatarResult.Failure(ErrorType.Unknown)
+        } returns GravatarResult.Failure(ErrorType.Unknown())
 
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
         assertEquals(
-            GravatarResult.Failure<String, QuickEditorError>(QuickEditorError.Request(ErrorType.Unknown)),
+            GravatarResult.Failure<String, QuickEditorError>(QuickEditorError.Request(ErrorType.Unknown())),
             result,
         )
     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -62,7 +62,7 @@ class AvatarPickerViewModelTest {
 
     @Before
     fun setup() {
-        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Failure(ErrorType.Unknown)
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Failure(ErrorType.Unknown())
         coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatars)
     }
 

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
@@ -91,7 +91,7 @@ class OAuthViewModelTest {
     fun `given token when association check failed then UiState_Status updated`() = runTest {
         coEvery {
             profileService.checkAssociatedEmailCatching(token, email)
-        } returns GravatarResult.Failure(ErrorType.Unknown)
+        } returns GravatarResult.Failure(ErrorType.Unknown())
 
         viewModel.uiState.test {
             expectMostRecentItem()
@@ -108,7 +108,7 @@ class OAuthViewModelTest {
     fun `given token when association check failed then token stored`() = runTest {
         coEvery {
             profileService.checkAssociatedEmailCatching(token, email)
-        } returns GravatarResult.Failure(ErrorType.Unknown)
+        } returns GravatarResult.Failure(ErrorType.Unknown())
 
         viewModel.tokenReceived(
             email,

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -750,6 +750,11 @@ public final class com/gravatar/services/GravatarResult$Success : com/gravatar/s
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/gravatar/services/HttpException : java/lang/RuntimeException {
+	public final fun getCode ()I
+	public fun getMessage ()Ljava/lang/String;
+}
+
 public final class com/gravatar/services/ProfileService {
 	public static final field LOG_TAG Ljava/lang/String;
 	public fun <init> ()V

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -705,10 +705,18 @@ public final class com/gravatar/services/ErrorType$Unauthorized : com/gravatar/s
 }
 
 public final class com/gravatar/services/ErrorType$Unknown : com/gravatar/services/ErrorType {
-	public static final field INSTANCE Lcom/gravatar/services/ErrorType$Unknown;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorMsg ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/gravatar/services/GravatarException : java/lang/RuntimeException {
+	public final fun getErrorType ()Lcom/gravatar/services/ErrorType;
+	public final fun getOriginalException ()Ljava/lang/Exception;
 }
 
 public abstract interface class com/gravatar/services/GravatarListener {
@@ -740,11 +748,6 @@ public final class com/gravatar/services/GravatarResult$Success : com/gravatar/s
 	public final fun getValue ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/gravatar/services/HttpException : java/lang/RuntimeException {
-	public final fun getCode ()I
-	public fun getMessage ()Ljava/lang/String;
 }
 
 public final class com/gravatar/services/ProfileService {

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     testImplementation(libs.mockk.android)
     testImplementation(libs.mockk.agent)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(kotlin("test"))
 }
 
 project.afterEvaluate {

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -29,23 +29,25 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
      * @param file The image file to upload
      * @param oauthToken The OAuth token to use for authentication
      */
-    public suspend fun upload(file: File, oauthToken: String): Avatar = withContext(GravatarSdkDI.dispatcherIO) {
-        val service = instance.getGravatarV3Service(okHttpClient, oauthToken)
+    public suspend fun upload(file: File, oauthToken: String): Avatar = runThrowingExceptionRequest {
+        withContext(GravatarSdkDI.dispatcherIO) {
+            val service = instance.getGravatarV3Service(okHttpClient, oauthToken)
 
-        val filePart =
-            MultipartBody.Part.createFormData("image", file.name, file.asRequestBody())
+            val filePart =
+                MultipartBody.Part.createFormData("image", file.name, file.asRequestBody())
 
-        val response = service.uploadAvatar(filePart)
+            val response = service.uploadAvatar(filePart)
 
-        if (response.isSuccessful && response.body() != null) {
-            response.body()!!
-        } else {
-            // Log the response body for debugging purposes if the response is not successful
-            Logger.w(
-                LOG_TAG,
-                "Network call unsuccessful trying to upload Gravatar: $response.body",
-            )
-            throw HttpException(response)
+            if (response.isSuccessful && response.body() != null) {
+                response.body()!!
+            } else {
+                // Log the response body for debugging purposes if the response is not successful
+                Logger.w(
+                    LOG_TAG,
+                    "Network call unsuccessful trying to upload Gravatar: $response.body",
+                )
+                throw HttpException(response)
+            }
         }
     }
 
@@ -70,7 +72,7 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
      * @param hash The hash of the email to associate the avatars with
      * @return The list of avatars
      */
-    public suspend fun retrieve(oauthToken: String, hash: Hash): List<Avatar> =
+    public suspend fun retrieve(oauthToken: String, hash: Hash): List<Avatar> = runThrowingExceptionRequest {
         withContext(GravatarSdkDI.dispatcherIO) {
             val service = instance.getGravatarV3Service(okHttpClient, oauthToken)
 
@@ -87,6 +89,7 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
                 throw HttpException(response)
             }
         }
+    }
 
     /**
      * Retrieves a list of available avatars for the authenticated user.
@@ -110,20 +113,22 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
      * @param oauthToken The OAuth token to use for authentication
      */
     public suspend fun setAvatar(hash: String, avatarId: String, oauthToken: String): Unit =
-        withContext(GravatarSdkDI.dispatcherIO) {
-            val service = GravatarSdkDI.getGravatarV3Service(okHttpClient, oauthToken)
+        runThrowingExceptionRequest {
+            withContext(GravatarSdkDI.dispatcherIO) {
+                val service = GravatarSdkDI.getGravatarV3Service(okHttpClient, oauthToken)
 
-            val response = service.setEmailAvatar(avatarId, SetEmailAvatarRequest { emailHash = hash })
+                val response = service.setEmailAvatar(avatarId, SetEmailAvatarRequest { emailHash = hash })
 
-            if (response.isSuccessful) {
-                Unit
-            } else {
-                // Log the response body for debugging purposes if the response is not successful
-                Logger.w(
-                    LOG_TAG,
-                    "Network call unsuccessful trying to set Gravatar avatar: $response.body",
-                )
-                throw HttpException(response)
+                if (response.isSuccessful) {
+                    Unit
+                } else {
+                    // Log the response body for debugging purposes if the response is not successful
+                    Logger.w(
+                        LOG_TAG,
+                        "Network call unsuccessful trying to set Gravatar avatar: $response.body",
+                    )
+                    throw HttpException(response)
+                }
             }
         }
 

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -20,7 +20,7 @@ internal fun HttpException.errorTypeFromHttpCode(moshi: Moshi): ErrorType = when
     }
 
     in HttpResponseCode.SERVER_ERRORS -> ErrorType.Server
-    else -> ErrorType.Unknown
+    else -> ErrorType.Unknown("HTTP Code $code - ErrorBody $rawErrorBody")
 }
 
 internal fun Throwable.errorType(moshi: Moshi): ErrorType {
@@ -28,7 +28,7 @@ internal fun Throwable.errorType(moshi: Moshi): ErrorType {
         is SocketTimeoutException -> ErrorType.Timeout
         is UnknownHostException -> ErrorType.Network
         is HttpException -> this.errorTypeFromHttpCode(moshi)
-        else -> ErrorType.Unknown
+        else -> ErrorType.Unknown(message)
     }
 }
 
@@ -54,8 +54,18 @@ public sealed class ErrorType {
     /** User not authorized to perform given action **/
     public data object Unauthorized : ErrorType()
 
-    /** An unknown error occurred */
-    public data object Unknown : ErrorType()
+    /**
+     * An unknown error occurred
+     *
+     * @property errorMsg The error message, if available.
+     */
+    public class Unknown(public val errorMsg: String? = null) : ErrorType() {
+        override fun toString(): String = "Unknown(errorMsg=$errorMsg)"
+
+        override fun equals(other: Any?): Boolean = other is Unknown && errorMsg == other.errorMsg
+
+        override fun hashCode(): Int = Objects.hash(errorMsg)
+    }
 
     /**
      * An error occurred while processing the request.

--- a/gravatar/src/main/java/com/gravatar/services/GravatarException.kt
+++ b/gravatar/src/main/java/com/gravatar/services/GravatarException.kt
@@ -1,0 +1,12 @@
+package com.gravatar.services
+
+/**
+ * Exception that will be thrown when an error occurs during Gravatar operations.
+ *
+ * @property errorType The type of error that occurred.
+ * @property originalException The original exception that caused this exception.
+ */
+public class GravatarException internal constructor(
+    public val errorType: ErrorType,
+    public val originalException: Exception? = null,
+) : RuntimeException()

--- a/gravatar/src/main/java/com/gravatar/services/HttpException.kt
+++ b/gravatar/src/main/java/com/gravatar/services/HttpException.kt
@@ -5,11 +5,10 @@ import retrofit2.Response
 /**
  * Exception thrown when an HTTP error occurs in a non-cathing method.
  *
+ * [rawErrorBody] The raw error body of the response.
  * [code] The HTTP status code.
- * [message] The HTTP status message.
  */
-public class HttpException internal constructor(response: Response<*>) : RuntimeException() {
-    internal val rawErrorBody: String? = response.errorBody()?.string()
-    public val code: Int = response.code()
-    public override val message: String = "HTTP ${response.code()} $rawErrorBody"
+internal class HttpException internal constructor(response: Response<*>) : RuntimeException() {
+    val rawErrorBody: String? = response.errorBody()?.string()
+    val code: Int = response.code()
 }

--- a/gravatar/src/main/java/com/gravatar/services/HttpException.kt
+++ b/gravatar/src/main/java/com/gravatar/services/HttpException.kt
@@ -5,10 +5,11 @@ import retrofit2.Response
 /**
  * Exception thrown when an HTTP error occurs in a non-cathing method.
  *
- * [rawErrorBody] The raw error body of the response.
  * [code] The HTTP status code.
+ * [message] The HTTP status message.
  */
-internal class HttpException internal constructor(response: Response<*>) : RuntimeException() {
-    val rawErrorBody: String? = response.errorBody()?.string()
-    val code: Int = response.code()
+public class HttpException internal constructor(response: Response<*>) : RuntimeException() {
+    internal val rawErrorBody: String? = response.errorBody()?.string()
+    public val code: Int = response.code()
+    public override val message: String = "HTTP ${response.code()} $rawErrorBody"
 }

--- a/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ServiceUtils.kt
@@ -14,7 +14,21 @@ internal inline fun <T> runCatchingRequest(block: () -> T?): GravatarResult<T, E
         }
     } catch (cancellationException: CancellationException) {
         throw cancellationException
+    } catch (gravatarException: GravatarException) {
+        GravatarResult.Failure(gravatarException.errorType)
     } catch (ex: Exception) {
         GravatarResult.Failure(ex.errorType(GravatarSdkContainer.instance.moshi))
+    }
+}
+
+@Suppress("ThrowsCount")
+internal inline fun <T> runThrowingExceptionRequest(block: () -> T?): T {
+    @Suppress("TooGenericExceptionCaught")
+    try {
+        return block() ?: throw GravatarException(ErrorType.NotFound)
+    } catch (cancellationException: CancellationException) {
+        throw cancellationException
+    } catch (ex: Exception) {
+        throw GravatarException(ex.errorType(GravatarSdkContainer.instance.moshi), ex)
     }
 }

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -62,16 +62,17 @@ class AvatarServiceTest {
         }
     }
 
-    @Test(expected = HttpException::class)
-    fun `given an avatar upload when an error occurs then an exception is thrown`() = runTest {
-        val mockResponse = mockk<Response<Avatar>>(relaxed = true) {
-            every { isSuccessful } returns false
-            every { code() } returns 500
-        }
-        coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+    @Test
+    fun `given an avatar upload when an error occurs then an exception is thrown`() =
+        runTestExpectingGravatarException(ErrorType.Server, HttpException::class.java) {
+            val mockResponse = mockk<Response<Avatar>>(relaxed = true) {
+                every { isSuccessful } returns false
+                every { code() } returns 500
+            }
+            coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
 
-        avatarService.upload(File("avatarFile"), oauthToken)
-    }
+            avatarService.upload(File("avatarFile"), oauthToken)
+        }
 
     @Test
     fun `given a file when uploadCatching avatar then Gravatar service is invoked`() = runTest {
@@ -136,9 +137,9 @@ class AvatarServiceTest {
         avatarService.setAvatar(hash, avatarId, oauthToken)
     }
 
-    @Test(expected = HttpException::class)
+    @Test
     fun `given a hash and an avatarId when setting an avatar and an error occurs then an exception is thrown`() =
-        runTest {
+        runTestExpectingGravatarException(ErrorType.Server, HttpException::class.java) {
             val hash = "hash"
             val avatarId = "avatarId"
             val mockResponse = mockk<Response<Unit>>(relaxed = true) {

--- a/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
@@ -32,7 +32,7 @@ class ErrorTypeTest {
         HTTP_CLIENT_TIMEOUT to ErrorType.Timeout,
         HTTP_NOT_FOUND to ErrorType.NotFound,
         HTTP_TOO_MANY_REQUESTS to ErrorType.RateLimitExceeded,
-        600 to ErrorType.Unknown,
+        600 to ErrorType.Unknown("HTTP Code 600 - ErrorBody $errorBody"),
         INVALID_REQUEST to ErrorType.InvalidRequest(
             error = Error {
                 code = "uncropped_image"
@@ -67,7 +67,7 @@ class ErrorTypeTest {
         val exceptionToErrorTypeRelation = mutableListOf(
             SocketTimeoutException() to ErrorType.Timeout,
             UnknownHostException() to ErrorType.Network,
-            Exception() to ErrorType.Unknown,
+            Exception() to ErrorType.Unknown(),
         ).apply {
             httpCodeToErrorTypeRelation.forEach { (code, errorType) ->
                 val exception = mockk<HttpException>(relaxed = true) {

--- a/gravatar/src/test/java/com/gravatar/services/ServiceTestUtils.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ServiceTestUtils.kt
@@ -1,0 +1,20 @@
+package com.gravatar.services
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlin.test.assertFailsWith
+
+internal fun runTestExpectingGravatarException(
+    errorType: ErrorType,
+    originalException: Class<out Exception>,
+    block: suspend () -> Unit,
+) {
+    val exception = assertFailsWith<GravatarException> {
+        runTest {
+            block()
+        }
+    }
+    assertEquals(errorType, exception.errorType)
+    assertTrue(originalException.isInstance(exception.originalException))
+}


### PR DESCRIPTION
Closes #377 

### Description

We want to wrap all exceptions that can occur inside the Gravatar service methods in our own `GravatarException` to provide the `ErrorType` as we do in the catching variants of those methods.

With this approach, we'll provide detailed information about the error, but at the same time, third-party developers know what exceptions can be expected from the Gravatar Services, basically `GravatarException`.

### Testing Steps

- Code review (including test)
- Smoke test demo-app (although we are not using `nonCatching` method there)