### PR TITLE
QuickEditor: Preventing queue the Snackbars when selecting an image

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/MainActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/MainActivity.kt
@@ -13,6 +13,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // Initialize the Gravatar SDK with the API key if it is available
+        @Suppress("UNNECESSARY_SAFE_CALL")
         BuildConfig.DEMO_GRAVATAR_API_KEY?.let { Gravatar.apiKey(it).context(applicationContext) }
 
         setContent {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -66,6 +66,7 @@ import com.yalantis.ucrop.UCrop
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import java.net.URI
 
@@ -85,6 +86,8 @@ internal fun AvatarPicker(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
     val scope = rememberCoroutineScope()
+    val avatarSelectedSnackbarMutex by remember { mutableStateOf(Mutex()) }
+    val avatarSelectedFailureSnackbarMutex by remember { mutableStateOf(Mutex()) }
 
     val uCropLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         it.data?.let { intentData ->
@@ -106,6 +109,8 @@ internal fun AvatarPicker(
                         context = context,
                         uCropLauncher = uCropLauncher,
                         scope = scope,
+                        avatarSelectedSnackbarMutex = avatarSelectedSnackbarMutex,
+                        avatarSelectedFailureSnackbarMutex = avatarSelectedFailureSnackbarMutex,
                     )
                 }
             }
@@ -216,15 +221,23 @@ private fun AvatarPickerAction.handle(
     context: Context,
     uCropLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>,
     scope: CoroutineScope,
+    avatarSelectedSnackbarMutex: Mutex,
+    avatarSelectedFailureSnackbarMutex: Mutex,
 ) {
     when (this) {
         is AvatarPickerAction.AvatarSelected -> {
             onAvatarSelected()
-            scope.launch {
-                snackState.showQESnackbar(
-                    message = context.getString(R.string.gravatar_qe_avatar_selected_confirmation),
-                    withDismissAction = true,
-                )
+            if (avatarSelectedSnackbarMutex.tryLock()) {
+                scope.launch {
+                    try {
+                        snackState.showQESnackbar(
+                            message = context.getString(R.string.gravatar_qe_avatar_selected_confirmation),
+                            withDismissAction = true,
+                        )
+                    } finally {
+                        avatarSelectedSnackbarMutex.unlock()
+                    }
+                }
             }
         }
 
@@ -233,12 +246,18 @@ private fun AvatarPickerAction.handle(
         }
 
         AvatarPickerAction.AvatarSelectionFailed -> {
-            scope.launch {
-                snackState.showQESnackbar(
-                    message = context.getString(R.string.gravatar_qe_avatar_selection_error),
-                    withDismissAction = true,
-                    snackbarType = SnackbarType.Error,
-                )
+            if (avatarSelectedFailureSnackbarMutex.tryLock()) {
+                scope.launch {
+                    try {
+                        snackState.showQESnackbar(
+                            message = context.getString(R.string.gravatar_qe_avatar_selection_error),
+                            withDismissAction = true,
+                            snackbarType = SnackbarType.Error,
+                        )
+                    } finally {
+                        avatarSelectedFailureSnackbarMutex.unlock()
+                    }
+                }
             }
         }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/extensions/QESnackbar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/extensions/QESnackbar.kt
@@ -51,16 +51,21 @@ internal suspend fun SnackbarHostState.showQESnackbar(
     snackbarType: SnackbarType = SnackbarType.Info,
     duration: SnackbarDuration =
         if (actionLabel == null) SnackbarDuration.Short else SnackbarDuration.Indefinite,
-): SnackbarResult {
-    return showSnackbar(
-        QESnackbarVisuals(
-            message = message,
-            withDismissAction = withDismissAction,
-            actionLabel = actionLabel,
-            duration = duration,
-            snackbarType = snackbarType,
-        ),
+): QESnackbarResult {
+    val visuals = QESnackbarVisuals(
+        message = message,
+        withDismissAction = withDismissAction,
+        actionLabel = actionLabel,
+        duration = duration,
+        snackbarType = snackbarType,
     )
+
+    // Only show the snackbar if the visuals are different from the current snackbar
+    return if (currentSnackbarData?.visuals != visuals) {
+        QESnackbarResult.fromSnackbarResult(showSnackbar(visuals))
+    } else {
+        QESnackbarResult.Skipped
+    }
 }
 
 internal val SnackbarType.containerColor: Color
@@ -78,4 +83,20 @@ internal val SnackbarType.contentColor: Color
 internal enum class SnackbarType {
     Info,
     Error,
+}
+
+internal enum class QESnackbarResult {
+    Dismissed,
+    ActionPerformed,
+    Skipped,
+    ;
+
+    companion object {
+        fun fromSnackbarResult(snackbarResult: SnackbarResult): QESnackbarResult {
+            return when (snackbarResult) {
+                SnackbarResult.Dismissed -> Dismissed
+                SnackbarResult.ActionPerformed -> ActionPerformed
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #364 

### Description

As described in issue #364, we are queueing snack bars when switching between avatars. If a previous snackbar is still visible, the next one is added to the queue and shown after the first one. 

We want to avoid that situation for both success and error snackbars. However, I think it makes sense to show a success snackbar after an error one, so we'll let snackbars to queue if they are from a different event.

<details>
<summary> Before </summary>

[Your text here...](https://github.com/user-attachments/assets/98b74234-bf94-4bf9-a178-c9a506d5a4d9)
</details>

<details>
<summary> After </summary>

https://github.com/user-attachments/assets/a8b0be91-9e7c-495c-8103-93377ee3a8ec
</details>

### Testing Steps

1. Open the QE with an account that has several avatars
2. Quickly switch between them
3. Verify snackbars are not queued
4. Turn off the device Internet connection
5. Quickly switch between them
6. Verify error snackbars are not queued