### PR TITLE
[Tooling] Add labels checker in Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -8,3 +8,9 @@ rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inl
              include_cop_names: true, skip_bundle_exec: true)
 
 manifest_pr_checker.check_gemfile_lock_updated
+
+labels_checker.check(
+  do_not_merge_labels: ['do not merge'],
+  required_labels: [//], # At least one label, regardless of its name
+  required_labels_error: 'You need to add at least one label to this PR'
+)


### PR DESCRIPTION
### Description

Adding a label checker to enforce at least one label in PRs.

Same as in [iOS repo](https://href.li/?https://github.com/Automattic/Gravatar-SDK-iOS/blob/3e45357683f3d852c15a3bf0f1181daf7cd92620/Dangerfile#L14-L15).


