### PR TITLE
Quick Editor: Show error toast with retry action when delete avatar fails

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -263,6 +264,7 @@ private fun AvatarPickerAction.handle(
                         actionLabel = context.getString(R.string.gravatar_qe_avatar_picker_error_retry_cta),
                         withDismissAction = true,
                         snackbarType = SnackbarType.Error,
+                        duration = SnackbarDuration.Long,
                     ) == QESnackbarResult.ActionPerformed
                 ) {
                     viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatar))

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
@@ -1,6 +1,7 @@
 package com.gravatar.quickeditor.ui.avatarpicker
 
 import android.net.Uri
+import com.gravatar.restapi.models.Avatar
 import java.io.File
 
 internal sealed class AvatarPickerAction {
@@ -11,4 +12,6 @@ internal sealed class AvatarPickerAction {
     data object AvatarSelectionFailed : AvatarPickerAction()
 
     data object InvokeAuthFailed : AvatarPickerAction()
+
+    data class AvatarDeletionFailed(val avatar: Avatar) : AvatarPickerAction()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -279,6 +279,7 @@ internal class AvatarPickerViewModel(
                 }
 
                 is GravatarResult.Failure -> {
+                    _actions.send(AvatarPickerAction.AvatarDeletionFailed(avatar))
                     _uiState.update { currentState ->
                         currentState.copy(
                             emailAvatars = currentState.emailAvatars?.copy(

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="gravatar_qe_photo_library_icon_description">Photo library</string>
     <string name="gravatar_qe_capture_photo_icon_description">Capture Photo</string>
     <string name="gravatar_qe_avatar_selection_error">Ooops, there was an error selecting the avatar.</string>
+    <string name="gravatar_qe_avatar_delete_avatar_error">Error deleting the image.</string>
     <string name="gravatar_qe_avatar_picker_server_error_title">Ooops</string>
     <string name="gravatar_qe_avatar_picker_server_error_message">Something went wrong and we couldn\'t connect to Gravatar servers.</string>
     <string name="gravatar_qe_avatar_picker_unknown_error_message">Something went terribly wrong.</string>

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -861,6 +861,9 @@ class AvatarPickerViewModelTest {
                 avatarPickerUiState,
                 awaitItem(),
             )
+            viewModel.actions.test {
+                assertEquals(AvatarPickerAction.AvatarDeletionFailed(avatarToDelete), awaitItem())
+            }
         }
     }
 
@@ -896,6 +899,9 @@ class AvatarPickerViewModelTest {
                 avatarPickerUiState,
                 awaitItem(),
             )
+            viewModel.actions.test {
+                assertEquals(AvatarPickerAction.AvatarDeletionFailed(avatarToDelete), awaitItem())
+            }
         }
     }
 


### PR DESCRIPTION
Closes #448 

### Description

When the avatar deletion fails, apart from adding the avatar again to the list, we want to show a toast notifying the user about what happened and giving them the possibility of retry.

**Note**: When opening this PR, the endpoints are not working yet, so you'll always receive a 404; however, I think testing the whole flow is possible. However, it's possible that we'll need to make minor adjustments when the endpoint is released.

https://github.com/user-attachments/assets/34051fce-41aa-46c6-afde-7c6b6cc27af2

### Testing Steps

1. Open the QE
2. In any of your uploaded avatars, tap the options button (...)
3. Select `Delete`
4. You should see how the avatar disappears immediately (as we are assuming the flow will work)
5. You should see the avatar reappear when we receive the 404 (that's the work part of not having the endpoints yet :) ) along with the error toast
6. Tap `Try again` and verify steps 4 and 5.
