### PR TITLE
QuickEditor: Delete avatar

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -62,6 +62,18 @@ internal class AvatarRepository(
                 }
             } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
         }
+
+    suspend fun deleteAvatar(email: Email, avatarId: String): GravatarResult<Unit, QuickEditorError> = withContext(
+        dispatcher,
+    ) {
+        val token = tokenStorage.getToken(email.hash().toString())
+        token?.let {
+            when (val result = avatarService.deleteAvatarCatching(avatarId, token)) {
+                is GravatarResult.Success -> GravatarResult.Success(Unit)
+                is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
+            }
+        } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
+    }
 }
 
 internal data class EmailAvatars(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gravatar.extensions.defaultProfile
 import com.gravatar.quickeditor.R
 import com.gravatar.quickeditor.data.repository.EmailAvatars
+import com.gravatar.quickeditor.ui.components.AvatarOption
 import com.gravatar.quickeditor.ui.components.AvatarsSection
 import com.gravatar.quickeditor.ui.components.EmailLabel
 import com.gravatar.quickeditor.ui.components.ErrorSection
@@ -188,12 +189,11 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
                                 is AvatarUi.Uploaded -> onEvent(AvatarPickerEvent.AvatarSelected(avatarUi.avatar))
                             }
                         },
-                        onAltTextSelected = { /* Future implementation */ },
-                        onDeleteSelected = { avatarUi ->
-                            when (avatarUi) {
-                                is AvatarUi.Uploaded -> onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarUi.avatar))
-                                is AvatarUi.Local -> {
-                                    // Local images are not uploaded yet, so we don't need to delete them
+                        onAvatarOptionClicked = { avatar, avatarOption ->
+                            when (avatarOption) {
+                                AvatarOption.ALT_TEXT -> Unit
+                                AvatarOption.DELETE -> {
+                                    onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatar))
                                 }
                             }
                         },

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -189,7 +189,14 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
                             }
                         },
                         onAltTextSelected = { /* Future implementation */ },
-                        onDeleteSelected = { /* Future implementation */ },
+                        onDeleteSelected = { avatarUi ->
+                            when (avatarUi) {
+                                is AvatarUi.Uploaded -> onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarUi.avatar))
+                                is AvatarUi.Local -> {
+                                    // Local images are not uploaded yet, so we don't need to delete them
+                                }
+                            }
+                        },
                         onLocalImageSelected = { onEvent(AvatarPickerEvent.LocalImageSelected(it)) },
                         modifier = sectionModifier
                             .padding(horizontal = 16.dp)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -189,6 +189,7 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
                             }
                         },
                         onAltTextSelected = { /* Future implementation */ },
+                        onDeleteSelected = { /* Future implementation */ },
                         onLocalImageSelected = { onEvent(AvatarPickerEvent.LocalImageSelected(it)) },
                         modifier = sectionModifier
                             .padding(horizontal = 16.dp)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerEvent.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerEvent.kt
@@ -19,4 +19,6 @@ internal sealed class AvatarPickerEvent {
     data object FailedAvatarDialogDismissed : AvatarPickerEvent()
 
     data object HandleAuthFailureTapped : AvatarPickerEvent()
+
+    data class AvatarDeleteSelected(val avatar: Avatar) : AvatarPickerEvent()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarMoreOptionsPickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarMoreOptionsPickerPopup.kt
@@ -20,8 +20,7 @@ internal fun AvatarMoreOptionsPickerPopup(
     anchorAlignment: Alignment.Horizontal,
     anchorBounds: Rect,
     onDismissRequest: () -> Unit,
-    onAltTextClick: () -> Unit,
-    onDeleteClicked: () -> Unit,
+    onAvatarOptionClicked: (AvatarOption) -> Unit,
 ) {
     PickerPopup(
         anchorAlignment = anchorAlignment,
@@ -32,17 +31,26 @@ internal fun AvatarMoreOptionsPickerPopup(
                 text = R.string.gravatar_qe_selectable_avatar_more_options_alt_text,
                 iconRes = R.drawable.gravatar_avatar_more_options_alt_text,
                 contentDescription = R.string.gravatar_qe_selectable_avatar_more_options_alt_text_content_description,
-                onClick = onAltTextClick,
+                onClick = {
+                    onAvatarOptionClicked(AvatarOption.ALT_TEXT)
+                },
             ),
             PickerPopupItem(
                 text = R.string.gravatar_qe_selectable_avatar_more_options_delete,
                 iconRes = R.drawable.gravatar_avatar_more_options_delete,
                 contentDescription = R.string.gravatar_qe_selectable_avatar_more_options_delete_content_description,
                 color = MaterialTheme.colorScheme.error,
-                onClick = onDeleteClicked,
+                onClick = {
+                    onAvatarOptionClicked(AvatarOption.DELETE)
+                },
             ),
         ),
     )
+}
+
+internal enum class AvatarOption {
+    ALT_TEXT,
+    DELETE,
 }
 
 @Preview
@@ -58,8 +66,7 @@ private fun AvatarMoreOptionsPickerPopupPreview() {
                 anchorAlignment = Alignment.Start,
                 onDismissRequest = {},
                 anchorBounds = Rect(Offset(0f, 300f), Size(1f, 1f)),
-                onAltTextClick = {},
-                onDeleteClicked = {},
+                onAvatarOptionClicked = {},
             )
         }
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarMoreOptionsPickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarMoreOptionsPickerPopup.kt
@@ -21,6 +21,7 @@ internal fun AvatarMoreOptionsPickerPopup(
     anchorBounds: Rect,
     onDismissRequest: () -> Unit,
     onAltTextClick: () -> Unit,
+    onDeleteClicked: () -> Unit,
 ) {
     PickerPopup(
         anchorAlignment = anchorAlignment,
@@ -32,6 +33,13 @@ internal fun AvatarMoreOptionsPickerPopup(
                 iconRes = R.drawable.gravatar_avatar_more_options_alt_text,
                 contentDescription = R.string.gravatar_qe_selectable_avatar_more_options_alt_text_content_description,
                 onClick = onAltTextClick,
+            ),
+            PickerPopupItem(
+                text = R.string.gravatar_qe_selectable_avatar_more_options_delete,
+                iconRes = R.drawable.gravatar_avatar_more_options_delete,
+                contentDescription = R.string.gravatar_qe_selectable_avatar_more_options_delete_content_description,
+                color = MaterialTheme.colorScheme.error,
+                onClick = onDeleteClicked,
             ),
         ),
     )
@@ -51,6 +59,7 @@ private fun AvatarMoreOptionsPickerPopupPreview() {
                 onDismissRequest = {},
                 anchorBounds = Rect(Offset(0f, 300f), Size(1f, 1f)),
                 onAltTextClick = {},
+                onDeleteClicked = {},
             )
         }
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarsSection.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.core.content.ContextCompat.startActivity
 import com.gravatar.quickeditor.QuickEditorFileProvider
 import com.gravatar.quickeditor.R
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarUi
@@ -36,8 +35,7 @@ import java.net.URI
 internal fun AvatarsSection(
     state: AvatarsSectionUiState,
     onAvatarSelected: (AvatarUi) -> Unit,
-    onAltTextSelected: (AvatarUi) -> Unit,
-    onDeleteSelected: (AvatarUi) -> Unit,
+    onAvatarOptionClicked: (Avatar, AvatarOption) -> Unit,
     onLocalImageSelected: (Uri) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -84,12 +82,11 @@ internal fun AvatarsSection(
                 state = state,
                 modifier = modifier,
                 onAvatarSelected = onAvatarSelected,
-                onAltTextSelected = onAltTextSelected,
+                onAvatarOptionClicked = onAvatarOptionClicked,
                 onChoosePhotoClick = {
                     pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                 },
                 onTakePhotoClick = permissionAwareTakePhotoCallback,
-                onDeleteSelected = onDeleteSelected,
             )
         }
 
@@ -98,8 +95,7 @@ internal fun AvatarsSection(
                 state = state,
                 modifier = modifier,
                 onAvatarSelected = onAvatarSelected,
-                onAltTextSelected = onAltTextSelected,
-                onDeleteSelected = onDeleteSelected,
+                onAvatarOptionClicked = onAvatarOptionClicked,
                 onTakePhotoClick = permissionAwareTakePhotoCallback,
                 onChoosePhotoClick = {
                     pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
@@ -182,8 +178,7 @@ private fun AvatarSectionPreview() {
                 avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal,
             ),
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
             onLocalImageSelected = { },
         )
     }
@@ -213,8 +208,7 @@ private fun AvatarSectionGridPreview() {
                 avatarPickerContentLayout = AvatarPickerContentLayout.Vertical,
             ),
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
             onLocalImageSelected = { },
         )
     }
@@ -232,8 +226,7 @@ private fun AvatarSectionEmptyPreview() {
                 avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal,
             ),
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
             onLocalImageSelected = { },
         )
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarsSection.kt
@@ -37,6 +37,7 @@ internal fun AvatarsSection(
     state: AvatarsSectionUiState,
     onAvatarSelected: (AvatarUi) -> Unit,
     onAltTextSelected: (AvatarUi) -> Unit,
+    onDeleteSelected: (AvatarUi) -> Unit,
     onLocalImageSelected: (Uri) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -88,6 +89,7 @@ internal fun AvatarsSection(
                     pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                 },
                 onTakePhotoClick = permissionAwareTakePhotoCallback,
+                onDeleteSelected = onDeleteSelected,
             )
         }
 
@@ -97,6 +99,7 @@ internal fun AvatarsSection(
                 modifier = modifier,
                 onAvatarSelected = onAvatarSelected,
                 onAltTextSelected = onAltTextSelected,
+                onDeleteSelected = onDeleteSelected,
                 onTakePhotoClick = permissionAwareTakePhotoCallback,
                 onChoosePhotoClick = {
                     pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
@@ -180,6 +183,7 @@ private fun AvatarSectionPreview() {
             ),
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
             onLocalImageSelected = { },
         )
     }
@@ -210,6 +214,7 @@ private fun AvatarSectionGridPreview() {
             ),
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
             onLocalImageSelected = { },
         )
     }
@@ -228,6 +233,7 @@ private fun AvatarSectionEmptyPreview() {
             ),
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
             onLocalImageSelected = { },
         )
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/HorizontalAvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/HorizontalAvatarsSection.kt
@@ -38,8 +38,7 @@ import java.net.URI
 internal fun HorizontalAvatarsSection(
     state: AvatarsSectionUiState,
     onAvatarSelected: (AvatarUi) -> Unit,
-    onAltTextSelected: (AvatarUi) -> Unit,
-    onDeleteSelected: (AvatarUi) -> Unit,
+    onAvatarOptionClicked: (Avatar, AvatarOption) -> Unit,
     onChoosePhotoClick: () -> Unit,
     onTakePhotoClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -84,8 +83,7 @@ internal fun HorizontalAvatarsSection(
                     LazyAvatarRow(
                         avatars = state.avatars,
                         onAvatarSelected = onAvatarSelected,
-                        onAltTextSelected = onAltTextSelected,
-                        onDeleteSelected = onDeleteSelected,
+                        onAvatarOptionClicked = onAvatarOptionClicked,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         modifier = Modifier.padding(vertical = 24.dp),
                         state = listState,
@@ -150,8 +148,7 @@ private fun HorizontalAvatarSectionPreview() {
             onTakePhotoClick = { },
             onChoosePhotoClick = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 }
@@ -170,8 +167,7 @@ private fun HorizontalAvatarSectionEmptyPreview() {
             onTakePhotoClick = { },
             onChoosePhotoClick = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/HorizontalAvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/HorizontalAvatarsSection.kt
@@ -39,6 +39,7 @@ internal fun HorizontalAvatarsSection(
     state: AvatarsSectionUiState,
     onAvatarSelected: (AvatarUi) -> Unit,
     onAltTextSelected: (AvatarUi) -> Unit,
+    onDeleteSelected: (AvatarUi) -> Unit,
     onChoosePhotoClick: () -> Unit,
     onTakePhotoClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -84,6 +85,7 @@ internal fun HorizontalAvatarsSection(
                         avatars = state.avatars,
                         onAvatarSelected = onAvatarSelected,
                         onAltTextSelected = onAltTextSelected,
+                        onDeleteSelected = onDeleteSelected,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         modifier = Modifier.padding(vertical = 24.dp),
                         state = listState,
@@ -149,6 +151,7 @@ private fun HorizontalAvatarSectionPreview() {
             onChoosePhotoClick = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 }
@@ -168,6 +171,7 @@ private fun HorizontalAvatarSectionEmptyPreview() {
             onChoosePhotoClick = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
@@ -19,6 +19,7 @@ internal fun LazyAvatarRow(
     avatars: List<AvatarUi>,
     onAvatarSelected: (AvatarUi) -> Unit,
     onAltTextSelected: (AvatarUi) -> Unit,
+    onDeleteSelected: (AvatarUi) -> Unit,
     horizontalArrangement: Arrangement.Horizontal,
     state: LazyListState,
     contentPadding: PaddingValues,
@@ -35,6 +36,7 @@ internal fun LazyAvatarRow(
                 avatar = avatarModel,
                 onAvatarSelected = { onAvatarSelected(avatarModel) },
                 onAltTextSelected = { onAltTextSelected(avatarModel) },
+                onDeleteSelected = { onDeleteSelected(avatarModel) },
                 size = avatarSize,
                 modifier = Modifier.size(avatarSize),
             )
@@ -50,6 +52,7 @@ internal fun Avatar(
     size: Dp,
     onAvatarSelected: (AvatarUi) -> Unit,
     onAltTextSelected: (AvatarUi) -> Unit,
+    onDeleteSelected: (AvatarUi) -> Unit,
     modifier: Modifier,
 ) {
     when (avatar) {
@@ -61,6 +64,7 @@ internal fun Avatar(
                 loadingState = avatar.loadingState,
                 onAvatarClicked = { onAvatarSelected(avatar) },
                 onAltTextClicked = { onAltTextSelected(avatar) },
+                onDeleteClicked = { onDeleteSelected(avatar) },
                 modifier = modifier,
             )
         }
@@ -71,6 +75,7 @@ internal fun Avatar(
             loadingState = avatar.loadingState,
             onAvatarClicked = { onAvatarSelected(avatar) },
             onAltTextClicked = { onAltTextSelected(avatar) },
+            onDeleteClicked = { onDeleteSelected(avatar) },
             modifier = modifier,
         )
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
@@ -38,7 +38,7 @@ internal fun LazyAvatarRow(
                 onAltTextSelected = { onAltTextSelected(avatarModel) },
                 onDeleteSelected = { onDeleteSelected(avatarModel) },
                 size = avatarSize,
-                modifier = Modifier.size(avatarSize),
+                modifier = Modifier.animateItem().size(avatarSize),
             )
         }
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
@@ -12,14 +12,14 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarUi
+import com.gravatar.restapi.models.Avatar
 import java.net.URL
 
 @Composable
 internal fun LazyAvatarRow(
     avatars: List<AvatarUi>,
     onAvatarSelected: (AvatarUi) -> Unit,
-    onAltTextSelected: (AvatarUi) -> Unit,
-    onDeleteSelected: (AvatarUi) -> Unit,
+    onAvatarOptionClicked: (Avatar, AvatarOption) -> Unit,
     horizontalArrangement: Arrangement.Horizontal,
     state: LazyListState,
     contentPadding: PaddingValues,
@@ -35,10 +35,11 @@ internal fun LazyAvatarRow(
             Avatar(
                 avatar = avatarModel,
                 onAvatarSelected = { onAvatarSelected(avatarModel) },
-                onAltTextSelected = { onAltTextSelected(avatarModel) },
-                onDeleteSelected = { onDeleteSelected(avatarModel) },
+                onAvatarOptionClicked = { avatar, option -> onAvatarOptionClicked(avatar, option) },
                 size = avatarSize,
-                modifier = Modifier.animateItem().size(avatarSize),
+                modifier = Modifier
+                    .animateItem()
+                    .size(avatarSize),
             )
         }
     }
@@ -50,9 +51,8 @@ internal val avatarSize = 96.dp
 internal fun Avatar(
     avatar: AvatarUi,
     size: Dp,
-    onAvatarSelected: (AvatarUi) -> Unit,
-    onAltTextSelected: (AvatarUi) -> Unit,
-    onDeleteSelected: (AvatarUi) -> Unit,
+    onAvatarSelected: () -> Unit,
+    onAvatarOptionClicked: (Avatar, AvatarOption) -> Unit,
     modifier: Modifier,
 ) {
     when (avatar) {
@@ -62,9 +62,8 @@ internal fun Avatar(
                 imageUrl = avatar.imageUrlWithSize(sizePx),
                 isSelected = avatar.isSelected,
                 loadingState = avatar.loadingState,
-                onAvatarClicked = { onAvatarSelected(avatar) },
-                onAltTextClicked = { onAltTextSelected(avatar) },
-                onDeleteClicked = { onDeleteSelected(avatar) },
+                onAvatarClicked = { onAvatarSelected() },
+                onAvatarOptionClicked = { onAvatarOptionClicked(avatar.avatar, it) },
                 modifier = modifier,
             )
         }
@@ -73,9 +72,7 @@ internal fun Avatar(
             imageUrl = avatar.uri.toString(),
             isSelected = false,
             loadingState = avatar.loadingState,
-            onAvatarClicked = { onAvatarSelected(avatar) },
-            onAltTextClicked = { onAltTextSelected(avatar) },
-            onDeleteClicked = { onDeleteSelected(avatar) },
+            onAvatarClicked = { onAvatarSelected() },
             modifier = modifier,
         )
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
@@ -109,6 +109,7 @@ private fun PickerPopup(
                                     iconRes = item.iconRes,
                                     contentDescription = stringResource(item.contentDescription),
                                     shape = popupButtonShape(index, popupItems.size, cornerRadius),
+                                    color = item.color,
                                     onClick = item.onClick,
                                 )
                                 if (index < popupItems.size - 1) {
@@ -143,6 +144,7 @@ internal data class PickerPopupItem(
     @StringRes val text: Int,
     @DrawableRes val iconRes: Int,
     @StringRes val contentDescription: Int,
+    val color: Color? = null,
     val onClick: () -> Unit,
 )
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PopupButton.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PopupButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -29,6 +30,7 @@ internal fun PopupButton(
     contentDescription: String,
     onClick: () -> Unit,
     shape: Shape,
+    color: Color? = null,
     modifier: Modifier = Modifier,
 ) {
     TextButton(
@@ -45,14 +47,14 @@ internal fun PopupButton(
                 text = text,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = color ?: MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 modifier = Modifier.weight(1f),
             )
             Icon(
                 painter = painterResource(id = iconRes),
                 contentDescription = contentDescription,
-                tint = MaterialTheme.colorScheme.onSurface,
+                tint = color ?: MaterialTheme.colorScheme.onSurface,
             )
         }
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/SelectableAvatar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/SelectableAvatar.kt
@@ -45,6 +45,7 @@ internal fun SelectableAvatar(
     loadingState: AvatarLoadingState,
     onAvatarClicked: () -> Unit,
     onAltTextClicked: () -> Unit,
+    onDeleteClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val cornerRadius = 8.dp
@@ -96,6 +97,10 @@ internal fun SelectableAvatar(
                 onAltTextClick = {
                     moreOptionsPopupVisible = false
                     onAltTextClicked()
+                },
+                onDeleteClicked = {
+                    moreOptionsPopupVisible = false
+                    onDeleteClicked()
                 },
             )
         }
@@ -185,6 +190,7 @@ private fun SelectableAvatarNotSelectedPreview() {
         loadingState = AvatarLoadingState.None,
         onAvatarClicked = { },
         onAltTextClicked = { },
+        onDeleteClicked = { },
         modifier = Modifier.size(150.dp),
     )
 }
@@ -198,6 +204,7 @@ private fun SelectableAvatarSelectedPreview() {
         loadingState = AvatarLoadingState.None,
         onAvatarClicked = { },
         onAltTextClicked = { },
+        onDeleteClicked = { },
         modifier = Modifier.size(150.dp),
     )
 }
@@ -211,6 +218,7 @@ private fun SelectableAvatarLoadingPreview() {
         loadingState = AvatarLoadingState.Loading,
         onAvatarClicked = { },
         onAltTextClicked = { },
+        onDeleteClicked = { },
         modifier = Modifier.size(150.dp),
     )
 }
@@ -224,6 +232,7 @@ private fun SelectableAvatarFailurePreview() {
         loadingState = AvatarLoadingState.Failure,
         onAvatarClicked = { },
         onAltTextClicked = { },
+        onDeleteClicked = { },
         modifier = Modifier.size(150.dp),
     )
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/SelectableAvatar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/SelectableAvatar.kt
@@ -44,8 +44,7 @@ internal fun SelectableAvatar(
     isSelected: Boolean,
     loadingState: AvatarLoadingState,
     onAvatarClicked: () -> Unit,
-    onAltTextClicked: () -> Unit,
-    onDeleteClicked: () -> Unit,
+    onAvatarOptionClicked: ((AvatarOption) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val cornerRadius = 8.dp
@@ -94,13 +93,9 @@ internal fun SelectableAvatar(
                 anchorAlignment = Alignment.CenterHorizontally,
                 anchorBounds = popupAnchorBounds,
                 onDismissRequest = { moreOptionsPopupVisible = false },
-                onAltTextClick = {
+                onAvatarOptionClicked = { avatarOption ->
                     moreOptionsPopupVisible = false
-                    onAltTextClicked()
-                },
-                onDeleteClicked = {
-                    moreOptionsPopupVisible = false
-                    onDeleteClicked()
+                    onAvatarOptionClicked?.let { it(avatarOption) }
                 },
             )
         }
@@ -189,8 +184,7 @@ private fun SelectableAvatarNotSelectedPreview() {
         isSelected = false,
         loadingState = AvatarLoadingState.None,
         onAvatarClicked = { },
-        onAltTextClicked = { },
-        onDeleteClicked = { },
+        onAvatarOptionClicked = { },
         modifier = Modifier.size(150.dp),
     )
 }
@@ -203,8 +197,7 @@ private fun SelectableAvatarSelectedPreview() {
         isSelected = true,
         loadingState = AvatarLoadingState.None,
         onAvatarClicked = { },
-        onAltTextClicked = { },
-        onDeleteClicked = { },
+        onAvatarOptionClicked = { },
         modifier = Modifier.size(150.dp),
     )
 }
@@ -217,8 +210,7 @@ private fun SelectableAvatarLoadingPreview() {
         isSelected = false,
         loadingState = AvatarLoadingState.Loading,
         onAvatarClicked = { },
-        onAltTextClicked = { },
-        onDeleteClicked = { },
+        onAvatarOptionClicked = { },
         modifier = Modifier.size(150.dp),
     )
 }
@@ -231,8 +223,7 @@ private fun SelectableAvatarFailurePreview() {
         isSelected = false,
         loadingState = AvatarLoadingState.Failure,
         onAvatarClicked = { },
-        onAltTextClicked = { },
-        onDeleteClicked = { },
+        onAvatarOptionClicked = { },
         modifier = Modifier.size(150.dp),
     )
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/VerticalAvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/VerticalAvatarsSection.kt
@@ -41,6 +41,7 @@ internal fun VerticalAvatarsSection(
     state: AvatarsSectionUiState,
     onAvatarSelected: (AvatarUi) -> Unit,
     onAltTextSelected: (AvatarUi) -> Unit,
+    onDeleteSelected: (AvatarUi) -> Unit,
     onChoosePhotoClick: () -> Unit,
     onTakePhotoClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -121,6 +122,7 @@ internal fun VerticalAvatarsSection(
                             avatar = avatarModel,
                             onAvatarSelected = { onAvatarSelected(avatarModel) },
                             onAltTextSelected = { onAltTextSelected(avatarModel) },
+                            onDeleteSelected = { onDeleteSelected(avatarModel) },
                             size = avatarSize,
                             modifier = Modifier,
                         )
@@ -174,6 +176,7 @@ private fun VerticalAvatarSectionPreview() {
             onChoosePhotoClick = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 }
@@ -193,6 +196,7 @@ private fun VerticalAvatarSectionEmptyPreview() {
             onChoosePhotoClick = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/VerticalAvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/VerticalAvatarsSection.kt
@@ -40,8 +40,7 @@ import java.net.URI
 internal fun VerticalAvatarsSection(
     state: AvatarsSectionUiState,
     onAvatarSelected: (AvatarUi) -> Unit,
-    onAltTextSelected: (AvatarUi) -> Unit,
-    onDeleteSelected: (AvatarUi) -> Unit,
+    onAvatarOptionClicked: (Avatar, AvatarOption) -> Unit,
     onChoosePhotoClick: () -> Unit,
     onTakePhotoClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -121,8 +120,7 @@ internal fun VerticalAvatarsSection(
                         Avatar(
                             avatar = avatarModel,
                             onAvatarSelected = { onAvatarSelected(avatarModel) },
-                            onAltTextSelected = { onAltTextSelected(avatarModel) },
-                            onDeleteSelected = { onDeleteSelected(avatarModel) },
+                            onAvatarOptionClicked = { avatar, option -> onAvatarOptionClicked(avatar, option) },
                             size = avatarSize,
                             modifier = Modifier,
                         )
@@ -175,8 +173,7 @@ private fun VerticalAvatarSectionPreview() {
             onTakePhotoClick = { },
             onChoosePhotoClick = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 }
@@ -195,8 +192,7 @@ private fun VerticalAvatarSectionEmptyPreview() {
             onTakePhotoClick = { },
             onChoosePhotoClick = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 }

--- a/gravatar-quickeditor/src/main/res/drawable/gravatar_avatar_more_options_delete.xml
+++ b/gravatar-quickeditor/src/main/res/drawable/gravatar_avatar_more_options_delete.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="16dp"
+    android:viewportWidth="14"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M7,0C5.186,0 3.672,1.288 3.325,3H0V4.5H1.27L2.088,13.497C2.217,14.913 3.404,15.998 4.827,15.998H9.174C10.596,15.998 11.784,14.913 11.912,13.497L12.73,4.5H14V3H10.675C10.328,1.288 8.814,0 7,0ZM7,1.5C6.02,1.5 5.187,2.126 4.878,3H9.122C8.813,2.126 7.98,1.5 7,1.5ZM11.224,4.5H2.776L3.582,13.361C3.64,14.005 4.18,14.498 4.827,14.498H9.174C9.82,14.498 10.36,14.005 10.418,13.361L11.224,4.5Z"
+      android:fillColor="#FF3B30"
+      android:fillType="evenOdd"/>
+</vector>

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="gravatar_qe_selectable_avatar_more_options_content_description">More Options</string>
     <string name="gravatar_qe_selectable_avatar_more_options_alt_text">Alt Text</string>
     <string name="gravatar_qe_selectable_avatar_more_options_alt_text_content_description">Alternative Text</string>
+    <string name="gravatar_qe_selectable_avatar_more_options_delete">Delete</string>
+    <string name="gravatar_qe_selectable_avatar_more_options_delete_content_description">Delete Avatar</string>
     <string name="gravatar_qe_bottom_sheet_done">Done</string>
     <string name="gravatar_qe_avatar_picker_title">Avatars</string>
     <string name="gravatar_qe_avatar_picker_title_empty_state">Let’s setup your avatar</string>

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -163,6 +163,45 @@ class AvatarRepositoryTest {
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)), result)
     }
 
+    @Test
+    fun `given token stored when avatar delete succeeds then Success result`() = runTest {
+        val imageId = "imageId"
+        coEvery { tokenStorage.getToken(any()) } returns "token"
+        coEvery {
+            avatarService.deleteAvatarCatching(imageId = "imageId", oauthToken = "token")
+        } returns GravatarResult.Success(Unit)
+
+        val result = avatarRepository.deleteAvatar(email, imageId)
+
+        assertEquals(GravatarResult.Success<Unit, QuickEditorError>(Unit), result)
+    }
+
+    @Test
+    fun `given token stored when avatar delete fails then Failure result`() = runTest {
+        val imageId = "imageId"
+        coEvery { tokenStorage.getToken(any()) } returns "token"
+        coEvery {
+            avatarService.deleteAvatarCatching(
+                imageId = "imageId",
+                oauthToken = "token",
+            )
+        } returns GravatarResult.Failure(ErrorType.Server)
+
+        val result = avatarRepository.deleteAvatar(email, imageId)
+
+        assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)), result)
+    }
+
+    @Test
+    fun `given no token when deleteAvatar is called then TokenNotFound result`() = runTest {
+        val imageId = "imageId"
+        coEvery { tokenStorage.getToken(any()) } returns null
+
+        val result = avatarRepository.deleteAvatar(email, imageId)
+
+        assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.TokenNotFound), result)
+    }
+
     private fun createAvatar(id: String, isSelected: Boolean = false) = Avatar {
         imageUrl = URI.create("https://gravatar.com/avatar/test")
         imageId = id

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/AvatarsSectionTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/AvatarsSectionTest.kt
@@ -23,6 +23,7 @@ class AvatarsSectionTest : RoborazziTest() {
             onLocalImageSelected = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 
@@ -39,6 +40,7 @@ class AvatarsSectionTest : RoborazziTest() {
             onLocalImageSelected = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 
@@ -54,6 +56,7 @@ class AvatarsSectionTest : RoborazziTest() {
             onLocalImageSelected = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 
@@ -69,6 +72,7 @@ class AvatarsSectionTest : RoborazziTest() {
             onLocalImageSelected = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 
@@ -84,6 +88,7 @@ class AvatarsSectionTest : RoborazziTest() {
             onLocalImageSelected = { },
             onAvatarSelected = { },
             onAltTextSelected = { },
+            onDeleteSelected = { },
         )
     }
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/AvatarsSectionTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/AvatarsSectionTest.kt
@@ -22,8 +22,7 @@ class AvatarsSectionTest : RoborazziTest() {
             ),
             onLocalImageSelected = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 
@@ -39,8 +38,7 @@ class AvatarsSectionTest : RoborazziTest() {
             ),
             onLocalImageSelected = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 
@@ -55,8 +53,7 @@ class AvatarsSectionTest : RoborazziTest() {
             ),
             onLocalImageSelected = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 
@@ -71,8 +68,7 @@ class AvatarsSectionTest : RoborazziTest() {
             ),
             onLocalImageSelected = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 
@@ -87,8 +83,7 @@ class AvatarsSectionTest : RoborazziTest() {
             ),
             onLocalImageSelected = { },
             onAvatarSelected = { },
-            onAltTextSelected = { },
-            onDeleteSelected = { },
+            onAvatarOptionClicked = { _, _ -> },
         )
     }
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/SelectableAvatarTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/SelectableAvatarTest.kt
@@ -16,6 +16,7 @@ class SelectableAvatarTest : RoborazziTest() {
             loadingState = AvatarLoadingState.None,
             onAvatarClicked = {},
             onAltTextClicked = {},
+            onDeleteClicked = {},
             modifier = Modifier.size(150.dp),
         )
     }
@@ -28,6 +29,7 @@ class SelectableAvatarTest : RoborazziTest() {
             loadingState = AvatarLoadingState.None,
             onAvatarClicked = {},
             onAltTextClicked = {},
+            onDeleteClicked = {},
             modifier = Modifier.size(150.dp),
         )
     }
@@ -40,6 +42,7 @@ class SelectableAvatarTest : RoborazziTest() {
             loadingState = AvatarLoadingState.Loading,
             onAvatarClicked = {},
             onAltTextClicked = {},
+            onDeleteClicked = {},
             modifier = Modifier.size(150.dp),
         )
     }
@@ -52,6 +55,7 @@ class SelectableAvatarTest : RoborazziTest() {
             loadingState = AvatarLoadingState.Failure,
             onAvatarClicked = {},
             onAltTextClicked = {},
+            onDeleteClicked = {},
             modifier = Modifier.size(150.dp),
         )
     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/SelectableAvatarTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/SelectableAvatarTest.kt
@@ -15,8 +15,7 @@ class SelectableAvatarTest : RoborazziTest() {
             isSelected = true,
             loadingState = AvatarLoadingState.None,
             onAvatarClicked = {},
-            onAltTextClicked = {},
-            onDeleteClicked = {},
+            onAvatarOptionClicked = {},
             modifier = Modifier.size(150.dp),
         )
     }
@@ -28,8 +27,7 @@ class SelectableAvatarTest : RoborazziTest() {
             isSelected = false,
             loadingState = AvatarLoadingState.None,
             onAvatarClicked = {},
-            onAltTextClicked = {},
-            onDeleteClicked = {},
+            onAvatarOptionClicked = {},
             modifier = Modifier.size(150.dp),
         )
     }
@@ -41,8 +39,7 @@ class SelectableAvatarTest : RoborazziTest() {
             isSelected = false,
             loadingState = AvatarLoadingState.Loading,
             onAvatarClicked = {},
-            onAltTextClicked = {},
-            onDeleteClicked = {},
+            onAvatarOptionClicked = {},
             modifier = Modifier.size(150.dp),
         )
     }
@@ -54,8 +51,7 @@ class SelectableAvatarTest : RoborazziTest() {
             isSelected = false,
             loadingState = AvatarLoadingState.Failure,
             onAvatarClicked = {},
-            onAltTextClicked = {},
-            onDeleteClicked = {},
+            onAvatarOptionClicked = {},
             modifier = Modifier.size(150.dp),
         )
     }

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -693,6 +693,8 @@ public final class com/gravatar/services/AvatarService {
 	public fun <init> ()V
 	public fun <init> (Lokhttp3/OkHttpClient;)V
 	public synthetic fun <init> (Lokhttp3/OkHttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun deleteAvatar (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteAvatarCatching (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieve (Ljava/lang/String;Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun retrieveCatching (Ljava/lang/String;Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAvatar (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -170,4 +170,43 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
     ): GravatarResult<Unit, ErrorType> = runCatchingRequest {
         setAvatar(hash, avatarId, oauthToken)
     }
+
+    /**
+     * Deletes the avatar with the given ID.
+     *
+     * @param imageId The ID of the avatar to delete
+     * @param oauthToken The OAuth token to use for authentication
+     */
+    public suspend fun deleteAvatar(imageId: String, oauthToken: String): Unit = runThrowingExceptionRequest {
+        withContext(GravatarSdkDI.dispatcherIO) {
+            val service = GravatarSdkDI.getGravatarV3Service(okHttpClient, oauthToken)
+
+            val response = service.deleteAvatar(imageId)
+
+            if (response.isSuccessful) {
+                Unit
+            } else {
+                // Log the response body for debugging purposes if the response is not successful
+                Logger.w(
+                    LOG_TAG,
+                    "Network call unsuccessful trying to delete Gravatar avatar: $response.body",
+                )
+                throw HttpException(response)
+            }
+        }
+    }
+
+    /**
+     * Deletes the avatar with the given ID.
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
+     *
+     * @param imageId The ID of the avatar to delete
+     * @param oauthToken The OAuth token to use for authentication
+     * @return The result of the operation
+     */
+    public suspend fun deleteAvatarCatching(imageId: String, oauthToken: String): GravatarResult<Unit, ErrorType> =
+        runCatchingRequest {
+            deleteAvatar(imageId, oauthToken)
+        }
 }

--- a/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/AvatarServiceTest.kt
@@ -242,4 +242,67 @@ class AvatarServiceTest {
 
             assertEquals(ErrorType.Server, (response as GravatarResult.Failure).error)
         }
+
+    @Test
+    fun `given an imageId when deleting avatar then Gravatar service is invoked`() = runTest {
+        val imageId = "imageId"
+        val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+            every { isSuccessful } returns true
+        }
+
+        coEvery { containerRule.gravatarApiMock.deleteAvatar(imageId) } returns mockResponse
+
+        avatarService.deleteAvatar(imageId, oauthToken)
+
+        coVerify(exactly = 1) {
+            containerRule.gravatarApiMock.deleteAvatar(imageId)
+        }
+    }
+
+    @Test
+    fun `given an imageId when deleting avatar and an error occurs then an exception is thrown`() =
+        runTestExpectingGravatarException(ErrorType.Server, HttpException::class.java) {
+            val imageId = "imageId"
+            val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+                every { isSuccessful } returns false
+                every { code() } returns 500
+            }
+
+            coEvery { containerRule.gravatarApiMock.deleteAvatar(imageId) } returns mockResponse
+
+            avatarService.deleteAvatar(imageId, oauthToken)
+        }
+
+    @Test
+    fun `given an imageId when deleteAvatarCatching then Gravatar service is invoked`() = runTest {
+        val imageId = "imageId"
+        val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+            every { isSuccessful } returns true
+        }
+
+        coEvery { containerRule.gravatarApiMock.deleteAvatar(imageId) } returns mockResponse
+
+        val response = avatarService.deleteAvatarCatching(imageId, oauthToken)
+
+        coVerify(exactly = 1) {
+            containerRule.gravatarApiMock.deleteAvatar(imageId)
+        }
+
+        assertEquals(Unit, (response as GravatarResult.Success).value)
+    }
+
+    @Test
+    fun `given an imageId when deleteAvatarCatching and an error occurs then a Result Failure is returned`() = runTest {
+        val imageId = "imageId"
+        val mockResponse = mockk<Response<Unit>>(relaxed = true) {
+            every { isSuccessful } returns false
+            every { code() } returns 500
+        }
+
+        coEvery { containerRule.gravatarApiMock.deleteAvatar(imageId) } returns mockResponse
+
+        val response = avatarService.deleteAvatarCatching(imageId, oauthToken)
+
+        assertEquals(ErrorType.Server, (response as GravatarResult.Failure).error)
+    }
 }


### PR DESCRIPTION
Closes #236

### Description

This PR implements the base of the delete avatar flow. 

**Note:** When opening this PR, the endpoints are not working yet, so you'll always receive a `404`; however, I think testing the whole flow is possible. However, it's possible that we'll need to make minor adjustments when the endpoint is released.

https://github.com/user-attachments/assets/7cc13327-c440-469f-8d13-61aa6ffb3d42

This PR will be followed by two more to add the confirmation dialog (#449)  and the error toast (#448).

### Testing Steps

1. Open the QE
2. In any of your uploaded avatars, tap the options button (...)
3. Select `Delete`
4. You should see how the avatar disappears immediately (as we are assuming the flow will work)
5. You should see the avatar reappear when we receive the `404` (that's the work part of not having the endpoints yet :) )
6. If you want, you can check logcat a see the error:
```
2024-11-20 12:05:40.816 10320-10465 AvatarService           com.gravatar.demoapp                 W  Network call unsuccessful trying to delete Gravatar avatar: Response{protocol=h2, code=404, message=, url=https://api.gravatar.com/v3/me/avatars/bfb35130743eb019b309a3c219ee77b5}.body
```
7. You can also play with a network interceptor and mock a 200 answer (I don't think it's completely necessary)