### PR TITLE
Add 413 HTTP error - CONTENT_TOO_LARGE

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerUiState.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerUiState.kt
@@ -5,6 +5,7 @@ import com.gravatar.quickeditor.data.repository.EmailAvatars
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.restapi.models.Profile
+import com.gravatar.services.ErrorType
 import com.gravatar.types.Email
 import com.gravatar.ui.components.ComponentState
 
@@ -81,7 +82,7 @@ internal data class AvatarsSectionUiState(
 
 internal data class AvatarUploadFailure(
     val uri: Uri,
-    val error: String?,
+    val error: ErrorType?,
 )
 
 internal sealed class AvatarUi(val avatarId: String) {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -184,8 +184,7 @@ internal class AvatarPickerViewModel(
                             scrollToIndex = null,
                             failedUploads = currentState.failedUploads + AvatarUploadFailure(
                                 uri,
-                                error = ((result.error as? QuickEditorError.Request)?.type as? ErrorType.InvalidRequest)
-                                    ?.error?.error,
+                                error = (result.error as? QuickEditorError.Request)?.type,
                             ),
                         )
                     }
@@ -266,6 +265,7 @@ internal class AvatarPickerViewModel(
                 ErrorType.Timeout,
                 is ErrorType.Unknown,
                 is ErrorType.InvalidRequest,
+                ErrorType.ContentLengthExceeded,
                 -> SectionError.Unknown
             }
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/FailedAvatarUploadAlertDialog.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/FailedAvatarUploadAlertDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.gravatar.quickeditor.R
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarUploadFailure
+import com.gravatar.services.ErrorType
 import com.gravatar.ui.GravatarTheme
 
 @Composable
@@ -26,7 +27,15 @@ internal fun FailedAvatarUploadAlertDialog(
                     Text(text = stringResource(id = R.string.avatar_upload_failure_dialog_title))
                 },
                 text = {
-                    avatarUploadFailure.error?.let { Text(text = it) }
+                    avatarUploadFailure.error?.let {
+                        when (it) {
+                            is ErrorType.InvalidRequest -> it.error?.error
+                            is ErrorType.ContentLengthExceeded -> stringResource(
+                                id = R.string.gravatar_avatar_upload_failure_image_too_big,
+                            )
+                            else -> null
+                        }?.let { errorString -> Text(text = errorString) }
+                    }
                 },
                 confirmButton = {
                     TextButton(
@@ -47,7 +56,7 @@ internal fun FailedAvatarUploadAlertDialog(
 @Composable
 private fun FailedAvatarUploadAlertDialogPreview() {
     FailedAvatarUploadAlertDialog(
-        avatarUploadFailure = AvatarUploadFailure(Uri.EMPTY, "Error message"),
+        avatarUploadFailure = AvatarUploadFailure(Uri.EMPTY, ErrorType.ContentLengthExceeded),
         onRemoveUploadClicked = {},
         onRetryClicked = {},
         onDismiss = {},

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="failed_to_load_avatar_content_description">Upload failed, tap to see actions.</string>
     <string name="avatar_upload_failure_dialog_title">Couldn\'t upload image</string>
     <string name="avatar_upload_failure_dialog_remove_upload">Remove upload</string>
+    <string name="gravatar_avatar_upload_failure_image_too_big">The provided image exceeds the maximum size: 10MB</string>
     <string name="oauth_email_associated_error_message">Something went wrong when verifying your email.</string>
     <string name="gravatar_qe_permission_required_alert_title">Permission required</string>
     <string name="gravatar_qe_camera_permission_rationale_message">To take a picture, you need to grant camera permission. You can grant it in the app settings.</string>

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -440,7 +440,7 @@ class AvatarPickerViewModelTest {
                 avatarPickerUiState.copy(
                     uploadingAvatar = null,
                     scrollToIndex = null,
-                    failedUploads = setOf(AvatarUploadFailure(uri, errorMessage)),
+                    failedUploads = setOf(AvatarUploadFailure(uri, invalidRequest.type)),
                 ),
                 awaitItem(),
             )
@@ -550,7 +550,7 @@ class AvatarPickerViewModelTest {
                 scrollToIndex = 0,
                 avatarPickerContentLayout = avatarPickerContentLayout,
                 failedUploads = setOf(
-                    AvatarUploadFailure(uriOne, errorMessage),
+                    AvatarUploadFailure(uriOne, invalidRequest.type),
                 ),
             )
             assertEquals(
@@ -597,7 +597,7 @@ class AvatarPickerViewModelTest {
             expectMostRecentItem()
             viewModel.onEvent(AvatarPickerEvent.FailedAvatarTapped(uri))
 
-            assertEquals(AvatarUploadFailure(uri, errorMessage), awaitItem().failedUploadDialog)
+            assertEquals(AvatarUploadFailure(uri, invalidRequest.type), awaitItem().failedUploadDialog)
         }
     }
 
@@ -649,7 +649,7 @@ class AvatarPickerViewModelTest {
 
             val awaitItem = awaitItem()
             assertEquals(null, awaitItem.failedUploadDialog)
-            assertEquals(setOf(AvatarUploadFailure(uri, errorMessage)), awaitItem.failedUploads)
+            assertEquals(setOf(AvatarUploadFailure(uri, invalidRequest.type)), awaitItem.failedUploads)
         }
     }
 

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -654,6 +654,13 @@ public final class com/gravatar/services/AvatarService {
 public abstract class com/gravatar/services/ErrorType {
 }
 
+public final class com/gravatar/services/ErrorType$ContentLengthExceeded : com/gravatar/services/ErrorType {
+	public static final field INSTANCE Lcom/gravatar/services/ErrorType$ContentLengthExceeded;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/services/ErrorType$InvalidRequest : com/gravatar/services/ErrorType {
 	public fun <init> (Lcom/gravatar/restapi/models/Error;)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/gravatar/src/main/java/com/gravatar/HttpResponseCode.kt
+++ b/gravatar/src/main/java/com/gravatar/HttpResponseCode.kt
@@ -7,6 +7,7 @@ internal object HttpResponseCode {
     const val HTTP_TOO_MANY_REQUESTS = 429
     const val UNAUTHORIZED = 401
     const val INVALID_REQUEST = 400
+    const val CONTENT_TOO_LARGE = 413
 
     private const val HTTP_INTERNAL_ERROR = 500
     private const val NETWORK_CONNECT_TIMEOUT_ERROR = 599

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -18,7 +18,7 @@ internal fun HttpException.errorTypeFromHttpCode(moshi: Moshi): ErrorType = when
         }.getOrNull()
         ErrorType.InvalidRequest(error)
     }
-
+    HttpResponseCode.CONTENT_TOO_LARGE -> ErrorType.ContentLengthExceeded
     in HttpResponseCode.SERVER_ERRORS -> ErrorType.Server
     else -> ErrorType.Unknown("HTTP Code $code - ErrorBody $rawErrorBody")
 }
@@ -53,6 +53,9 @@ public sealed class ErrorType {
 
     /** User not authorized to perform given action **/
     public data object Unauthorized : ErrorType()
+
+    /** Content length exceeded **/
+    public data object ContentLengthExceeded : ErrorType()
 
     /**
      * An unknown error occurred

--- a/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
@@ -1,5 +1,6 @@
 package com.gravatar.services
 
+import com.gravatar.HttpResponseCode.CONTENT_TOO_LARGE
 import com.gravatar.HttpResponseCode.HTTP_CLIENT_TIMEOUT
 import com.gravatar.HttpResponseCode.HTTP_NOT_FOUND
 import com.gravatar.HttpResponseCode.HTTP_TOO_MANY_REQUESTS
@@ -39,6 +40,7 @@ class ErrorTypeTest {
                 error = "Only square images are accepted"
             },
         ),
+        CONTENT_TOO_LARGE to ErrorType.ContentLengthExceeded,
     ).apply {
         SERVER_ERRORS.forEach { code ->
             add(code to ErrorType.Server)


### PR DESCRIPTION
Closes #352 

### Description

This PR aims to solve the same issue as https://github.com/Automattic/Gravatar-SDK-iOS/pull/467 in the iOS repo.

When an image that is too big is uploaded, the server will answer with a 413, which we should handle and show the proper error message. For that reason, we need to add a new ErrorType. 

**Note:** We've discussed ErrorType being a sealed class and the problems that could arise when adding a new ErrorType (Breaking change—it can break the compilation in a when clause). I'll open a different PR for that. #401

### Testing Steps

As we are compressing and limiting the maximum size of the final image, it's not easy to test the changes. You have two options:

**Modifying the code**

- Apply the following patch (or comment the compression/size options in `UCropCropperLauncher`)
[Gravatar-Android-12-47-55.patch](https://github.com/user-attachments/files/17434223/Gravatar-Android-12-47-55.patch)
- Build the demo-app
- Upload a huge image (you can use the [resources](https://drive.google.com/drive/u/0/folders/16bRuYugP99X3grDlh938ffJaomlfFXaT) from the iOS PR)

**Mock the server response**

- Using your favorite network tool (ex: Charles...) mock the response from the server when uploading an avatar - 413


**In both options ->** Verify you see the error on the avatar picker with the associated message.

<img width="324" alt="image" src="https://github.com/user-attachments/assets/63969953-2939-4ce2-8534-f1905a44b531">

