### PR TITLE
Apply tint to verified services remote icons

### DIFF
--- a/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
+++ b/gravatar-ui/src/main/java/com/gravatar/ui/components/atomic/SocialMedia.kt
@@ -12,9 +12,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -155,6 +157,7 @@ public fun SocialIcon(media: SocialMedia, modifier: Modifier = Modifier) {
                 contentDescription = media.name,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = androidx.compose.ui.layout.ContentScale.FillHeight,
+                colorFilter = ColorFilter.tint(LocalContentColor.current),
             )
         }
     }


### PR DESCRIPTION
Closes #462

### Description

There's an issue with icon tint for verified services that Icon are from a URL rather than a local resource. Those icons are not properly tinted in dark themes.

This PR solves that by applying a `LocalContentColor.current` to them.

| Before | After |
|---|---|
| <img width="381" alt="Screenshot 2024-11-27 at 14 07 07" src="https://github.com/user-attachments/assets/7fed40a2-286a-496d-9b45-93e933ff92d9"> | <img width="382" alt="Screenshot 2024-11-27 at 14 04 50" src="https://github.com/user-attachments/assets/6b184441-4006-4544-821a-03d8400f84f3"> |
| <img width="382" alt="Screenshot 2024-11-27 at 14 06 57" src="https://github.com/user-attachments/assets/7b6a1c7c-c41a-4349-bf75-ec02033947b7"> | <img width="382" alt="Screenshot 2024-11-27 at 14 04 58" src="https://github.com/user-attachments/assets/2cee9682-3443-4704-b8ee-d45555669329"> |

### Testing Steps

1. Add one of the services we don't have a local icon for to your profile: LinkedIn, BlueSky works.
2. Alternatively you can test other public profiles that have those services added.
3. Run the demo app.
4. On the profile tab test the components.
5. Repeat in the other UI mode (dark/light).
