### PR TITLE
Refactor how MediaPickerPopup position is calculated

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/MediaPickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/MediaPickerPopup.kt
@@ -1,5 +1,6 @@
 package com.gravatar.quickeditor.ui.components
 
+import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.Spring
@@ -16,34 +17,45 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-import androidx.compose.ui.zIndex
+import com.composables.core.Dialog
+import com.composables.core.DialogPanel
+import com.composables.core.LocalModalWindow
+import com.composables.core.rememberDialogState
 import com.gravatar.quickeditor.R
 import com.gravatar.ui.GravatarTheme
 
 @Composable
 internal fun MediaPickerPopup(
-    alignment: Alignment,
-    offset: IntOffset,
+    anchorAlignment: Alignment.Horizontal,
+    anchorBounds: Rect,
     onDismissRequest: () -> Unit,
     onChoosePhotoClick: () -> Unit,
     onTakePhotoClick: () -> Unit,
 ) {
     MediaPickerPopup(
-        alignment = alignment,
-        offset = offset,
+        anchorAlignment = anchorAlignment,
+        anchorBounds = anchorBounds,
         onDismissRequest = onDismissRequest,
         onChoosePhotoClick = onChoosePhotoClick,
         onTakePhotoClick = onTakePhotoClick,
@@ -58,8 +70,8 @@ internal fun MediaPickerPopup(
 
 @Composable
 private fun MediaPickerPopup(
-    alignment: Alignment,
-    offset: IntOffset,
+    anchorAlignment: Alignment.Horizontal,
+    anchorBounds: Rect,
     onDismissRequest: () -> Unit,
     onChoosePhotoClick: () -> Unit,
     onTakePhotoClick: () -> Unit,
@@ -67,23 +79,29 @@ private fun MediaPickerPopup(
 ) {
     val cornerRadius = 8.dp
     // full screen background
-    Dialog(
-        onDismissRequest = {},
-        DialogProperties(
-            usePlatformDefaultWidth = false,
-        ),
-    ) {
-        (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.2f)
-        Box(
+    Dialog(state = rememberDialogState(initiallyVisible = true)) {
+        DialogPanel(
             modifier = Modifier
-                .fillMaxSize()
-                .zIndex(10F),
-            contentAlignment = Alignment.Center,
+                .fillMaxSize(),
         ) {
+            val window = LocalModalWindow.current
+            LaunchedEffect(Unit) {
+                window.apply {
+                    addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+                    setDimAmount(0.2f)
+                }
+            }
+            val configuration = LocalConfiguration.current
+            val screenWidth = configuration.screenWidthDp.dp.dpToPx()
+            var popupSize by remember { mutableStateOf(IntSize.Zero) }
+
             Popup(
-                alignment = alignment,
+                alignment = Alignment.TopStart,
                 onDismissRequest = onDismissRequest,
-                offset = offset,
+                offset = IntOffset(
+                    calculatePopupXOffset(anchorAlignment, anchorBounds, popupSize, screenWidth),
+                    (anchorBounds.top - popupSize.height - 10.dp.dpToPx()).toInt(),
+                ),
                 properties = PopupProperties(focusable = true),
             ) {
                 AnimatedVisibility(
@@ -92,7 +110,10 @@ private fun MediaPickerPopup(
                 ) {
                     Surface(
                         modifier = Modifier
-                            .fillMaxWidth(0.6f),
+                            .fillMaxWidth(0.6f)
+                            .onGloballyPositioned {
+                                popupSize = it.size
+                            },
                         shape = RoundedCornerShape(cornerRadius),
                         tonalElevation = 3.dp,
                         shadowElevation = 2.dp,
@@ -125,6 +146,26 @@ private fun MediaPickerPopup(
     }
 }
 
+private fun calculatePopupXOffset(
+    anchorAlignment: Alignment.Horizontal,
+    anchorBounds: Rect,
+    popupSize: IntSize,
+    screenWidth: Float,
+): Int {
+    return when (anchorAlignment) {
+        Alignment.Start -> {
+            anchorBounds.left.toInt()
+        }
+        // Default to Alignment.CenterHorizontally
+        else -> {
+            ((screenWidth - popupSize.width) / 2).toInt()
+        }
+    }
+}
+
+@Composable
+private fun Dp.dpToPx() = with(LocalDensity.current) { this@dpToPx.toPx() }
+
 @Preview
 @Composable
 private fun MediaPickerPopupPreview() {
@@ -135,9 +176,9 @@ private fun MediaPickerPopupPreview() {
                 .background(MaterialTheme.colorScheme.background),
         ) {
             MediaPickerPopup(
-                alignment = Alignment.TopStart,
+                anchorAlignment = Alignment.Start,
                 onDismissRequest = {},
-                offset = IntOffset(0, 0),
+                anchorBounds = Rect(Offset(0f, 300f), Size(1f, 1f)),
                 onChoosePhotoClick = {},
                 onTakePhotoClick = {},
                 state = remember { MutableTransitionState(true) },

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/MediaPickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/MediaPickerPopup.kt
@@ -1,6 +1,5 @@
 package com.gravatar.quickeditor.ui.components
 
-import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.Spring
@@ -17,7 +16,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
@@ -40,7 +39,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.composables.core.Dialog
 import com.composables.core.DialogPanel
-import com.composables.core.LocalModalWindow
+import com.composables.core.Scrim
 import com.composables.core.rememberDialogState
 import com.gravatar.quickeditor.R
 import com.gravatar.ui.GravatarTheme
@@ -80,17 +79,11 @@ private fun MediaPickerPopup(
     val cornerRadius = 8.dp
     // full screen background
     Dialog(state = rememberDialogState(initiallyVisible = true)) {
+        Scrim(scrimColor = Color.Black.copy(alpha = 0.2f))
         DialogPanel(
             modifier = Modifier
                 .fillMaxSize(),
         ) {
-            val window = LocalModalWindow.current
-            LaunchedEffect(Unit) {
-                window.apply {
-                    addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-                    setDimAmount(0.2f)
-                }
-            }
             val configuration = LocalConfiguration.current
             val screenWidth = configuration.screenWidthDp.dp.dpToPx()
             var popupSize by remember { mutableStateOf(IntSize.Zero) }


### PR DESCRIPTION
Closes #367

### Description

On some devices, the `MediaPickerPopup` wouldn't be shown in the correct position on the screen. It's unclear why there would be a different behavior but it seemed like it could be caused by window insets. 

Anyway, I couldn't figure out how to fix the calculation with the previous logic, so I've decided to change how the position is calculated.  

Instead of doing the calculation outside of the `MediaPickerPopup` I have now put that logic inside the component. We now have to pass the anchor bounds rather than an already calculated offset. The alignment of the `Popup` is now hardcoded so we always know from where the offset will be calculated. In the new calculations, we include the `Popup` size as well, and this is the crucial part here. Additionally, I have allowed for basic customization to meet our needs. `anchorAlignment` can be passed (the difference between horizontal and vertical avatar picker content layout) to define how the horizontal anchor offset should be calculated. 

You can also notice that I replaced the `Dialog` from material library with the one from Composable Unstyled. The reason for that is because the `anchorBounds` we get are in relation to the whole screen (status and navigation bars included) but the material `Dialog` is only drawn in the safe area, meaning the `anchorBounds` could actually be bigger the whole available space of the dialog. This makes it impossible to properly draw the popup in a correct position. The one from the Composable Unstyled will be drawn fully unless limited by proper modifiers. 

| Before | After |
|---|---|
| <img width="449" alt="Screenshot 2024-10-23 at 15 49 03" src="https://github.com/user-attachments/assets/d46a43f7-6098-47d7-9c9e-9f4023ad2f42"> | <img width="468" alt="Screenshot 2024-10-23 at 15 45 09" src="https://github.com/user-attachments/assets/af74358e-24ea-46a5-a271-fc929e65261d"> |
| <img width="449" alt="Screenshot 2024-10-23 at 15 49 11" src="https://github.com/user-attachments/assets/1a59b17a-0de2-4c8a-af43-26ab914ea8fc"> | <img width="468" alt="Screenshot 2024-10-23 at 15 45 26" src="https://github.com/user-attachments/assets/571c512e-fb22-47ad-a917-06bca637e128"> |
| <img width="449" alt="Screenshot 2024-10-23 at 15 48 49" src="https://github.com/user-attachments/assets/10f04c74-9b01-42ea-b215-d8bb34dc7295"> | <img width="468" alt="Screenshot 2024-10-23 at 15 46 43" src="https://github.com/user-attachments/assets/0cde0981-09de-4a92-a422-a94b15b3abc8"> |

### Testing Steps

It's possible to test this with Pixel 6 Pro emulator (with device frame - not sure if that matters). I can repro this on all physical devices I have, only some emulators worked fine with the previous logic.

1. Go to the QE and tap `Upload image` 
2. Confirm the popup is aligned properly - it should be slightly above the upload button
3. Repeat with Vertical layout with images and an empty list. 



