### PR TITLE
QuickEditor: Handle CAMERA permission

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+<!--    <uses-permission android:name="android.permission.CAMERA" />-->
 
     <application
         android:allowBackup="true"

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -28,6 +28,17 @@ public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$A
 	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$CameraPermissionRationaleDialogKt {
+	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/components/ComposableSingletons$CameraPermissionRationaleDialogKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$EmailLabelKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/components/ComposableSingletons$EmailLabelKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/CameraPermissionRationaleDialog.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/CameraPermissionRationaleDialog.kt
@@ -1,0 +1,38 @@
+package com.gravatar.quickeditor.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.gravatar.quickeditor.R
+
+@Composable
+internal fun CameraPermissionRationaleDialog(
+    isVisible: Boolean,
+    onConfirmation: () -> Unit,
+    onDismiss: () -> Unit = {},
+) {
+    if (isVisible) {
+        AlertDialog(
+            title = {
+                Text(text = stringResource(R.string.gravatar_qe_permission_required_alert_title))
+            },
+            text = {
+                Text(
+                    text = stringResource(R.string.gravatar_qe_camera_permission_rationale_message),
+                )
+            },
+            onDismissRequest = onDismiss,
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onConfirmation()
+                    },
+                ) {
+                    Text(stringResource(R.string.gravatar_qe_dismiss))
+                }
+            },
+        )
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
@@ -172,7 +172,7 @@ private fun launchCustomTab(context: Context, oauthParams: OAuthParams, email: E
     )
 }
 
-private fun Context.findComponentActivity(): ComponentActivity? = when (this) {
+internal fun Context.findComponentActivity(): ComponentActivity? = when (this) {
     is ComponentActivity -> this
     is ContextWrapper -> baseContext.findComponentActivity()
     else -> null

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -34,4 +34,7 @@
     <string name="avatar_upload_failure_dialog_title">Couldn\'t upload image</string>
     <string name="avatar_upload_failure_dialog_remove_upload">Remove upload</string>
     <string name="oauth_email_associated_error_message">Something went wrong when verifying your email.</string>
+    <string name="gravatar_qe_permission_required_alert_title">Permission required</string>
+    <string name="gravatar_qe_camera_permission_rationale_message">To take a picture, you need to grant camera permission. You can grant it in the app settings.</string>
+    <string name="gravatar_qe_dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
Closes #393

### Description

It turns out we need to handle the Camera permission when a third-party app has `<uses-permission android:name="android.permission.CAMERA" />` defined in its `AndroidManifest.xml`. If we don't we will get `SecurityException` when launching the `ACTION_IMAGE_CAPTURE` intent - [source](https://developer.android.com/reference/android/provider/MediaStore#ACTION_IMAGE_CAPTURE).

**Permission granted**
https://github.com/user-attachments/assets/55dd6c8e-100d-4145-9d59-d88112d9efd8

**Permission denied**
https://github.com/user-attachments/assets/c5062aa4-25a7-47ca-9c36-dfe42f04b14c

**No permission in the third-party app**
https://github.com/user-attachments/assets/e742f451-c297-431a-98ff-7ddc9b7651ca


### Testing Steps

Camera permission is commented out in the Demo app manifest
1. Try to take a photo - all should work as usual.
2. Uncomment the Camera permission
3. Try to take a photo - you should see the permission dialog
4. Try different options - granting, denying, etc.
