### PR TITLE
QuickEditor: Delete avatar - Don't reload profile until sucessful response

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -304,16 +304,19 @@ internal class AvatarPickerViewModel(
                                 currentState.emailAvatars.selectedAvatarId
                             },
                         ),
-                        avatarUpdates = if (isSelectedAvatar) {
-                            currentState.avatarUpdates.inc()
-                        } else {
-                            currentState.avatarUpdates
-                        },
                     )
                 }
                 when (avatarRepository.deleteAvatar(email, avatarId)) {
                     is GravatarResult.Success -> {
-                        // As we've already updated the UI, we don't need to do anything here
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                avatarUpdates = if (isSelectedAvatar) {
+                                    currentState.avatarUpdates.inc()
+                                } else {
+                                    currentState.avatarUpdates
+                                },
+                            )
+                        }
                     }
 
                     is GravatarResult.Failure -> {
@@ -330,11 +333,6 @@ internal class AvatarPickerViewModel(
                                         currentState.emailAvatars.selectedAvatarId
                                     },
                                 ),
-                                avatarUpdates = if (isSelectedAvatar) {
-                                    currentState.avatarUpdates.inc()
-                                } else {
-                                    currentState.avatarUpdates
-                                },
                             )
                         }
                     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -781,14 +781,22 @@ class AvatarPickerViewModelTest {
             expectMostRecentItem()
             val avatarToDelete = avatars.first()
             viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
-            val avatarPickerUiState = AvatarPickerUiState(
+            var avatarPickerUiState = AvatarPickerUiState(
                 email = email,
                 emailAvatars = emailAvatarsCopy.copy(avatars = avatars.minus(avatarToDelete), selectedAvatarId = null),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 avatarPickerContentLayout = avatarPickerContentLayout,
-                avatarUpdates = 1,
+                avatarUpdates = 0,
                 scrollToIndex = 0,
+            )
+            assertEquals(
+                avatarPickerUiState,
+                awaitItem(),
+            )
+
+            avatarPickerUiState = avatarPickerUiState.copy(
+                avatarUpdates = 1,
             )
             assertEquals(
                 avatarPickerUiState,
@@ -857,7 +865,7 @@ class AvatarPickerViewModelTest {
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 avatarPickerContentLayout = avatarPickerContentLayout,
-                avatarUpdates = 2,
+                avatarUpdates = 0,
                 scrollToIndex = 0,
             )
             assertEquals(


### PR DESCRIPTION
Closes #236

### Description

When the selected avatar was deleted, as we assume the deletion will be OK, we automatically refreshed the profile card (with the avatar). However, the deletion process can finish later than the refresh, so we can still see the "old" avatar. 

We need to wait to reload the profile until we receive a successful response indicating that the avatar deletion has been completed.

<details>
<summary> Before </summary>

[Your text here...](https://github.com/user-attachments/assets/e3fc189b-4b54-453c-9349-5d8683973a02)
</details>

<details>
<summary> After </summary>

[Your text here...](https://github.com/user-attachments/assets/14907cc3-45fb-449b-acab-9881ccfd3e40)
</details>

### Testing Steps

1. In the `demo-app` open the QE
2. Make sure you have an avatar selected (or select one)
3. Delete the selected avatar (use the `...` button in the avatar)
4. Verify the profile card is refreshed and you see the Gravatar (G) default avatar.