### PR TITLE
Refactor ErrorType from `sealed class` to `interface`

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -260,13 +260,7 @@ internal class AvatarPickerViewModel(
                 ErrorType.Server -> SectionError.ServerError
                 ErrorType.Network -> SectionError.NoInternetConnection
                 ErrorType.Unauthorized -> SectionError.InvalidToken(handleExpiredSession)
-                ErrorType.NotFound,
-                ErrorType.RateLimitExceeded,
-                ErrorType.Timeout,
-                is ErrorType.Unknown,
-                is ErrorType.InvalidRequest,
-                ErrorType.ContentLengthExceeded,
-                -> SectionError.Unknown
+                else -> SectionError.Unknown
             }
         }
 }

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -651,7 +651,7 @@ public final class com/gravatar/services/AvatarService {
 	public final fun uploadCatching (Ljava/io/File;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract class com/gravatar/services/ErrorType {
+public abstract interface class com/gravatar/services/ErrorType {
 }
 
 public final class com/gravatar/services/ErrorType$ContentLengthExceeded : com/gravatar/services/ErrorType {

--- a/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
+++ b/gravatar/src/main/java/com/gravatar/services/ErrorType.kt
@@ -33,36 +33,36 @@ internal fun Throwable.errorType(moshi: Moshi): ErrorType {
 }
 
 /**
- * Error types for Gravatar image upload
+ * Error types for Gravatar API requests.
  */
-public sealed class ErrorType {
+public interface ErrorType {
     /** server returned an error */
-    public data object Server : ErrorType()
+    public data object Server : ErrorType
 
     /** network request timed out */
-    public data object Timeout : ErrorType()
+    public data object Timeout : ErrorType
 
     /** network is not available */
-    public data object Network : ErrorType()
+    public data object Network : ErrorType
 
     /** User or hash not found */
-    public data object NotFound : ErrorType()
+    public data object NotFound : ErrorType
 
     /** User or hash not found */
-    public data object RateLimitExceeded : ErrorType()
+    public data object RateLimitExceeded : ErrorType
 
     /** User not authorized to perform given action **/
-    public data object Unauthorized : ErrorType()
+    public data object Unauthorized : ErrorType
 
     /** Content length exceeded **/
-    public data object ContentLengthExceeded : ErrorType()
+    public data object ContentLengthExceeded : ErrorType
 
     /**
      * An unknown error occurred
      *
      * @property errorMsg The error message, if available.
      */
-    public class Unknown(public val errorMsg: String? = null) : ErrorType() {
+    public class Unknown(public val errorMsg: String? = null) : ErrorType {
         override fun toString(): String = "Unknown(errorMsg=$errorMsg)"
 
         override fun equals(other: Any?): Boolean = other is Unknown && errorMsg == other.errorMsg
@@ -75,7 +75,7 @@ public sealed class ErrorType {
      *
      * @property error The detailed error that occurred, if returned from the server.
      */
-    public class InvalidRequest(public val error: Error?) : ErrorType() {
+    public class InvalidRequest(public val error: Error?) : ErrorType {
         override fun toString(): String = "InvalidRequest(error=$error)"
 
         override fun equals(other: Any?): Boolean = other is InvalidRequest && error == other.error


### PR DESCRIPTION
Closes #401 

### Description

Adding a new ErrorType would cause a breaking change as we used a `sealed class`. Switching from the `sealed class` to an `interface` will remove the breaking change as the third-party developers will need to add an else branch into their `when` clauses. You can read more about this discussion in this PR #403.

### Testing Steps

- Smoke Test demo-app, force some errors in the QE
