### PR TITLE
Disable the option to override QuickEditor theme

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -20,10 +20,12 @@ import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,6 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -56,6 +59,8 @@ import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
 import com.gravatar.types.Email
+import com.gravatar.ui.GravatarTheme
+import com.gravatar.ui.LocalGravatarTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -176,24 +181,35 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                 },
             )
         }
-        GravatarQuickEditorBottomSheet(
-            gravatarQuickEditorParams = GravatarQuickEditorParams {
-                email = Email(userEmail)
-                avatarPickerContentLayout = pickerContentLayout
+        // CompositionLocalProvider is not required, it's added here
+        // to test that the QuickEditor theme can't be overridden
+        CompositionLocalProvider(
+            LocalGravatarTheme provides object : GravatarTheme {
+                // Override theme colors
+                override val colorScheme: ColorScheme
+                    @Composable
+                    get() = MaterialTheme.colorScheme.copy(surface = Color.Red)
             },
-            authenticationMethod = authenticationMethod,
-            onAvatarSelected = remember {
-                {
-                    cacheBuster = System.currentTimeMillis().toString()
-                }
-            },
-            onDismiss = remember {
-                {
-                    Toast.makeText(context, it.toString(), Toast.LENGTH_SHORT).show()
-                    showBottomSheet = false
-                }
-            },
-        )
+        ) {
+            GravatarQuickEditorBottomSheet(
+                gravatarQuickEditorParams = GravatarQuickEditorParams {
+                    email = Email(userEmail)
+                    avatarPickerContentLayout = pickerContentLayout
+                },
+                authenticationMethod = authenticationMethod,
+                onAvatarSelected = remember {
+                    {
+                        cacheBuster = System.currentTimeMillis().toString()
+                    }
+                },
+                onDismiss = remember {
+                    {
+                        Toast.makeText(context, it.toString(), Toast.LENGTH_SHORT).show()
+                        showBottomSheet = false
+                    }
+                },
+            )
+        }
     }
 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -70,17 +70,15 @@ public fun GravatarQuickEditorBottomSheet(
     onAvatarSelected: () -> Unit,
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
 ) {
-    CompositionLocalProvider(LocalGravatarTheme provides mainGravatarTheme) {
-        GravatarQuickEditorBottomSheet(
-            gravatarQuickEditorParams = gravatarQuickEditorParams,
-            authenticationMethod = authenticationMethod,
-            onAvatarSelected = onAvatarSelected,
-            onDismiss = onDismiss,
-            modalBottomSheetState = rememberGravatarModalBottomSheetState(
-                avatarPickerContentLayout = gravatarQuickEditorParams.avatarPickerContentLayout,
-            ),
-        )
-    }
+    GravatarQuickEditorBottomSheet(
+        gravatarQuickEditorParams = gravatarQuickEditorParams,
+        authenticationMethod = authenticationMethod,
+        onAvatarSelected = onAvatarSelected,
+        onDismiss = onDismiss,
+        modalBottomSheetState = rememberGravatarModalBottomSheetState(
+            avatarPickerContentLayout = gravatarQuickEditorParams.avatarPickerContentLayout,
+        ),
+    )
 }
 
 @Composable
@@ -91,27 +89,29 @@ internal fun GravatarQuickEditorBottomSheet(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
     modalBottomSheetState: ModalBottomSheetState,
 ) {
-    GravatarModalBottomSheet(
-        onDismiss = onDismiss,
-        modalBottomSheetState = modalBottomSheetState,
-    ) {
-        when (authenticationMethod) {
-            is AuthenticationMethod.Bearer -> {
-                GravatarQuickEditorPage(
-                    gravatarQuickEditorParams = gravatarQuickEditorParams,
-                    authToken = authenticationMethod.token,
-                    onDismiss = onDismiss,
-                    onAvatarSelected = onAvatarSelected,
-                )
-            }
+    CompositionLocalProvider(LocalGravatarTheme provides mainGravatarTheme) {
+        GravatarModalBottomSheet(
+            onDismiss = onDismiss,
+            modalBottomSheetState = modalBottomSheetState,
+        ) {
+            when (authenticationMethod) {
+                is AuthenticationMethod.Bearer -> {
+                    GravatarQuickEditorPage(
+                        gravatarQuickEditorParams = gravatarQuickEditorParams,
+                        authToken = authenticationMethod.token,
+                        onDismiss = onDismiss,
+                        onAvatarSelected = onAvatarSelected,
+                    )
+                }
 
-            is AuthenticationMethod.OAuth -> {
-                GravatarQuickEditorPage(
-                    gravatarQuickEditorParams = gravatarQuickEditorParams,
-                    oAuthParams = authenticationMethod.oAuthParams,
-                    onDismiss = onDismiss,
-                    onAvatarSelected = onAvatarSelected,
-                )
+                is AuthenticationMethod.OAuth -> {
+                    GravatarQuickEditorPage(
+                        gravatarQuickEditorParams = gravatarQuickEditorParams,
+                        oAuthParams = authenticationMethod.oAuthParams,
+                        onDismiss = onDismiss,
+                        onAvatarSelected = onAvatarSelected,
+                    )
+                }
             }
         }
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -46,6 +47,8 @@ import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorPage
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.ui.GravatarTheme
+import com.gravatar.ui.LocalGravatarTheme
+import com.gravatar.ui.mainGravatarTheme
 import kotlinx.coroutines.launch
 
 /**
@@ -67,15 +70,17 @@ public fun GravatarQuickEditorBottomSheet(
     onAvatarSelected: () -> Unit,
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
 ) {
-    GravatarQuickEditorBottomSheet(
-        gravatarQuickEditorParams = gravatarQuickEditorParams,
-        authenticationMethod = authenticationMethod,
-        onAvatarSelected = onAvatarSelected,
-        onDismiss = onDismiss,
-        modalBottomSheetState = rememberGravatarModalBottomSheetState(
-            avatarPickerContentLayout = gravatarQuickEditorParams.avatarPickerContentLayout,
-        ),
-    )
+    CompositionLocalProvider(LocalGravatarTheme provides mainGravatarTheme) {
+        GravatarQuickEditorBottomSheet(
+            gravatarQuickEditorParams = gravatarQuickEditorParams,
+            authenticationMethod = authenticationMethod,
+            onAvatarSelected = onAvatarSelected,
+            onDismiss = onDismiss,
+            modalBottomSheetState = rememberGravatarModalBottomSheetState(
+                avatarPickerContentLayout = gravatarQuickEditorParams.avatarPickerContentLayout,
+            ),
+        )
+    }
 }
 
 @Composable

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
@@ -4,9 +4,7 @@ import android.view.ViewGroup
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import com.composables.core.SheetDetent.Companion.Hidden
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod

--- a/gravatar-ui/api/gravatar-ui.api
+++ b/gravatar-ui/api/gravatar-ui.api
@@ -14,6 +14,7 @@ public final class com/gravatar/ui/GravatarThemeKt {
 	public static final fun GravatarTheme (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
 	public static final fun getGravatarTheme (Landroidx/compose/runtime/Composer;I)Lcom/gravatar/ui/GravatarTheme;
 	public static final fun getLocalGravatarTheme ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getMainGravatarTheme ()Lcom/gravatar/ui/GravatarTheme;
 }
 
 public abstract class com/gravatar/ui/components/ComponentState {

--- a/gravatar-ui/src/main/java/com/gravatar/ui/GravatarTheme.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/GravatarTheme.kt
@@ -53,16 +53,19 @@ public interface GravatarTheme {
 }
 
 /**
+ * [mainGravatarTheme] is the default [GravatarTheme] to be used in the Gravatar UI components.
+ */
+public val mainGravatarTheme: GravatarTheme = object : GravatarTheme {
+    override val colorScheme: ColorScheme
+        @Composable
+        get() = if (isSystemInDarkTheme()) DarkColorScheme else LightColorScheme
+}
+
+/**
  * [LocalGravatarTheme] is a CompositionLocal that provides the current [GravatarTheme].
  */
 public val LocalGravatarTheme: ProvidableCompositionLocal<GravatarTheme> =
-    staticCompositionLocalOf {
-        object : GravatarTheme {
-            override val colorScheme: ColorScheme
-                @Composable
-                get() = if (isSystemInDarkTheme()) DarkColorScheme else LightColorScheme
-        }
-    }
+    staticCompositionLocalOf { mainGravatarTheme }
 
 /** The current [GravatarTheme]. */
 public val gravatarTheme: GravatarTheme


### PR DESCRIPTION
Closes #332 
### Description

We don't want the QuickEditor theme to be overridden. It should be always obvious this is an official part of Gravatar even when implemented within a third-party app.

### Testing Steps

The Demo app now tries to modify the theme, so just smoke-test it and make sure the surface color in the QE is not RED.
