### PR TITLE
Create an empty GravatarUCropActivity to avoid Manifest merger fails

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.ucrop)
     implementation(project(":gravatar"))
     implementation(project(":gravatar-ui"))
     implementation(project(":gravatar-quickeditor"))

--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -55,6 +55,12 @@
 <!--                    android:scheme="${DEMO_OAUTH_REDIRECT_URI_SCHEME}" />-->
 <!--            </intent-filter>-->
         </activity>
+
+        <!-- Lib activities -->
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:theme="@style/Theme.AppCompat" />
+
         <provider
             android:name=".DemoFileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/gravatar-quickeditor/src/main/AndroidManifest.xml
+++ b/gravatar-quickeditor/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
 
         <!-- Lib activities-->
         <activity
-            android:name="com.yalantis.ucrop.UCropActivity"
+            android:name=".ui.cropperlauncher.GravatarUCropActivity"
             android:theme="@style/Theme.AppCompat.NoActionBar" />
     </application>
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -50,8 +50,8 @@ import com.gravatar.quickeditor.ui.components.EmailLabel
 import com.gravatar.quickeditor.ui.components.ErrorSection
 import com.gravatar.quickeditor.ui.components.FailedAvatarUploadAlertDialog
 import com.gravatar.quickeditor.ui.components.ProfileCard
-import com.gravatar.quickeditor.ui.copperlauncher.CropperLauncher
-import com.gravatar.quickeditor.ui.copperlauncher.UCropCropperLauncher
+import com.gravatar.quickeditor.ui.cropperlauncher.CropperLauncher
+import com.gravatar.quickeditor.ui.cropperlauncher.UCropCropperLauncher
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.editor.bottomsheet.DEFAULT_PAGE_HEIGHT

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/cropperlauncher/CropperLauncher.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/cropperlauncher/CropperLauncher.kt
@@ -1,4 +1,4 @@
-package com.gravatar.quickeditor.ui.copperlauncher
+package com.gravatar.quickeditor.ui.cropperlauncher
 
 import android.content.Context
 import android.content.Intent

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/cropperlauncher/UCropCropperLauncher.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/cropperlauncher/UCropCropperLauncher.kt
@@ -1,4 +1,4 @@
-package com.gravatar.quickeditor.ui.copperlauncher
+package com.gravatar.quickeditor.ui.cropperlauncher
 
 import android.content.Context
 import android.content.Intent
@@ -24,7 +24,21 @@ internal class UCropCropperLauncher : CropperLauncher {
             setCircleDimmedLayer(true)
         }
         launcher.launch(
-            UCrop.of(image, Uri.fromFile(tempFile)).withAspectRatio(1f, 1f).withOptions(options).getIntent(context),
+            UCrop.of(image, Uri.fromFile(tempFile))
+                .withAspectRatio(1f, 1f)
+                .withOptions(options)
+                .getGravatarIntent(context),
         )
     }
 }
+
+private fun UCrop.getGravatarIntent(context: Context): Intent {
+    return getIntent(context).apply {
+        setClass(context, GravatarUCropActivity::class.java)
+    }
+}
+
+/**
+ * Empty Activity to not cause conflicts with UCropActivity when third-party apps depend on it already
+ */
+internal class GravatarUCropActivity : UCropActivity()


### PR DESCRIPTION
### Description

When a third-party app depends on UCrop already they likely have defined the `UCropActivity` in the manifest. We do that as well in the QE and this causes the Manifest merger to fail. 

It's possible to remove that declaration from a third-party app (or use `tools:replace`) and keep the one from QE, but it's not ideal because there could be custom fields set that could differ from the ones we use. 

To fix this I've added a "fake" UCrop activity to not have clashing names. This way we can define our Activity in the manifest without requiring third-party apps to remove theirs. 

### Testing Steps

I've added a potentially conflicting UCropActivity to the demo app, so the CI should be enough. 

I was also able to confirm this in the WP app with the built from this PR.
