### PR TITLE
Add a new ErrorType to handle possible future errors

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -266,6 +266,7 @@ internal class AvatarPickerViewModel(
                 is ErrorType.Unknown,
                 is ErrorType.InvalidRequest,
                 ErrorType.ContentLengthExceeded,
+                is ErrorType.FutureError,
                 -> SectionError.Unknown
             }
         }

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -661,6 +661,10 @@ public final class com/gravatar/services/ErrorType$ContentLengthExceeded : com/g
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class com/gravatar/services/ErrorType$FutureError : com/gravatar/services/ErrorType {
+	public fun <init> ()V
+}
+
 public final class com/gravatar/services/ErrorType$InvalidRequest : com/gravatar/services/ErrorType {
 	public fun <init> (Lcom/gravatar/restapi/models/Error;)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -82,4 +82,10 @@ public sealed class ErrorType {
 
         override fun hashCode(): Int = Objects.hash(error)
     }
+
+    /**
+     * Future errors that may be added in the future will extend this class to ensure that all errors are handled.
+     * When a new major release is made, all [FutureError] should extend directly from [ErrorType].
+     */
+    public abstract class FutureError : ErrorType()
 }


### PR DESCRIPTION
Closes #401 

### Description

```kotlin
public abstract class FutureErrors : ErrorType()
```

That will force any developer to add that consideration in their current exhaustive when clauses.

During the `2.x.x` every new ErrorType that we want to add should inherit from `FutureErrors`. Any exhaustive code will still compile as they are already considering the parent class. If someone is interested in a new concrete error, they can add that branch to the when without problems while keeping the FutureErrors branch.

```kotlin
public abstract class FutureErrors : ErrorType()
public data object WTFError: FutureErrors()
```

When we release new major versions, we need to change the parent class for the new errors:

```
public data object WTFError: ErrorType()
public abstract class FutureErrors : ErrorType()
```

The exact process will be followed during the life of a major version.

The downside of this approach is that, as a third-party developer, the new type will force me to consider a `generic` error if I don't currently have one. 

Thoughts?

### Testing Steps

- Code Review
