### PR TITLE
Use alias for `libs.plugins.android.library` instead of `id` in `build.gradle` files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ import org.jetbrains.dokka.versioning.VersioningPlugin
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     // Ktlint
     alias(libs.plugins.ktlint) apply false

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id(libs.plugins.android.library.get().pluginId)
+    alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.publish.to.s3)
     alias(libs.plugins.ktlint)

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id(libs.plugins.android.library.get().pluginId)
+    alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.publish.to.s3)
     alias(libs.plugins.ktlint)

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    id(libs.plugins.android.library.get().pluginId)
+    alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.detekt)

--- a/uitestutils/build.gradle.kts
+++ b/uitestutils/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id(libs.plugins.android.library.get().pluginId)
+    alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
 
     // Ktlint


### PR DESCRIPTION
Closes #432 

### Description

As @davidburstrom mentioned [here](https://github.com/Automattic/Gravatar-SDK-Android/pull/221#discussion_r1831691853), we can use `alias` as we do for the `application` plugin.

### Testing Steps

- CI should be enough
