### PR TITLE
Gravatar UI: Filter hidden VerifiedAccount on Profile UI components

### DIFF
--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -95,8 +95,8 @@ private fun mediaList(profile: Profile): List<SocialMedia> {
     val mediaList = mutableListOf<SocialMedia>()
     // Force the Gravatar icon
     mediaList.add(SocialMedia(profile.profileUrl().url, LocalIcon.Gravatar.name, icon = LocalIcon.Gravatar))
-    // List and filter the other accounts from the profile, keep the same order coming from UserProfile.accounts list
-    profile.verifiedAccounts.forEach { account ->
+    // List and filter non hidden accounts from the profile, keep the same order coming from UserProfile.accounts list
+    profile.verifiedAccounts.filter { !it.isHidden }.forEach { account ->
         try {
             if (LocalIcon.valueForLabel(account.serviceLabel) != null) {
                 // Add local icon if the shortname exists in our predefined list
@@ -245,6 +245,13 @@ private fun SocialIconRowPreview() {
                 url = URI("https://example.com")
                 serviceIcon = URI("https://example.com/icon.svg")
                 isHidden = false
+            },
+            VerifiedAccount {
+                serviceType = "twitch"
+                serviceLabel = "Twitch"
+                url = URI("https://example.com")
+                serviceIcon = URI("https://example.com/icon.svg")
+                isHidden = true
             },
             VerifiedAccount {
                 serviceType = "tumblr"

--- a/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/ProfileTestUtils.kt
+++ b/gravatar-ui/src/test/java/com/gravatar/gravatar/ui/ProfileTestUtils.kt
@@ -21,6 +21,13 @@ internal fun completeProfile(
             isHidden = false
         },
         VerifiedAccount {
+            serviceType = "twitch"
+            serviceLabel = "Twitch"
+            url = URI("https://example.com")
+            serviceIcon = URI("https://example.com/icon.svg")
+            isHidden = true
+        },
+        VerifiedAccount {
             serviceType = "tumblr"
             serviceLabel = "Tumblr"
             url = URI("https://example.com")


### PR DESCRIPTION
Closes #356 

### Description

In #351 we updated the API with the `isHidden` value for Verified Accounts. We are not currently using that value, but we should hide it in our UI components, Verified Accounts, which the user has decided to keep hidden in the public profile.

<img width="376" alt="image" src="https://github.com/user-attachments/assets/ce98fa02-b6a2-4263-a234-0f744ee4dbb8">
 
### Testing Steps

1. Add some Verified Account in one of your Gravatar accounts
2. With the demo-app try to get your profile
3. Hide some Verified Account on the web
4. Verify that you don't see those accounts in the UI profile components.
