### PR TITLE
Make onDismiss optional in the GravatarQuickEditor.show()

### DIFF
--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -2,8 +2,12 @@ public final class com/gravatar/quickeditor/GravatarQuickEditor {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/gravatar/quickeditor/GravatarQuickEditor;
 	public final fun logout (Lcom/gravatar/types/Email;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun show (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;)V
 	public static final fun show (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public static final fun show (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;)V
 	public static final fun show (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun show$default (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun show$default (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class com/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
@@ -21,16 +21,16 @@ public object GravatarQuickEditor {
      * @param authenticationMethod The method used for authentication with the Gravatar REST API.
      * @param onAvatarSelected The callback for the avatar update.
      *                       Can be invoked multiple times while the Quick Editor is open.
-     * @param onDismiss The callback for the dismiss action.
-     *                  [GravatarQuickEditorError] will be non-null if the dismiss was caused by an error.
+     * @param onDismiss The callback for the dismiss action containing [GravatarQuickEditorDismissReason]
      */
     @JvmStatic
+    @JvmOverloads
     public fun show(
         activity: Activity,
         gravatarQuickEditorParams: GravatarQuickEditorParams,
         authenticationMethod: AuthenticationMethod,
         onAvatarSelected: () -> Unit,
-        onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
+        onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
     ) {
         val viewGroup: ViewGroup = activity.findViewById(android.R.id.content)
         addQuickEditorToView(viewGroup, gravatarQuickEditorParams, authenticationMethod, onAvatarSelected, onDismiss)
@@ -45,16 +45,16 @@ public object GravatarQuickEditor {
      * @param authenticationMethod The method used for authentication with the Gravatar REST API.
      * @param onAvatarSelected The callback for the avatar update.
      *                       Can be invoked multiple times while the Quick Editor is open.
-     * @param onDismiss The callback for the dismiss action.
-     *                  [GravatarQuickEditorError] will be non-null if the dismiss was caused by an error.
+     * @param onDismiss The callback for the dismiss action containing [GravatarQuickEditorDismissReason]
      */
     @JvmStatic
+    @JvmOverloads
     public fun show(
         fragment: Fragment,
         gravatarQuickEditorParams: GravatarQuickEditorParams,
         authenticationMethod: AuthenticationMethod,
         onAvatarSelected: () -> Unit,
-        onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
+        onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
     ) {
         val viewGroup: ViewGroup = fragment.requireActivity().findViewById(android.R.id.content)
         addQuickEditorToView(viewGroup, gravatarQuickEditorParams, authenticationMethod, onAvatarSelected, onDismiss)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -56,8 +56,7 @@ import kotlinx.coroutines.launch
  * @param authenticationMethod The method used for authentication with the Gravatar REST API.
  * @param onAvatarSelected The callback for the avatar update.
  *                       Can be invoked multiple times while the Quick Editor is open.
- * @param onDismiss The callback for the dismiss action.
- *                  [GravatarQuickEditorError] will be non-null if the dismiss was caused by an error.
+ * @param onDismiss The callback for the dismiss action containing [GravatarQuickEditorDismissReason]
  */
 @Composable
 public fun GravatarQuickEditorBottomSheet(


### PR DESCRIPTION


### Description

Small public API update. The `onDismiss` callback can be ignored, as it's not critical to QE functioning, so I made it optional and added the `@JvmOverloads` for Java interop. 

I noticed we had an outdated doc comment for this callback so updated it as well.

### Testing Steps

Smoke test QE from the XML Activity class


