### PR TITLE
QuickEditor: Confirmation dialog before deleting an avatar

### DIFF
--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -57,21 +57,26 @@ public final class com/gravatar/quickeditor/ui/GravatarQuickEditorResult : java/
 
 public final class com/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$AvatarDeletionConfirmationDialogKt {
+	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/components/ComposableSingletons$AvatarDeletionConfirmationDialogKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
 	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
-	public static field lambda-5 Lkotlin/jvm/functions/Function2;
-	public static field lambda-6 Lkotlin/jvm/functions/Function2;
-	public static field lambda-7 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-4$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-5$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-6$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-7$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$AvatarMoreOptionsPickerPopupKt {

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -57,13 +57,21 @@ public final class com/gravatar/quickeditor/ui/GravatarQuickEditorResult : java/
 
 public final class com/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/avatarpicker/ComposableSingletons$AvatarPickerKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public static field lambda-6 Lkotlin/jvm/functions/Function2;
+	public static field lambda-7 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-6$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-7$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$AvatarMoreOptionsPickerPopupKt {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -177,7 +177,7 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
         }
     }
 
-    var confirmAvatarDeletion by remember { mutableStateOf<String?>(null) }
+    var confirmAvatarDeletion by rememberSaveable { mutableStateOf<String?>(null) }
     Surface(
         Modifier
             .fillMaxWidth()

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -21,14 +21,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -55,6 +51,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gravatar.extensions.defaultProfile
 import com.gravatar.quickeditor.R
 import com.gravatar.quickeditor.data.repository.EmailAvatars
+import com.gravatar.quickeditor.ui.components.AvatarDeletionConfirmationDialog
 import com.gravatar.quickeditor.ui.components.AvatarOption
 import com.gravatar.quickeditor.ui.components.AvatarsSection
 import com.gravatar.quickeditor.ui.components.DownloadManagerDisabledAlertDialog
@@ -307,32 +304,6 @@ private fun openDownloadManagerSettings(context: Context) {
         val intent = Intent(Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS)
         context.startActivity(intent)
     }
-}
-
-@Composable
-private fun AvatarDeletionConfirmationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_title))
-        },
-        text = {
-            Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_message))
-        },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(
-                    text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_confirm),
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_cancel))
-            }
-        },
-    )
 }
 
 @Suppress("LongParameterList")

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -177,7 +177,7 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
         }
     }
 
-    var confirmAvatarDeletion by remember { mutableStateOf<Avatar?>(null) }
+    var confirmAvatarDeletion by remember { mutableStateOf<String?>(null) }
     Surface(
         Modifier
             .fillMaxWidth()
@@ -239,7 +239,7 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
                             when (avatarOption) {
                                 AvatarOption.ALT_TEXT -> Unit
                                 AvatarOption.DELETE -> {
-                                    confirmAvatarDeletion = avatar
+                                    confirmAvatarDeletion = avatar.imageId
                                 }
 
                                 AvatarOption.DOWNLOAD_IMAGE -> {
@@ -354,7 +354,7 @@ private fun AvatarPickerAction.handle(
                         duration = SnackbarDuration.Long,
                     ) == QESnackbarResult.ActionPerformed
                 ) {
-                    viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatar))
+                    viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarId))
                 }
             }
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -21,10 +21,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -176,6 +180,7 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
         }
     }
 
+    var confirmAvatarDeletion by remember { mutableStateOf<Avatar?>(null) }
     Surface(
         Modifier
             .fillMaxWidth()
@@ -237,7 +242,7 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
                             when (avatarOption) {
                                 AvatarOption.ALT_TEXT -> Unit
                                 AvatarOption.DELETE -> {
-                                    onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatar))
+                                    confirmAvatarDeletion = avatar
                                 }
 
                                 AvatarOption.DOWNLOAD_IMAGE -> {
@@ -278,6 +283,15 @@ internal fun AvatarPicker(uiState: AvatarPickerUiState, onEvent: (AvatarPickerEv
             },
             onDismiss = { storagePermissionRationaleDialogVisible = false },
         )
+        confirmAvatarDeletion?.let {
+            AvatarDeletionConfirmationDialog(
+                onConfirm = {
+                    onEvent(AvatarPickerEvent.AvatarDeleteSelected(it))
+                    confirmAvatarDeletion = null
+                },
+                onDismiss = { confirmAvatarDeletion = null },
+            )
+        }
     }
 }
 
@@ -293,6 +307,32 @@ private fun openDownloadManagerSettings(context: Context) {
         val intent = Intent(Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS)
         context.startActivity(intent)
     }
+}
+
+@Composable
+private fun AvatarDeletionConfirmationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_title))
+        },
+        text = {
+            Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_message))
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_confirm),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_cancel))
+            }
+        },
+    )
 }
 
 @Suppress("LongParameterList")

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
@@ -1,7 +1,6 @@
 package com.gravatar.quickeditor.ui.avatarpicker
 
 import android.net.Uri
-import com.gravatar.restapi.models.Avatar
 import java.io.File
 
 internal sealed class AvatarPickerAction {
@@ -13,9 +12,9 @@ internal sealed class AvatarPickerAction {
 
     data object InvokeAuthFailed : AvatarPickerAction()
 
-    data class AvatarDeletionFailed(val avatar: Avatar) : AvatarPickerAction()
-
     data object AvatarDownloadStarted : AvatarPickerAction()
 
     data object DownloadManagerNotAvailable : AvatarPickerAction()
+
+    data class AvatarDeletionFailed(val avatarId: String) : AvatarPickerAction()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerEvent.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerEvent.kt
@@ -20,9 +20,9 @@ internal sealed class AvatarPickerEvent {
 
     data object HandleAuthFailureTapped : AvatarPickerEvent()
 
-    data class AvatarDeleteSelected(val avatar: Avatar) : AvatarPickerEvent()
-
     data class DownloadAvatarTapped(val avatar: Avatar) : AvatarPickerEvent()
 
     data object DownloadManagerDisabledDialogDismissed : AvatarPickerEvent()
+
+    data class AvatarDeleteSelected(val avatarId: String) : AvatarPickerEvent()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarDeletionConfirmationDialog.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarDeletionConfirmationDialog.kt
@@ -1,0 +1,35 @@
+package com.gravatar.quickeditor.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.gravatar.quickeditor.R
+
+@Composable
+internal fun AvatarDeletionConfirmationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_title))
+        },
+        text = {
+            Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_message))
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_confirm),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.gravatar_qe_avatar_delete_confirmation_cancel))
+            }
+        },
+    )
+}

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
     <string name="gravatar_qe_capture_photo_icon_description">Capture Photo</string>
     <string name="gravatar_qe_avatar_selection_error">Ooops, there was an error selecting the avatar.</string>
     <string name="gravatar_qe_avatar_delete_avatar_error">Error deleting the image.</string>
+    <string name="gravatar_qe_avatar_delete_confirmation_title">Delete Image</string>
+    <string name="gravatar_qe_avatar_delete_confirmation_message">Are you sure you want to delete this image?</string>
+    <string name="gravatar_qe_avatar_delete_confirmation_confirm">Delete</string>
+    <string name="gravatar_qe_avatar_delete_confirmation_cancel">Cancel</string>
     <string name="gravatar_qe_avatar_picker_server_error_title">Ooops</string>
     <string name="gravatar_qe_avatar_picker_server_error_message">Something went wrong and we couldn\'t connect to Gravatar servers.</string>
     <string name="gravatar_qe_avatar_picker_unknown_error_message">Something went terribly wrong.</string>

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -780,7 +780,7 @@ class AvatarPickerViewModelTest {
         viewModel.uiState.test {
             expectMostRecentItem()
             val avatarToDelete = avatars.first()
-            viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete))
+            viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
                 emailAvatars = emailAvatarsCopy.copy(avatars = avatars.minus(avatarToDelete), selectedAvatarId = null),
@@ -812,7 +812,7 @@ class AvatarPickerViewModelTest {
         viewModel.uiState.test {
             expectMostRecentItem()
             val avatarToDelete = avatars.last() // Non selected avatar
-            viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete))
+            viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
                 emailAvatars = emailAvatarsCopy.copy(
@@ -847,7 +847,7 @@ class AvatarPickerViewModelTest {
         viewModel.uiState.test {
             expectMostRecentItem()
             val avatarToDelete = avatars.first()
-            viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete))
+            viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
 
             awaitItem()
 
@@ -865,7 +865,7 @@ class AvatarPickerViewModelTest {
                 awaitItem(),
             )
             viewModel.actions.test {
-                assertEquals(AvatarPickerAction.AvatarDeletionFailed(avatarToDelete), awaitItem())
+                assertEquals(AvatarPickerAction.AvatarDeletionFailed(avatarToDelete.imageId), awaitItem())
             }
         }
     }
@@ -885,7 +885,7 @@ class AvatarPickerViewModelTest {
         viewModel.uiState.test {
             expectMostRecentItem()
             val avatarToDelete = avatars.last() // Non selected avatar
-            viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete))
+            viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
 
             awaitItem()
 
@@ -903,7 +903,7 @@ class AvatarPickerViewModelTest {
                 awaitItem(),
             )
             viewModel.actions.test {
-                assertEquals(AvatarPickerAction.AvatarDeletionFailed(avatarToDelete), awaitItem())
+                assertEquals(AvatarPickerAction.AvatarDeletionFailed(avatarToDelete.imageId), awaitItem())
             }
         }
     }


### PR DESCRIPTION
Closes #449 

### Description

Before proceeding with the avatar deletion, we want to show the users a confirmation dialog.

https://github.com/user-attachments/assets/fa1646c4-44d4-4c3f-9a2b-a7d8dcdf64a7

### Testing Steps

1. Open the QE
2. In any of your uploaded avatars, tap the options button (...)
3. Select `Delete`
4. Verify you can see the confirmation dialog.
5. Click "Cancel"
6. Verify the dialog disappears, and nothing more happens
7. Open the options again, select `Delete`, and confirm your choice.
8. Verify the avatar deletion flow is executed.


