### PR TITLE
QuickEditor: Update AvatarsApi - Delete Avatar

### DIFF
--- a/gravatar/openapi/api-gravatar.json
+++ b/gravatar/openapi/api-gravatar.json
@@ -971,7 +971,7 @@
         }
       }
     },
-    "/me/avatars/{imageId}": {
+    "/me/avatars/{imageHash}": {
       "delete": {
         "summary": "Delete avatar",
         "description": "Deletes a specific avatar for the authenticated user.",
@@ -986,17 +986,17 @@
         ],
         "parameters": [
           {
-            "name": "imageId",
+            "name": "imageHash",
             "in": "path",
             "required": true,
-            "description": "The ID of the avatar to delete.",
+            "description": "The hash of the avatar to delete.",
             "schema": {
               "type": "string"
             }
           }
         ],
         "responses": {
-          "204": {
+          "200": {
             "description": "Avatar deleted successfully"
           },
           "401": {
@@ -1006,6 +1006,9 @@
           "403": {
             "description": "Insufficient Scope",
             "$ref": "#/components/responses/insufficient_scope"
+          },
+          "404": {
+            "description": "Avatar not found"
           }
         }
       },
@@ -1048,10 +1051,10 @@
         },
         "parameters": [
           {
-            "name": "imageId",
+            "name": "imageHash",
             "in": "path",
             "required": true,
-            "description": "The ID of the avatar to update.",
+            "description": "The hash of the avatar to update.",
             "schema": {
               "type": "string"
             }
@@ -1075,6 +1078,9 @@
           "403": {
             "description": "Insufficient Scope",
             "$ref": "#/components/responses/insufficient_scope"
+          },
+          "404": {
+            "description": "Avatar not found"
           }
         }
       }
@@ -1127,7 +1133,7 @@
           }
         ],
         "responses": {
-          "204": {
+          "200": {
             "description": "Avatar successfully set"
           },
           "401": {

--- a/gravatar/src/main/java/com/gravatar/restapi/apis/AvatarsApi.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/apis/AvatarsApi.kt
@@ -27,16 +27,17 @@ internal interface AvatarsApi {
      * Delete avatar
      * Deletes a specific avatar for the authenticated user.
      * Responses:
-     *  - 204: Avatar deleted successfully
+     *  - 200: Avatar deleted successfully
      *  - 401: Not Authorized
      *  - 403: Insufficient Scope
+     *  - 404: Avatar not found
      *
-     * @param imageId The ID of the avatar to delete.
+     * @param imageHash The hash of the avatar to delete.
      * @return [Unit]
      */
-    @DELETE("me/avatars/{imageId}")
+    @DELETE("me/avatars/{imageHash}")
     suspend fun deleteAvatar(
-        @Path("imageId") imageId: kotlin.String,
+        @Path("imageHash") imageHash: kotlin.String,
     ): Response<Unit>
 
     /**
@@ -59,7 +60,7 @@ internal interface AvatarsApi {
      * Set avatar for the hashed email
      * Sets the avatar for the provided email hash.
      * Responses:
-     *  - 204: Avatar successfully set
+     *  - 200: Avatar successfully set
      *  - 401: Not Authorized
      *  - 403: Insufficient Scope
      *
@@ -80,14 +81,15 @@ internal interface AvatarsApi {
      *  - 200: Avatar updated successfully
      *  - 401: Not Authorized
      *  - 403: Insufficient Scope
+     *  - 404: Avatar not found
      *
-     * @param imageId The ID of the avatar to update.
+     * @param imageHash The hash of the avatar to update.
      * @param updateAvatarRequest
      * @return [Avatar]
      */
-    @PATCH("me/avatars/{imageId}")
+    @PATCH("me/avatars/{imageHash}")
     suspend fun updateAvatar(
-        @Path("imageId") imageId: kotlin.String,
+        @Path("imageHash") imageHash: kotlin.String,
         @Body updateAvatarRequest: UpdateAvatarRequest,
     ): Response<Avatar>
 


### PR DESCRIPTION
Closes #236

### Description

Updating the OpenApi file with the latest version and regenerating the code. 

**Note:** Backend has been deployed, so the image deletion should work as expected.

### Testing Steps

The same steps as in #452 :

1. Open the QE
2. In any of your uploaded avatars, tap the options button (...)
3. Select `Delete`
4. Verify you can see the confirmation dialog.
5. Click "Cancel"
6. Verify the dialog disappears, and nothing more happens
7. Open the options again, select `Delete`, and confirm your choice.
8. Verify the avatar deletion flow is executed.

**Note:** The backend has an issue when deleting the selected avatar. You'll still see it as your avatar in spite of the fact that the image has been deleted.
