### PR TITLE
QuickEditor: Check not null when getting "access_token" from OAuth flow

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
@@ -77,7 +77,7 @@ internal fun OAuthPage(
                         split.first() to split.last()
                     }
                     ?.get("access_token")
-                    .let { URLDecoder.decode(it, "UTF-8") }
+                    ?.let { URLDecoder.decode(it, "UTF-8") }
 
                 if (token != null) {
                     viewModel.tokenReceived(email, token)


### PR DESCRIPTION
Closes #426

### Description

URLDecoder.decode requires a non-null string, which we aren't checking before calling the method, so we are producing a NullPointerException when the OAuth flow is denied.

I'm not sure how we haven't detected this before. Maybe the backend has changed its response, and that's why we see this now?

### Testing Steps

1. With the demo-app open, the OAuth flow
2. Deny the permission
3. Verify the app doesn't crash (You can verify with `2.0.0` that, in fact, it crashes)
