### PR TITLE
QuickEditor: Implement GravatarQuickEditorActivity

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -56,6 +56,24 @@
 <!--            </intent-filter>-->
         </activity>
 
+        <!-- Gravatar QE Activity -->
+<!--        <activity-->
+<!--            android:name="com.gravatar.quickeditor.ui.GravatarQuickEditorActivity"-->
+<!--            tools:node="merge">-->
+
+<!--            <intent-filter>-->
+<!--                <action android:name="android.intent.action.VIEW" />-->
+
+<!--                <category android:name="android.intent.category.DEFAULT" />-->
+<!--                <category android:name="android.intent.category.BROWSABLE" />-->
+
+<!--                <data-->
+<!--                    android:host="${DEMO_OAUTH_REDIRECT_URI_HOST}"-->
+<!--                    android:scheme="${DEMO_OAUTH_REDIRECT_URI_SCHEME}" />-->
+<!--            </intent-filter>-->
+<!--        </activity>-->
+
+
         <!-- Lib activities -->
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
@@ -41,6 +41,7 @@ class QuickEditorTestActivity : AppCompatActivity() {
     private fun setupViews() {
         val profileCard = findViewById<ComposeView>(R.id.profile_card)
         val btnUpdateAvatar = findViewById<Button>(R.id.btn_update_avatar)
+        val btnUpdateAvatarWithQEActivity = findViewById<Button>(R.id.btn_update_avatar_qe_activity)
 
         profileCard.setContent {
             GravatarProfileSummary(emailAddress = BuildConfig.DEMO_EMAIL)
@@ -65,6 +66,22 @@ class QuickEditorTestActivity : AppCompatActivity() {
                 onDismiss = {
                     Toast.makeText(this, it.toString(), Toast.LENGTH_SHORT).show()
                 },
+            )
+        }
+
+        btnUpdateAvatarWithQEActivity.setOnClickListener {
+            GravatarQuickEditor.showActivity(
+                context = this,
+                gravatarQuickEditorParams = GravatarQuickEditorParams {
+                    email = Email(BuildConfig.DEMO_EMAIL)
+                    avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal
+                },
+                authenticationMethod = AuthenticationMethod.OAuth(
+                    OAuthParams {
+                        clientId = BuildConfig.DEMO_OAUTH_CLIENT_ID
+                        redirectUri = BuildConfig.DEMO_OAUTH_REDIRECT_URI
+                    },
+                ),
             )
         }
     }

--- a/demo-app/src/main/res/layout/activity_quick_editor_test.xml
+++ b/demo-app/src/main/res/layout/activity_quick_editor_test.xml
@@ -35,6 +35,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/profile_container" />
 
+    <Button
+        android:id="@+id/btn_update_avatar_qe_activity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="Update Avatar with QuickEditor Activity"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_update_avatar" />
+
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -364,7 +364,7 @@ getQEResult.launch(
 )
 ```
 
-It's important to note that using the `GravatarQuickEditorActivity` you'll only receive the result of the Quick Editor when it's dismissed not instantly as with using the `@Composable` component from your `singleTask` activity.
+It's important to note that using the `GravatarQuickEditorActivity` you'll only receive the result of the Quick Editor when it's dismissed not instantly as with using the `@Composable` component from your `singleTask` activity (see [Section 1.1](#11-using-you-own-activity-with-androidlaunchmodesingletask-recommended)).
 
 In the `demo-app` you can find a detailed implementation showing how to use the provided activity. See `QuickEditorTestActivity`.
 

--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -244,6 +244,8 @@ To do that the QuickEditor needs an authorization token to perform requests on b
 
 ### 1. Let the Quick Editor handle the OAuth flow
 
+#### 1.1 Using you own activity with `android:launchMode="singleTask"` (Recommended)
+
 Quick Editor can handle the heavy lifting of running the full OAuth flow, so you don't have to do that. We will still need a few things from you.
 First, you have to go to [OAuth docs](https://docs.gravatar.com/oauth/) and create your Application. Define the `Redirect URLs`.
 
@@ -310,6 +312,61 @@ When the user logs out form the app, make sure to run:
 ```kotlin
 GravatarQuickEditor.logout(Email("{USER_EMAIL}"))
 ```
+
+#### 1.2 Using the provided activity
+
+If using an activity with `android:launchMode="singleTask"` is not an option, you can use the provided activity. With this option, you don't need to modify how your activities are set up.
+
+You need to add the provided activity to your `AndroidManifest.xml`:
+
+```xml
+<activity
+    android:name="com.gravatar.quickeditor.ui.GravatarQuickEditorActivity"
+    tools:node="merge">
+
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data
+            android:scheme="https"
+            android:host="yourhost.com"
+            android:pathPrefix="/redirect-url"
+        />
+    </intent-filter>
+</activity>
+```
+
+_Note the important difference here: the `tools:node="merge"` attribute. This is necessary to merge the intent filter with the one defined in the library._
+
+The `GravatarQuickEditorActivity` defines an Activity Result contract that you can use to launch the Quick Editor and handle the result. Here's an example of how you can use it:
+
+```kotlin
+private val getQEResult = registerForActivityResult(GetQuickEditorResult()) { quickEditorResult ->
+        when (quickEditorResult) {
+            GravatarQuickEditorResult.AVATAR_SELECTED -> { ... }
+
+            GravatarQuickEditorResult.DISMISSED -> { ... }
+
+            else -> { ... }
+        }
+}
+
+getQEResult.launch(
+    GravatarQuickEditorActivity.GravatarEditorActivityArguments(
+        GravatarQuickEditorParams { ... },
+        AuthenticationMethod.OAuth(
+            OAuthParams { ... },
+        ),
+    ),
+)
+```
+
+It's important to note that using the `GravatarQuickEditorActivity` you'll only receive the result of the Quick Editor when it's dismissed not instantly as with using the `@Composable` component from your `singleTask` activity.
+
+In the `demo-app` you can find a detailed implementation showing how to use the provided activity. See `QuickEditorTestActivity`.
 
 #### Exclude Data Store files from Android backup (optional, but recommended)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,5 +90,6 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi" }
+parcelize = { id = "kotlin-parcelize" }
 publish-to-s3 = { id = "com.automattic.android.publish-to-s3", version.ref = "publishToS3" }
 roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -8,12 +8,25 @@ public final class com/gravatar/quickeditor/GravatarQuickEditor {
 	public static final fun show (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun show$default (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun show$default (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static final fun showActivity (Landroid/content/Context;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;)V
+}
+
+public final class com/gravatar/quickeditor/ui/GetQuickEditorResult : androidx/activity/result/contract/ActivityResultContract {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun createIntent (Landroid/content/Context;Lcom/gravatar/quickeditor/ui/GravatarQuickEditorActivity$GravatarEditorActivityArguments;)Landroid/content/Intent;
+	public synthetic fun createIntent (Landroid/content/Context;Ljava/lang/Object;)Landroid/content/Intent;
+	public fun parseResult (ILandroid/content/Intent;)Lcom/gravatar/quickeditor/ui/GravatarQuickEditorResult;
+	public synthetic fun parseResult (ILandroid/content/Intent;)Ljava/lang/Object;
 }
 
 public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity : androidx/appcompat/app/AppCompatActivity {
 	public static final field $stable I
+	public static final field ACTIVITY_RESULT Ljava/lang/String;
+	public static final field EXTRA_QE_ARGUMENTS Ljava/lang/String;
+	public static final field RESULT_AVATAR_SELECTED I
+	public static final field RESULT_DISMISSED I
 	public fun <init> ()V
+	public fun finish ()V
 }
 
 public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity$GravatarEditorActivityArguments : android/os/Parcelable {
@@ -23,7 +36,6 @@ public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity$Grava
 	public fun describeContents ()I
 	public final fun getAuthenticationMethod ()Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;
 	public final fun getGravatarQuickEditorParams ()Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
-	public final fun startGravatarQuickEditor (Landroid/content/Context;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
@@ -33,6 +45,14 @@ public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity$Grava
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/gravatar/quickeditor/ui/GravatarQuickEditorActivity$GravatarEditorActivityArguments;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/gravatar/quickeditor/ui/GravatarQuickEditorResult : java/lang/Enum {
+	public static final field AVATAR_SELECTED Lcom/gravatar/quickeditor/ui/GravatarQuickEditorResult;
+	public static final field DISMISSED Lcom/gravatar/quickeditor/ui/GravatarQuickEditorResult;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/GravatarQuickEditorResult;
+	public static fun values ()[Lcom/gravatar/quickeditor/ui/GravatarQuickEditorResult;
 }
 
 public final class com/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt {

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -8,6 +8,31 @@ public final class com/gravatar/quickeditor/GravatarQuickEditor {
 	public static final fun show (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun show$default (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun show$default (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun showActivity (Landroid/content/Context;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;)V
+}
+
+public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity : androidx/appcompat/app/AppCompatActivity {
+	public static final field $stable I
+	public fun <init> ()V
+}
+
+public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity$GravatarEditorActivityArguments : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;)V
+	public fun describeContents ()I
+	public final fun getAuthenticationMethod ()Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;
+	public final fun getGravatarQuickEditorParams ()Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
+	public final fun startGravatarQuickEditor (Landroid/content/Context;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity$GravatarEditorActivityArguments$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/GravatarQuickEditorActivity$GravatarEditorActivityArguments;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/gravatar/quickeditor/ui/GravatarQuickEditorActivity$GravatarEditorActivityArguments;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt {
@@ -169,46 +194,90 @@ public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$V
 	public final fun getLambda-4$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public abstract class com/gravatar/quickeditor/ui/editor/AuthenticationMethod {
+public abstract class com/gravatar/quickeditor/ui/editor/AuthenticationMethod : android/os/Parcelable {
 	public static final field $stable I
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AuthenticationMethod$Bearer : com/gravatar/quickeditor/ui/editor/AuthenticationMethod {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getToken ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/gravatar/quickeditor/ui/editor/AuthenticationMethod$Bearer$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod$Bearer;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod$Bearer;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AuthenticationMethod$OAuth : com/gravatar/quickeditor/ui/editor/AuthenticationMethod {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;)V
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOAuthParams ()Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public abstract class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout {
+public final class com/gravatar/quickeditor/ui/editor/AuthenticationMethod$OAuth$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod$OAuth;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod$OAuth;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public abstract class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout : android/os/Parcelable {
 	public static final field $stable I
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Horizontal : com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Horizontal;
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Horizontal$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Horizontal;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Horizontal;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Vertical : com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Vertical;
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Vertical$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Vertical;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Vertical;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public abstract class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorDismissReason {
@@ -239,14 +308,17 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorDismiss
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams {
+public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams : android/os/Parcelable {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public synthetic fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder {
@@ -259,6 +331,14 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$
 	public final synthetic fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)V
 	public final fun setEmail (Lcom/gravatar/types/Email;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setEmail (Lcom/gravatar/types/Email;)V
+}
+
+public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParamsKt {
@@ -283,14 +363,17 @@ public final class com/gravatar/quickeditor/ui/oauth/ComposableSingletons$OAuthP
 	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class com/gravatar/quickeditor/ui/oauth/OAuthParams {
+public final class com/gravatar/quickeditor/ui/oauth/OAuthParams : android/os/Parcelable {
 	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClientId ()Ljava/lang/String;
 	public final fun getRedirectUri ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/oauth/OAuthParams$Builder {
@@ -303,6 +386,14 @@ public final class com/gravatar/quickeditor/ui/oauth/OAuthParams$Builder {
 	public final synthetic fun setClientId (Ljava/lang/String;)V
 	public final fun setRedirectUri (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/oauth/OAuthParams$Builder;
 	public final synthetic fun setRedirectUri (Ljava/lang/String;)V
+}
+
+public final class com/gravatar/quickeditor/ui/oauth/OAuthParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/gravatar/quickeditor/ui/oauth/OAuthParamsKt {

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
     id(libs.plugins.android.library.get().pluginId)
+    alias(libs.plugins.parcelize)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.publish.to.s3)
     // Ktlint

--- a/gravatar-quickeditor/src/main/AndroidManifest.xml
+++ b/gravatar-quickeditor/src/main/AndroidManifest.xml
@@ -5,6 +5,12 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
+        <activity
+            android:name=".ui.GravatarQuickEditorActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/GravatarQETheme.Transparent" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
@@ -1,10 +1,8 @@
 package com.gravatar.quickeditor
 
 import android.app.Activity
-import android.content.Context
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.gravatar.quickeditor.ui.GravatarQuickEditorActivity
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
@@ -60,25 +58,6 @@ public object GravatarQuickEditor {
     ) {
         val viewGroup: ViewGroup = fragment.requireActivity().findViewById(android.R.id.content)
         addQuickEditorToView(viewGroup, gravatarQuickEditorParams, authenticationMethod, onAvatarSelected, onDismiss)
-    }
-
-    /**
-     * Helper function to launch the Gravatar Quick Editor inside a Gravatar Activity.
-     *
-     * @param context The context to launch the Gravatar Quick Editor from.
-     * @param gravatarQuickEditorParams The parameters to configure the Quick Editor.
-     * @param authenticationMethod The method used for authentication with the Gravatar REST API.
-     */
-    @JvmStatic
-    public fun showActivity(
-        context: Context,
-        gravatarQuickEditorParams: GravatarQuickEditorParams,
-        authenticationMethod: AuthenticationMethod,
-    ) {
-        GravatarQuickEditorActivity.GravatarEditorActivityArguments(
-            gravatarQuickEditorParams = gravatarQuickEditorParams,
-            authenticationMethod = authenticationMethod,
-        ).startGravatarQuickEditor(context)
     }
 
     /**

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
@@ -1,8 +1,10 @@
 package com.gravatar.quickeditor
 
 import android.app.Activity
+import android.content.Context
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.gravatar.quickeditor.ui.GravatarQuickEditorActivity
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
@@ -58,6 +60,25 @@ public object GravatarQuickEditor {
     ) {
         val viewGroup: ViewGroup = fragment.requireActivity().findViewById(android.R.id.content)
         addQuickEditorToView(viewGroup, gravatarQuickEditorParams, authenticationMethod, onAvatarSelected, onDismiss)
+    }
+
+    /**
+     * Helper function to launch the Gravatar Quick Editor inside a Gravatar Activity.
+     *
+     * @param context The context to launch the Gravatar Quick Editor from.
+     * @param gravatarQuickEditorParams The parameters to configure the Quick Editor.
+     * @param authenticationMethod The method used for authentication with the Gravatar REST API.
+     */
+    @JvmStatic
+    public fun showActivity(
+        context: Context,
+        gravatarQuickEditorParams: GravatarQuickEditorParams,
+        authenticationMethod: AuthenticationMethod,
+    ) {
+        GravatarQuickEditorActivity.GravatarEditorActivityArguments(
+            gravatarQuickEditorParams = gravatarQuickEditorParams,
+            authenticationMethod = authenticationMethod,
+        ).startGravatarQuickEditor(context)
     }
 
     /**

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorActivity.kt
@@ -3,6 +3,7 @@ package com.gravatar.quickeditor.ui
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Bundle
@@ -27,6 +28,13 @@ public class GravatarQuickEditorActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
+        } else {
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+        }
+
         val arguments = requireNotNull(intent.parcelable<GravatarEditorActivityArguments>(EXTRA_QE_ARGUMENTS))
         setContent {
             GravatarQuickEditorBottomSheet(
@@ -61,6 +69,16 @@ public class GravatarQuickEditorActivity : AppCompatActivity() {
         }
         setResult(Activity.RESULT_OK, resultIntent)
         finish()
+    }
+
+    override fun finish() {
+        super.finish()
+        if (SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
+        } else {
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+        }
     }
 
     /**

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorActivity.kt
@@ -1,0 +1,70 @@
+package com.gravatar.quickeditor.ui
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.TIRAMISU
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
+import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
+import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Activity that hosts the [GravatarQuickEditorBottomSheet] composable.
+ * This activity is used to show the Gravatar Quick Editor in a bottom sheet.
+ *
+ * @see GravatarEditorActivityArguments
+ */
+public class GravatarQuickEditorActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val arguments = requireNotNull(intent.parcelable<GravatarEditorActivityArguments>(EXTRA_QE_ARGUMENTS))
+        setContent {
+            GravatarQuickEditorBottomSheet(
+                gravatarQuickEditorParams = arguments.gravatarQuickEditorParams,
+                authenticationMethod = arguments.authenticationMethod,
+                onAvatarSelected = {
+                    // Do nothing for the moment
+                },
+                onDismiss = { finish() },
+            )
+        }
+    }
+
+    /**
+     * Arguments for the [GravatarQuickEditorActivity].
+     *
+     * [gravatarQuickEditorParams] The parameters to configure the Quick Editor.
+     * [authenticationMethod] The method used for authentication with the Gravatar REST API.
+     */
+    @Parcelize
+    public class GravatarEditorActivityArguments(
+        public val gravatarQuickEditorParams: GravatarQuickEditorParams,
+        public val authenticationMethod: AuthenticationMethod,
+    ) : Parcelable {
+        /**
+         * Starts the [GravatarQuickEditorActivity] with the provided arguments.
+         */
+        public fun startGravatarQuickEditor(context: Context) {
+            val intent = Intent(context, GravatarQuickEditorActivity::class.java)
+            intent.putExtra(EXTRA_QE_ARGUMENTS, this)
+            context.startActivity(intent)
+        }
+    }
+
+    private companion object {
+        private const val EXTRA_QE_ARGUMENTS = "qeArguments"
+    }
+}
+
+private inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
+    SDK_INT >= TIRAMISU -> getParcelableExtra(key, T::class.java)
+    else -> {
+        @Suppress("DEPRECATION")
+        getParcelableExtra(key) as? T
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorActivity.kt
@@ -48,12 +48,12 @@ public class GravatarQuickEditorActivity : AppCompatActivity() {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putBoolean("avatarHasChanged", avatarHasChanged)
+        outState.putBoolean(AVATAR_HAS_CHANGED_KEY, avatarHasChanged)
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
-        avatarHasChanged = savedInstanceState.getBoolean("avatarHasChanged")
+        avatarHasChanged = savedInstanceState.getBoolean(AVATAR_HAS_CHANGED_KEY)
     }
 
     private fun finishWithResult() {
@@ -95,6 +95,7 @@ public class GravatarQuickEditorActivity : AppCompatActivity() {
 
     internal companion object {
         const val EXTRA_QE_ARGUMENTS: String = "qeArguments"
+        private const val AVATAR_HAS_CHANGED_KEY: String = "avatarHasChanged"
 
         const val ACTIVITY_RESULT: String = "activityResult"
         const val RESULT_DISMISSED: Int = 1000

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/AuthenticationMethod.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/AuthenticationMethod.kt
@@ -1,12 +1,15 @@
 package com.gravatar.quickeditor.ui.editor
 
+import android.os.Parcelable
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
+import kotlinx.parcelize.Parcelize
 import java.util.Objects
 
 /**
  * Represents the authentication method used for the Gravatar Quick Editor.
  */
-public sealed class AuthenticationMethod {
+@Parcelize
+public sealed class AuthenticationMethod : Parcelable {
     /**
      * OAuth authentication method.
      *

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout.kt
@@ -1,16 +1,22 @@
 package com.gravatar.quickeditor.ui.editor
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * The layout direction of the Avatar picker in the Quick Editor.
  */
-public sealed class AvatarPickerContentLayout {
+@Parcelize
+public sealed class AvatarPickerContentLayout : Parcelable {
     /**
-     * Horizontal scrolling for the Avatars.
+     * Horizontal layout.
      */
+    @Parcelize
     public data object Horizontal : AvatarPickerContentLayout()
 
     /**
-     * Vertical scrolling for the Avatars.
+     * Vertical layout.
      */
+    @Parcelize
     public data object Vertical : AvatarPickerContentLayout()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
@@ -1,6 +1,8 @@
 package com.gravatar.quickeditor.ui.editor
 
+import android.os.Parcelable
 import com.gravatar.types.Email
+import kotlinx.parcelize.Parcelize
 import java.util.Objects
 
 /**
@@ -9,10 +11,11 @@ import java.util.Objects
  * @property email The email of the user
  * @property avatarPickerContentLayout The layout direction used in the Avatar Picker.
  */
+@Parcelize
 public class GravatarQuickEditorParams private constructor(
     public val email: Email,
     public val avatarPickerContentLayout: AvatarPickerContentLayout,
-) {
+) : Parcelable {
     override fun toString(): String =
         "GravatarQuickEditorParams(email='$email', avatarPickerContentLayout=$avatarPickerContentLayout)"
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthParams.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthParams.kt
@@ -1,5 +1,7 @@
 package com.gravatar.quickeditor.ui.oauth
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import java.util.Objects
 
 /**
@@ -8,10 +10,11 @@ import java.util.Objects
  * @property clientId The clientId of your WP.com application
  * @property redirectUri The redirect URI configured for your WP.com application
  */
+@Parcelize
 public class OAuthParams private constructor(
     public val clientId: String,
     public val redirectUri: String,
-) {
+) : Parcelable {
     override fun toString(): String = "OAuthParams(clientId=$clientId, redirectUri=$redirectUri)"
 
     override fun equals(other: Any?): Boolean {

--- a/gravatar-quickeditor/src/main/res/values/themes.xml
+++ b/gravatar-quickeditor/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="GravatarQETheme.Transparent" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
+</resources>

--- a/gravatar-quickeditor/src/main/res/values/themes.xml
+++ b/gravatar-quickeditor/src/main/res/values/themes.xml
@@ -3,6 +3,5 @@
     <style name="GravatarQETheme.Transparent" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowAnimationStyle">@null</item>
     </style>
 </resources>

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -781,10 +781,21 @@ public final class com/gravatar/services/ProfileService {
 	public final fun retrieveCatching (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/gravatar/types/Email {
+public final class com/gravatar/types/Email : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
+	public fun describeContents ()I
 	public final fun hash ()Lcom/gravatar/types/Hash;
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/gravatar/types/Email$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/types/Email;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/gravatar/types/Email;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/gravatar/types/Hash {

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
     id(libs.plugins.android.library.get().pluginId)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.parcelize)
     // Ktlint
     alias(libs.plugins.ktlint)
     // Detekt

--- a/gravatar/src/main/java/com/gravatar/types/Email.kt
+++ b/gravatar/src/main/java/com/gravatar/types/Email.kt
@@ -1,11 +1,15 @@
 package com.gravatar.types
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * Email address representation.
  *
  * @param address the email address
  */
-public class Email(private val address: String) {
+@Parcelize
+public class Email(private val address: String) : Parcelable {
     /**
      * Get a Gravatar hash for a given email address.
      *


### PR DESCRIPTION
Closes #424 

### Description

To simplify the integration we need to remove the limitation of using the QuickEditor from an activity using the launchMode="singleTask".

The approach is to create an intermediate activity that can assume the complexity and the launch mode required by the QE. The behavior should be as much as possible as it is using the Composable directly.

https://github.com/user-attachments/assets/a0b8c091-ee85-4cf7-8e49-520f8b090d11

### Testing Steps

* In the `demo-app` manifest uncomment the `Gravatar QE Activity` part and comment the intent filter in `MainActivity` (or apply this [patch](https://github.com/user-attachments/files/17733845/Gravatar-Android-15-17-02.patch))
* Launch the `demo-app`
* Tap over `Test with Activity without Compose`
* Tap over the second button, `Update Avatar with QuickEditor Activity`
* Verify everything works as expected. 
  - OAuth flow with different browsers and using custom tabs (Firefox would be nice)
  - Avatar switch (Note that with this approach, we only notify the avatar change when our activity finishes)
  - Close the bottom sheet without switching avatars
  - You can also test rotating the device orientation with the bottom sheet (GravatarQuickEditorActivity) visible
