### PR TITLE
QuickEditor: Missing action on gravatar icon

### DIFF
--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -128,14 +128,12 @@ public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$Q
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public static field lambda-3 Lkotlin/jvm/functions/Function3;
-	public static field lambda-4 Lkotlin/jvm/functions/Function3;
-	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-4$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-5$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$SelectableAvatarKt {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/QETopBar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/QETopBar.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -26,9 +25,7 @@ import com.gravatar.quickeditor.R
 import com.gravatar.ui.GravatarTheme
 
 @Composable
-internal fun QETopBar(onDoneClick: () -> Unit, gravatarIconUrl: String, modifier: Modifier = Modifier) {
-    val uriHandler = LocalUriHandler.current
-
+internal fun QETopBar(onDoneClick: () -> Unit, modifier: Modifier = Modifier, onGravatarIconClick: () -> Unit = {}) {
     GravatarCenterAlignedTopAppBar(
         modifier = modifier,
         title = {
@@ -53,9 +50,7 @@ internal fun QETopBar(onDoneClick: () -> Unit, gravatarIconUrl: String, modifier
                 tint = MaterialTheme.colorScheme.primary,
                 contentDescription = stringResource(id = R.string.gravatar),
                 modifier = Modifier
-                    .clickable(onClick = {
-                        uriHandler.openUri(gravatarIconUrl)
-                    })
+                    .clickable(onClick = onGravatarIconClick)
                     .size(34.dp)
                     .padding(end = 8.dp),
             )
@@ -114,6 +109,6 @@ private fun GravatarCenterAlignedTopAppBar(
 @Composable
 private fun QETopBarPreview() {
     GravatarTheme {
-        QETopBar(onDoneClick = {}, "")
+        QETopBar(onDoneClick = {}, onGravatarIconClick = {})
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/QETopBar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/QETopBar.kt
@@ -1,5 +1,6 @@
 package com.gravatar.quickeditor.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -15,6 +16,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -24,7 +26,9 @@ import com.gravatar.quickeditor.R
 import com.gravatar.ui.GravatarTheme
 
 @Composable
-internal fun QETopBar(onDoneClick: () -> Unit, modifier: Modifier = Modifier) {
+internal fun QETopBar(onDoneClick: () -> Unit, gravatarIconUrl: String, modifier: Modifier = Modifier) {
+    val uriHandler = LocalUriHandler.current
+
     GravatarCenterAlignedTopAppBar(
         modifier = modifier,
         title = {
@@ -49,6 +53,9 @@ internal fun QETopBar(onDoneClick: () -> Unit, modifier: Modifier = Modifier) {
                 tint = MaterialTheme.colorScheme.primary,
                 contentDescription = stringResource(id = R.string.gravatar),
                 modifier = Modifier
+                    .clickable(onClick = {
+                        uriHandler.openUri(gravatarIconUrl)
+                    })
                     .size(34.dp)
                     .padding(end = 8.dp),
             )
@@ -107,6 +114,6 @@ private fun GravatarCenterAlignedTopAppBar(
 @Composable
 private fun QETopBarPreview() {
     GravatarTheme {
-        QETopBar(onDoneClick = {})
+        QETopBar(onDoneClick = {}, "")
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -85,7 +85,6 @@ internal fun GravatarQuickEditorBottomSheet(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
     modalBottomSheetState: ModalBottomSheetState,
 ) {
-
     GravatarModalBottomSheet(
         onDismiss = onDismiss,
         modalBottomSheetState = modalBottomSheetState,
@@ -168,7 +167,7 @@ private fun GravatarModalBottomSheet(
                                     modalBottomSheetState.currentDetent = Hidden
                                 }
                             },
-                            gravatarIconUrl = GravatarConstants.GRAVATAR_SIGN_IN_URL
+                            gravatarIconUrl = GravatarConstants.GRAVATAR_SIGN_IN_URL,
                         )
                         content()
                     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -36,7 +36,7 @@ import com.composables.core.SheetDetent
 import com.composables.core.SheetDetent.Companion.FullyExpanded
 import com.composables.core.SheetDetent.Companion.Hidden
 import com.composables.core.rememberModalBottomSheetState
-import com.gravatar.ProfileUrl
+import com.gravatar.GravatarConstants
 import com.gravatar.quickeditor.ui.components.QEDragHandle
 import com.gravatar.quickeditor.ui.components.QETopBar
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
@@ -88,7 +88,6 @@ internal fun GravatarQuickEditorBottomSheet(
 
     GravatarModalBottomSheet(
         onDismiss = onDismiss,
-        gravatarIconUrl = ProfileUrl(gravatarQuickEditorParams.email.hash()).url.toString(),
         modalBottomSheetState = modalBottomSheetState,
     ) {
         when (authenticationMethod) {
@@ -116,7 +115,6 @@ internal fun GravatarQuickEditorBottomSheet(
 @Composable
 private fun GravatarModalBottomSheet(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
-    gravatarIconUrl: String,
     modalBottomSheetState: ModalBottomSheetState,
     content: @Composable () -> Unit,
 ) {
@@ -170,7 +168,7 @@ private fun GravatarModalBottomSheet(
                                     modalBottomSheetState.currentDetent = Hidden
                                 }
                             },
-                            gravatarIconUrl = gravatarIconUrl
+                            gravatarIconUrl = GravatarConstants.GRAVATAR_SIGN_IN_URL
                         )
                         content()
                     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.window.core.layout.WindowHeightSizeClass
@@ -118,6 +119,7 @@ private fun GravatarModalBottomSheet(
     content: @Composable () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val uriHandler = LocalUriHandler.current
 
     LaunchedEffect(modalBottomSheetState.currentDetent) {
         if (modalBottomSheetState.currentDetent == Hidden) {
@@ -167,7 +169,9 @@ private fun GravatarModalBottomSheet(
                                     modalBottomSheetState.currentDetent = Hidden
                                 }
                             },
-                            gravatarIconUrl = GravatarConstants.GRAVATAR_SIGN_IN_URL,
+                            onGravatarIconClick = {
+                                uriHandler.openUri(GravatarConstants.GRAVATAR_SIGN_IN_URL)
+                            },
                         )
                         content()
                     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -36,6 +36,7 @@ import com.composables.core.SheetDetent
 import com.composables.core.SheetDetent.Companion.FullyExpanded
 import com.composables.core.SheetDetent.Companion.Hidden
 import com.composables.core.rememberModalBottomSheetState
+import com.gravatar.ProfileUrl
 import com.gravatar.quickeditor.ui.components.QEDragHandle
 import com.gravatar.quickeditor.ui.components.QETopBar
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
@@ -84,8 +85,10 @@ internal fun GravatarQuickEditorBottomSheet(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
     modalBottomSheetState: ModalBottomSheetState,
 ) {
+
     GravatarModalBottomSheet(
         onDismiss = onDismiss,
+        gravatarIconUrl = ProfileUrl(gravatarQuickEditorParams.email.hash()).url.toString(),
         modalBottomSheetState = modalBottomSheetState,
     ) {
         when (authenticationMethod) {
@@ -113,6 +116,7 @@ internal fun GravatarQuickEditorBottomSheet(
 @Composable
 private fun GravatarModalBottomSheet(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
+    gravatarIconUrl: String,
     modalBottomSheetState: ModalBottomSheetState,
     content: @Composable () -> Unit,
 ) {
@@ -166,6 +170,7 @@ private fun GravatarModalBottomSheet(
                                     modalBottomSheetState.currentDetent = Hidden
                                 }
                             },
+                            gravatarIconUrl = gravatarIconUrl
                         )
                         content()
                     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/QETopBarTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/QETopBarTest.kt
@@ -8,12 +8,12 @@ import org.robolectric.annotation.Config
 class QETopBarTest : RoborazziTest() {
     @Test
     fun qrTopBarLight() = gravatarScreenshotTest {
-        QETopBar(onDoneClick = {})
+        QETopBar(onDoneClick = {}, gravatarIconUrl = "")
     }
 
     @Test
     @Config(qualifiers = "+night")
     fun qrTopBarDark() = gravatarScreenshotTest {
-        QETopBar(onDoneClick = {})
+        QETopBar(onDoneClick = {}, gravatarIconUrl = "")
     }
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/QETopBarTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/QETopBarTest.kt
@@ -8,12 +8,12 @@ import org.robolectric.annotation.Config
 class QETopBarTest : RoborazziTest() {
     @Test
     fun qrTopBarLight() = gravatarScreenshotTest {
-        QETopBar(onDoneClick = {}, gravatarIconUrl = "")
+        QETopBar(onDoneClick = {}, onGravatarIconClick = {})
     }
 
     @Test
     @Config(qualifiers = "+night")
     fun qrTopBarDark() = gravatarScreenshotTest {
-        QETopBar(onDoneClick = {}, gravatarIconUrl = "")
+        QETopBar(onDoneClick = {}, onGravatarIconClick = {})
     }
 }


### PR DESCRIPTION
Closes #376 

### Description

Adds a redirection to https://gravatar.com/profile in a ~~custom~~ browser tab when clicking on the bottomsheet's Gravatar icon in the top right corner.

edit: launches in a regular browser tab to align with the behavior of the "view profile" button.

### Testing Steps
- [ ] While logged out of Gravatar in your browser, click on the icon and see that you are redirected to the login page
- [ ] While logged in Gravatar in your browser, click on the icon and see that you are redirected to your profile edition page