### PR TITLE
Update to the latest OpenAPI spec

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -77,7 +77,7 @@ comments:
     searchProtectedProperty: false
   OutdatedDocumentation:
     active: true
-    excludes: [ '**/test/**', '**/androidTest/**', '**/demoapp/**', '**/api/models/**', '**/restapi/models/**' ]
+    excludes: [ '**/test/**', '**/androidTest/**', '**/demoapp/**', '**/restapi/models/**', '**/restapi/apis/**' ]
     matchTypeParameters: true
     matchDeclarationsOrder: true
     allowParamOnConstructorProperties: false

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -49,17 +49,20 @@ internal class AvatarRepository(
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
     }
 
-    suspend fun uploadAvatar(email: Email, avatarUri: Uri): GravatarResult<Avatar, QuickEditorError> = withContext(
-        dispatcher,
-    ) {
-        val token = tokenStorage.getToken(email.hash().toString())
-        token?.let {
-            when (val result = avatarService.uploadCatching(avatarUri.toFile(), token)) {
-                is GravatarResult.Success -> GravatarResult.Success(result.value)
-                is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
-            }
-        } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
-    }
+    suspend fun uploadAvatar(email: Email, avatarUri: Uri): GravatarResult<Avatar, QuickEditorError> =
+        withContext(dispatcher) {
+            val hash = email.hash()
+            val token = tokenStorage.getToken(hash.toString())
+            token?.let {
+                when (
+                    val result =
+                        avatarService.uploadCatching(avatarUri.toFile(), hash, selectAvatar = false, token)
+                ) {
+                    is GravatarResult.Success -> GravatarResult.Success(result.value)
+                    is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
+                }
+            } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
+        }
 }
 
 internal data class EmailAvatars(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -49,20 +49,23 @@ internal class AvatarRepository(
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
     }
 
-    suspend fun uploadAvatar(email: Email, avatarUri: Uri): GravatarResult<Avatar, QuickEditorError> =
-        withContext(dispatcher) {
-            val hash = email.hash()
-            val token = tokenStorage.getToken(hash.toString())
-            token?.let {
-                when (
-                    val result =
-                        avatarService.uploadCatching(avatarUri.toFile(), hash, selectAvatar = false, token)
-                ) {
-                    is GravatarResult.Success -> GravatarResult.Success(result.value)
-                    is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
-                }
-            } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
-        }
+    suspend fun uploadAvatar(
+        email: Email,
+        avatarUri: Uri,
+        selectAvatar: Boolean,
+    ): GravatarResult<Avatar, QuickEditorError> = withContext(dispatcher) {
+        val hash = email.hash()
+        val token = tokenStorage.getToken(hash.toString())
+        token?.let {
+            when (
+                val result =
+                    avatarService.uploadCatching(avatarUri.toFile(), hash, selectAvatar, token)
+            ) {
+                is GravatarResult.Success -> GravatarResult.Success(result.value)
+                is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
+            }
+        } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
+    }
 }
 
 internal data class EmailAvatars(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -49,23 +49,19 @@ internal class AvatarRepository(
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
     }
 
-    suspend fun uploadAvatar(
-        email: Email,
-        avatarUri: Uri,
-        selectAvatar: Boolean,
-    ): GravatarResult<Avatar, QuickEditorError> = withContext(dispatcher) {
-        val hash = email.hash()
-        val token = tokenStorage.getToken(hash.toString())
-        token?.let {
-            when (
-                val result =
-                    avatarService.uploadCatching(avatarUri.toFile(), hash, selectAvatar, token)
-            ) {
-                is GravatarResult.Success -> GravatarResult.Success(result.value)
-                is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
-            }
-        } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
-    }
+    suspend fun uploadAvatar(email: Email, avatarUri: Uri): GravatarResult<Avatar, QuickEditorError> =
+        withContext(dispatcher) {
+            val hash = email.hash()
+            val token = tokenStorage.getToken(hash.toString())
+            token?.let {
+                when (
+                    val result = avatarService.uploadCatching(avatarUri.toFile(), token, hash)
+                ) {
+                    is GravatarResult.Success -> GravatarResult.Success(result.value)
+                    is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
+                }
+            } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
+        }
 }
 
 internal data class EmailAvatars(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -143,37 +143,37 @@ internal class AvatarPickerViewModel(
                     failedUploadDialog = null,
                 )
             }
-            when (val result = avatarRepository.uploadAvatar(email, uri)) {
+            val selectAvatar = _uiState.value.emailAvatars?.selectedAvatarId == null
+            when (val result = avatarRepository.uploadAvatar(email, uri, selectAvatar)) {
                 is GravatarResult.Success -> {
                     fileUtils.deleteFile(uri)
-                    val isAutoSelected = _uiState.value.emailAvatars?.selectedAvatarId == null
-                    if (isAutoSelected) {
-                        fetchAvatars(showLoading = false, scrollToSelected = true)
-                        _uiState.update { currentState ->
-                            currentState.copy(
-                                uploadingAvatar = null,
-                                avatarUpdates = currentState.avatarUpdates.inc(),
-                            )
-                        }
-                        if (_uiState.value.emailAvatars?.selectedAvatarId != null) {
-                            _actions.send(AvatarPickerAction.AvatarSelected)
-                        }
-                    } else {
-                        _uiState.update { currentState ->
-                            val avatar = result.value
-                            currentState.copy(
-                                uploadingAvatar = null,
-                                emailAvatars = currentState.emailAvatars?.copy(
-                                    avatars = buildList {
-                                        add(avatar)
-                                        addAll(
-                                            currentState.emailAvatars.avatars.filter { it.imageId != avatar.imageId },
-                                        )
-                                    },
-                                ),
-                                scrollToIndex = null,
-                            )
-                        }
+                    val avatar = result.value
+                    if (avatar.selected == true) {
+                        _actions.send(AvatarPickerAction.AvatarSelected)
+                    }
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            uploadingAvatar = null,
+                            emailAvatars = currentState.emailAvatars?.copy(
+                                avatars = buildList {
+                                    add(avatar)
+                                    addAll(
+                                        currentState.emailAvatars.avatars.filter { it.imageId != avatar.imageId },
+                                    )
+                                },
+                                selectedAvatarId = if (avatar.selected == true) {
+                                    avatar.imageId
+                                } else {
+                                    currentState.emailAvatars.selectedAvatarId
+                                },
+                            ),
+                            scrollToIndex = null,
+                            avatarUpdates = if (avatar.selected == true) {
+                                currentState.avatarUpdates.inc()
+                            } else {
+                                currentState.avatarUpdates
+                            },
+                        )
                     }
                 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -143,8 +143,7 @@ internal class AvatarPickerViewModel(
                     failedUploadDialog = null,
                 )
             }
-            val selectAvatar = _uiState.value.emailAvatars?.selectedAvatarId == null
-            when (val result = avatarRepository.uploadAvatar(email, uri, selectAvatar)) {
+            when (val result = avatarRepository.uploadAvatar(email, uri)) {
                 is GravatarResult.Success -> {
                     fileUtils.deleteFile(uri)
                     val avatar = result.value

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -121,7 +121,9 @@ class AvatarRepositoryTest {
     fun `given token not stored when avatar upload then Failure result`() = runTest {
         val uri = mockk<Uri>()
         coEvery { tokenStorage.getToken(any()) } returns null
-        coEvery { avatarService.uploadCatching(any(), any()) } returns GravatarResult.Success(createAvatar("1"))
+        coEvery {
+            avatarService.uploadCatching(any(), any(), any(), any())
+        } returns GravatarResult.Success(createAvatar("1"))
 
         val result = avatarRepository.uploadAvatar(email, uri)
 
@@ -137,7 +139,7 @@ class AvatarRepositoryTest {
             every { toFile() } returns file
         }
         coEvery { tokenStorage.getToken(any()) } returns "token"
-        coEvery { avatarService.uploadCatching(any(), any()) } returns GravatarResult.Success(avatar)
+        coEvery { avatarService.uploadCatching(any(), any(), any(), any()) } returns GravatarResult.Success(avatar)
 
         val result = avatarRepository.uploadAvatar(email, uri)
 
@@ -152,7 +154,9 @@ class AvatarRepositoryTest {
             every { toFile() } returns file
         }
         coEvery { tokenStorage.getToken(any()) } returns "token"
-        coEvery { avatarService.uploadCatching(any(), any()) } returns GravatarResult.Failure(ErrorType.Server)
+        coEvery {
+            avatarService.uploadCatching(any(), any(), any(), any())
+        } returns GravatarResult.Failure(ErrorType.Server)
 
         val result = avatarRepository.uploadAvatar(email, uri)
 

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -125,7 +125,7 @@ class AvatarRepositoryTest {
             avatarService.uploadCatching(any(), any(), any(), any())
         } returns GravatarResult.Success(createAvatar("1"))
 
-        val result = avatarRepository.uploadAvatar(email, uri)
+        val result = avatarRepository.uploadAvatar(email, uri, false)
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.TokenNotFound), result)
     }
@@ -141,7 +141,7 @@ class AvatarRepositoryTest {
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery { avatarService.uploadCatching(any(), any(), any(), any()) } returns GravatarResult.Success(avatar)
 
-        val result = avatarRepository.uploadAvatar(email, uri)
+        val result = avatarRepository.uploadAvatar(email, uri, false)
 
         assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(avatar), result)
     }
@@ -158,7 +158,7 @@ class AvatarRepositoryTest {
             avatarService.uploadCatching(any(), any(), any(), any())
         } returns GravatarResult.Failure(ErrorType.Server)
 
-        val result = avatarRepository.uploadAvatar(email, uri)
+        val result = avatarRepository.uploadAvatar(email, uri, false)
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)), result)
     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -125,7 +125,7 @@ class AvatarRepositoryTest {
             avatarService.uploadCatching(any(), any(), any(), any())
         } returns GravatarResult.Success(createAvatar("1"))
 
-        val result = avatarRepository.uploadAvatar(email, uri, false)
+        val result = avatarRepository.uploadAvatar(email, uri)
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.TokenNotFound), result)
     }
@@ -141,7 +141,7 @@ class AvatarRepositoryTest {
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery { avatarService.uploadCatching(any(), any(), any(), any()) } returns GravatarResult.Success(avatar)
 
-        val result = avatarRepository.uploadAvatar(email, uri, false)
+        val result = avatarRepository.uploadAvatar(email, uri)
 
         assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(avatar), result)
     }
@@ -158,7 +158,7 @@ class AvatarRepositoryTest {
             avatarService.uploadCatching(any(), any(), any(), any())
         } returns GravatarResult.Failure(ErrorType.Server)
 
-        val result = avatarRepository.uploadAvatar(email, uri, false)
+        val result = avatarRepository.uploadAvatar(email, uri)
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)), result)
     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -305,7 +305,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val uploadedAvatar = createAvatar("3")
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
+        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Success(uploadedAvatar)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
@@ -355,7 +355,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val uploadedAvatar = createAvatar("2")
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
+        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Success(uploadedAvatar)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
@@ -409,7 +409,7 @@ class AvatarPickerViewModelTest {
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
@@ -455,7 +455,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
-            avatarRepository.uploadAvatar(any(), any())
+            avatarRepository.uploadAvatar(any(), any(), any())
         } returns GravatarResult.Success(createAvatar("3"))
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
@@ -489,7 +489,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
-            avatarRepository.uploadAvatar(any(), any())
+            avatarRepository.uploadAvatar(any(), any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
@@ -524,7 +524,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriOne))
@@ -536,7 +536,7 @@ class AvatarPickerViewModelTest {
             expectMostRecentItem()
 
             coEvery {
-                avatarRepository.uploadAvatar(any(), any())
+                avatarRepository.uploadAvatar(any(), any(), any())
             } returns GravatarResult.Success(createAvatar("1"))
 
             viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriTwo))
@@ -585,7 +585,7 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Failure(invalidRequest)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
         viewModel = initViewModel()
@@ -608,7 +608,7 @@ class AvatarPickerViewModelTest {
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
-            avatarRepository.uploadAvatar(any(), any())
+            avatarRepository.uploadAvatar(any(), any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
@@ -634,7 +634,7 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Failure(invalidRequest)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
         viewModel = initViewModel()
@@ -660,7 +660,7 @@ class AvatarPickerViewModelTest {
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
-            avatarRepository.uploadAvatar(any(), any())
+            avatarRepository.uploadAvatar(any(), any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
@@ -709,7 +709,7 @@ class AvatarPickerViewModelTest {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
         val uploadedAvatar = createAvatar(id = "1", isSelected = true)
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
+        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Success(uploadedAvatar)
 
         viewModel = initViewModel()
 
@@ -719,10 +719,9 @@ class AvatarPickerViewModelTest {
             expectMostRecentItem()
 
             val emailAvatarsUpdated = emailAvatars.copy(
-                avatars = listOf(createAvatar("1"), createAvatar("3")),
+                avatars = listOf(createAvatar("1", isSelected = true), createAvatar("3", isSelected = false)),
                 selectedAvatarId = "1",
             )
-            coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsUpdated)
             viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriOne))
 
             // State before upload starts
@@ -741,25 +740,6 @@ class AvatarPickerViewModelTest {
                 avatarPickerUiState,
                 awaitItem(),
             )
-
-            // State produced by fetchAvatars within Upload.Success
-            avatarPickerUiState = AvatarPickerUiState(
-                email = email,
-                emailAvatars = emailAvatarsUpdated,
-                error = null,
-                profile = ComponentState.Loaded(profile),
-                selectingAvatarId = null,
-                uploadingAvatar = uriOne,
-                scrollToIndex = 0,
-                avatarPickerContentLayout = avatarPickerContentLayout,
-                avatarUpdates = 0,
-            )
-
-            assertEquals(
-                avatarPickerUiState,
-                awaitItem(),
-            )
-
             // State produced before finishing uploadAvatar, just after fetchAvatars has finished
             avatarPickerUiState = AvatarPickerUiState(
                 email = email,
@@ -768,11 +748,10 @@ class AvatarPickerViewModelTest {
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = null,
                 uploadingAvatar = null,
-                scrollToIndex = 0,
+                scrollToIndex = null,
                 avatarPickerContentLayout = avatarPickerContentLayout,
                 avatarUpdates = 1,
             )
-
             assertEquals(
                 avatarPickerUiState,
                 awaitItem(),

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -305,7 +305,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val uploadedAvatar = createAvatar("3")
-        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Success(uploadedAvatar)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
@@ -355,7 +355,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val uploadedAvatar = createAvatar("2")
-        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Success(uploadedAvatar)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
         viewModel = initViewModel()
@@ -409,7 +409,7 @@ class AvatarPickerViewModelTest {
         val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
@@ -455,7 +455,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
-            avatarRepository.uploadAvatar(any(), any(), any())
+            avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Success(createAvatar("3"))
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
@@ -489,7 +489,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
-            avatarRepository.uploadAvatar(any(), any(), any())
+            avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
 
@@ -524,7 +524,7 @@ class AvatarPickerViewModelTest {
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
-        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriOne))
@@ -536,7 +536,7 @@ class AvatarPickerViewModelTest {
             expectMostRecentItem()
 
             coEvery {
-                avatarRepository.uploadAvatar(any(), any(), any())
+                avatarRepository.uploadAvatar(any(), any())
             } returns GravatarResult.Success(createAvatar("1"))
 
             viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriTwo))
@@ -585,7 +585,7 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
         viewModel = initViewModel()
@@ -608,7 +608,7 @@ class AvatarPickerViewModelTest {
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
-            avatarRepository.uploadAvatar(any(), any(), any())
+            avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
@@ -634,7 +634,7 @@ class AvatarPickerViewModelTest {
         val uri = mockk<Uri>()
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Failure(invalidRequest)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
         viewModel = initViewModel()
@@ -660,7 +660,7 @@ class AvatarPickerViewModelTest {
         val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
-            avatarRepository.uploadAvatar(any(), any(), any())
+            avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
 
@@ -709,7 +709,7 @@ class AvatarPickerViewModelTest {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
         val uploadedAvatar = createAvatar(id = "1", isSelected = true)
-        coEvery { avatarRepository.uploadAvatar(any(), any(), any()) } returns GravatarResult.Success(uploadedAvatar)
+        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
 
         viewModel = initViewModel()
 

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -647,8 +647,8 @@ public final class com/gravatar/services/AvatarService {
 	public final fun retrieveCatching (Ljava/lang/String;Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAvatar (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAvatarCatching (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun upload (Ljava/io/File;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun uploadCatching (Ljava/io/File;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun upload (Ljava/io/File;Lcom/gravatar/types/Hash;ZLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun uploadCatching (Ljava/io/File;Lcom/gravatar/types/Hash;ZLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/gravatar/services/ErrorType {

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -647,8 +647,10 @@ public final class com/gravatar/services/AvatarService {
 	public final fun retrieveCatching (Ljava/lang/String;Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAvatar (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAvatarCatching (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun upload (Ljava/io/File;Lcom/gravatar/types/Hash;ZLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun uploadCatching (Ljava/io/File;Lcom/gravatar/types/Hash;ZLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun upload (Ljava/io/File;Ljava/lang/String;Lcom/gravatar/types/Hash;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun upload$default (Lcom/gravatar/services/AvatarService;Ljava/io/File;Ljava/lang/String;Lcom/gravatar/types/Hash;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun uploadCatching (Ljava/io/File;Ljava/lang/String;Lcom/gravatar/types/Hash;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun uploadCatching$default (Lcom/gravatar/services/AvatarService;Ljava/io/File;Ljava/lang/String;Lcom/gravatar/types/Hash;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/gravatar/services/ErrorType {

--- a/gravatar/openapi/api-gravatar.json
+++ b/gravatar/openapi/api-gravatar.json
@@ -610,7 +610,8 @@
           "implicit": {
             "authorizationUrl": "https://public-api.wordpress.com/oauth2/authorize",
             "tokenUrl": "https://public-api.wordpress.com/oauth2/token",
-            "scopes": {}
+            "scopes": {
+            }
           }
         },
         "description": "WordPress OAuth token to authenticate the request."
@@ -818,10 +819,10 @@
           {
             "name": "selected_email_hash",
             "in": "query",
-            "description": "The sha256 hash of the email address used to determine which avatar is selected. The 'selected' attribute in the avatar list will be set to 'true' for the avatar associated with this email.",
+            "description": "The SHA256 hash of the email address used to determine which avatar is selected. The 'selected' attribute in the avatar list will be set to 'true' for the avatar associated with this email.",
             "schema": {
               "type": "string",
-              "default": null
+              "default": ""
             }
           }
         ],
@@ -859,6 +860,30 @@
         "security": [
           {
             "oauth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "selected_email_hash",
+            "in": "query",
+            "description": "The SHA256 hash of email. If provided, the uploaded image will be selected as the avatar for this email.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "select_avatar",
+            "in": "query",
+            "description": "Determines if the uploaded image should be set as the avatar for the email. If not passed, the image is only selected as the email's avatar if no previous avatar has been set. Accepts '1'/'true' to always set the avatar or '0'/'false' to never set the avatar.",
+            "required": false,
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            }
           }
         ],
         "requestBody": {

--- a/gravatar/src/main/java/com/gravatar/restapi/apis/AvatarsApi.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/apis/AvatarsApi.kt
@@ -28,12 +28,12 @@ internal interface AvatarsApi {
      *  - 401: Not Authorized
      *  - 403: Insufficient Scope
      *
-     * @param selectedEmailHash The sha256 hash of the email address used to determine which avatar is selected. The &#39;selected&#39; attribute in the avatar list will be set to &#39;true&#39; for the avatar associated with this email. (optional, default to "null")
+     * @param selectedEmailHash The SHA256 hash of the email address used to determine which avatar is selected. The &#39;selected&#39; attribute in the avatar list will be set to &#39;true&#39; for the avatar associated with this email. (optional, default to "")
      * @return [kotlin.collections.List<Avatar>]
      */
     @GET("me/avatars")
     suspend fun getAvatars(
-        @Query("selected_email_hash") selectedEmailHash: kotlin.String? = "null",
+        @Query("selected_email_hash") selectedEmailHash: kotlin.String? = "",
     ): Response<kotlin.collections.List<Avatar>>
 
     /**
@@ -64,11 +64,15 @@ internal interface AvatarsApi {
      *  - 403: Insufficient Scope
      *
      * @param `data` The avatar image file
+     * @param selectedEmailHash The SHA256 hash of email. If provided, the uploaded image will be selected as the avatar for this email. (optional)
+     * @param selectAvatar Determines if the uploaded image should be set as the avatar for the email. If not passed, the image is only selected as the email&#39;s avatar if no previous avatar has been set. Accepts &#39;1&#39;/&#39;true&#39; to always set the avatar or &#39;0&#39;/&#39;false&#39; to never set the avatar. (optional, default to null)
      * @return [Avatar]
      */
     @Multipart
     @POST("me/avatars")
     suspend fun uploadAvatar(
         @Part `data`: MultipartBody.Part,
+        @Query("selected_email_hash") selectedEmailHash: kotlin.String? = null,
+        @Query("select_avatar") selectAvatar: kotlin.Boolean? = null,
     ): Response<Avatar>
 }

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -47,7 +47,7 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
 
             val response = service.uploadAvatar(
                 data = filePart,
-                selectedEmailHash = hash.toString(),
+                selectedEmailHash = hash?.toString(),
                 selectAvatar = selectAvatar,
             )
 

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -27,36 +27,42 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
      * Uploads an image to be used as Gravatar avatar.
      *
      * @param file The image file to upload
-     * @param hash The hash of the email to associate the avatar with
-     * @param selectAvatar Determines if the uploaded image should be set automatically as the avatar for the given hash
      * @param oauthToken The OAuth token to use for authentication
+     * @param hash The hash of the email to associate the avatar with.
+     * If null the primary email of the account will be used.
+     * @param selectAvatar Determines if the uploaded image should be set automatically as the avatar
+     * for the given hash. If null, the avatar will be selected only if no other avatar is set.
      */
-    public suspend fun upload(file: File, hash: Hash, selectAvatar: Boolean, oauthToken: String): Avatar =
-        runThrowingExceptionRequest {
-            withContext(GravatarSdkDI.dispatcherIO) {
-                val service = instance.getGravatarV3Service(okHttpClient, oauthToken)
+    public suspend fun upload(
+        file: File,
+        oauthToken: String,
+        hash: Hash? = null,
+        selectAvatar: Boolean? = null,
+    ): Avatar = runThrowingExceptionRequest {
+        withContext(GravatarSdkDI.dispatcherIO) {
+            val service = instance.getGravatarV3Service(okHttpClient, oauthToken)
 
-                val filePart =
-                    MultipartBody.Part.createFormData("image", file.name, file.asRequestBody())
+            val filePart =
+                MultipartBody.Part.createFormData("image", file.name, file.asRequestBody())
 
-                val response = service.uploadAvatar(
-                    data = filePart,
-                    selectedEmailHash = hash.toString(),
-                    selectAvatar = selectAvatar,
+            val response = service.uploadAvatar(
+                data = filePart,
+                selectedEmailHash = hash.toString(),
+                selectAvatar = selectAvatar,
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                response.body()!!
+            } else {
+                // Log the response body for debugging purposes if the response is not successful
+                Logger.w(
+                    LOG_TAG,
+                    "Network call unsuccessful trying to upload Gravatar: $response.body",
                 )
-
-                if (response.isSuccessful && response.body() != null) {
-                    response.body()!!
-                } else {
-                    // Log the response body for debugging purposes if the response is not successful
-                    Logger.w(
-                        LOG_TAG,
-                        "Network call unsuccessful trying to upload Gravatar: $response.body",
-                    )
-                    throw HttpException(response)
-                }
+                throw HttpException(response)
             }
         }
+    }
 
     /**
      * Uploads an image to be used as Gravatar avatar.
@@ -64,18 +70,20 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
      * the execution and return it as a [GravatarResult.Failure].
      *
      * @param file The image file to upload
-     * @param hash The hash of the email to associate the avatar with
-     * @param selectAvatar Determines if the uploaded image should be set automatically as the avatar for the given hash
      * @param oauthToken The OAuth token to use for authentication
      * @return The result of the operation
+     * @param hash The hash of the email to associate the avatar with.
+     * If null the primary email of the account will be used.
+     * @param selectAvatar Determines if the uploaded image should be set automatically as the avatar
+     * for the given hash. If null, the avatar will be selected only if no other avatar is set.
      */
     public suspend fun uploadCatching(
         file: File,
-        hash: Hash,
-        selectAvatar: Boolean,
         oauthToken: String,
+        hash: Hash? = null,
+        selectAvatar: Boolean? = null,
     ): GravatarResult<Avatar, ErrorType> = runCatchingRequest {
-        upload(file, hash, selectAvatar, oauthToken)
+        upload(file, oauthToken, hash, selectAvatar)
     }
 
     /**

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -2,6 +2,7 @@ package com.gravatar.services
 
 import com.gravatar.GravatarSdkContainerRule
 import com.gravatar.restapi.models.Avatar
+import com.gravatar.types.Hash
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -44,10 +45,15 @@ class AvatarServiceTest {
             every { isSuccessful } returns true
             every { body() } returns avatar
         }
-        coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+        coEvery { containerRule.gravatarApiMock.uploadAvatar(any(), any(), any()) } returns mockResponse
         every { mockResponse.isSuccessful } returns true
 
-        avatarService.upload(File("avatarFile"), oauthToken)
+        avatarService.upload(
+            File("avatarFile"),
+            Hash("hash"),
+            selectAvatar = false,
+            oauthToken,
+        )
 
         coVerify(exactly = 1) {
             containerRule.gravatarApiMock.uploadAvatar(
@@ -58,6 +64,8 @@ class AvatarServiceTest {
                         },
                     )
                 },
+                withArg { },
+                withArg { },
             )
         }
     }
@@ -69,9 +77,14 @@ class AvatarServiceTest {
                 every { isSuccessful } returns false
                 every { code() } returns 500
             }
-            coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+            coEvery { containerRule.gravatarApiMock.uploadAvatar(any(), any(), any()) } returns mockResponse
 
-            avatarService.upload(File("avatarFile"), oauthToken)
+            avatarService.upload(
+                File("avatarFile"),
+                Hash("hash"),
+                selectAvatar = false,
+                oauthToken,
+            )
         }
 
     @Test
@@ -80,9 +93,14 @@ class AvatarServiceTest {
             every { isSuccessful } returns true
             every { body() } returns avatar
         }
-        coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+        coEvery { containerRule.gravatarApiMock.uploadAvatar(any(), any(), any()) } returns mockResponse
 
-        val response = avatarService.uploadCatching(File("avatarFile"), oauthToken)
+        val response = avatarService.uploadCatching(
+            File("avatarFile"),
+            Hash("hash"),
+            selectAvatar = false,
+            oauthToken,
+        )
 
         coVerify(exactly = 1) {
             containerRule.gravatarApiMock.uploadAvatar(
@@ -93,6 +111,8 @@ class AvatarServiceTest {
                         },
                     )
                 },
+                withArg { },
+                withArg { },
             )
         }
 
@@ -105,9 +125,14 @@ class AvatarServiceTest {
             every { isSuccessful } returns false
             every { code() } returns 500
         }
-        coEvery { containerRule.gravatarApiMock.uploadAvatar(any()) } returns mockResponse
+        coEvery { containerRule.gravatarApiMock.uploadAvatar(any(), any(), any()) } returns mockResponse
 
-        val response = avatarService.uploadCatching(File("avatarFile"), oauthToken)
+        val response = avatarService.uploadCatching(
+            File("avatarFile"),
+            Hash("hash"),
+            selectAvatar = false,
+            oauthToken,
+        )
 
         coVerify(exactly = 1) {
             containerRule.gravatarApiMock.uploadAvatar(
@@ -118,6 +143,8 @@ class AvatarServiceTest {
                         },
                     )
                 },
+                withArg { },
+                withArg { },
             )
         }
 

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import retrofit2.Response
 import java.io.File
 import java.net.URI
+import kotlin.test.assertNull
 
 class AvatarServiceTest {
     @get:Rule
@@ -66,6 +67,37 @@ class AvatarServiceTest {
                 },
                 withArg { },
                 withArg { },
+            )
+        }
+    }
+
+    @Test
+    fun `given null optional params when uploading avatar then null values passed`() = runTest {
+        val mockResponse = mockk<Response<Avatar>>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body() } returns avatar
+        }
+        coEvery { containerRule.gravatarApiMock.uploadAvatar(any(), any(), any()) } returns mockResponse
+        every { mockResponse.isSuccessful } returns true
+
+        avatarService.upload(
+            File("avatarFile"),
+            oauthToken,
+            null,
+            null,
+        )
+
+        coVerify(exactly = 1) {
+            containerRule.gravatarApiMock.uploadAvatar(
+                withArg {
+                    assertTrue(
+                        with(it.headers?.values("Content-Disposition").toString()) {
+                            contains("image") && contains("avatarFile")
+                        },
+                    )
+                },
+                withNullableArg { assertNull(it) },
+                withNullableArg { assertNull(it) },
             )
         }
     }

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -50,9 +50,9 @@ class AvatarServiceTest {
 
         avatarService.upload(
             File("avatarFile"),
+            oauthToken,
             Hash("hash"),
             selectAvatar = false,
-            oauthToken,
         )
 
         coVerify(exactly = 1) {
@@ -81,9 +81,9 @@ class AvatarServiceTest {
 
             avatarService.upload(
                 File("avatarFile"),
+                oauthToken,
                 Hash("hash"),
                 selectAvatar = false,
-                oauthToken,
             )
         }
 
@@ -97,9 +97,9 @@ class AvatarServiceTest {
 
         val response = avatarService.uploadCatching(
             File("avatarFile"),
+            oauthToken,
             Hash("hash"),
             selectAvatar = false,
-            oauthToken,
         )
 
         coVerify(exactly = 1) {
@@ -129,9 +129,9 @@ class AvatarServiceTest {
 
         val response = avatarService.uploadCatching(
             File("avatarFile"),
+            oauthToken,
             Hash("hash"),
             selectAvatar = false,
-            oauthToken,
         )
 
         coVerify(exactly = 1) {


### PR DESCRIPTION


### Description

This PR updates to the latest OpenAPI spec and updates the QE code to match the previous behavior of the upload avatar endpoint. 

### Testing Steps

There should be no visual or behavioral changes. 

Verify that the Avatar is selected automatically when a new photo is uploaded while no avatar is selected.