### PR TITLE
QuickEditor: Fix crash when opening Avatar's contextual menu

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/HorizontalAvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/HorizontalAvatarsSection.kt
@@ -45,6 +45,7 @@ internal fun HorizontalAvatarsSection(
 ) {
     var popupVisible by remember { mutableStateOf(false) }
     var popupAnchorBounds: Rect by remember { mutableStateOf(Rect(Offset.Zero, Size.Zero)) }
+    var parentBounds by remember { mutableStateOf(Rect(Offset.Zero, Size.Zero)) }
     val listState = rememberLazyListState()
 
     LaunchedEffect(state.scrollToIndex) {
@@ -55,11 +56,15 @@ internal fun HorizontalAvatarsSection(
 
     val sectionPadding = 16.dp
     Surface(
-        modifier.border(
-            width = 1.dp,
-            color = MaterialTheme.colorScheme.surfaceContainerHighest,
-            shape = RoundedCornerShape(8.dp),
-        ),
+        modifier
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .onGloballyPositioned { coordinates ->
+                parentBounds = coordinates.boundsInRoot()
+            },
     ) {
         Box {
             Column(
@@ -85,6 +90,7 @@ internal fun HorizontalAvatarsSection(
                         onAvatarSelected = onAvatarSelected,
                         onAvatarOptionClicked = onAvatarOptionClicked,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        parentBounds = parentBounds,
                         modifier = Modifier.padding(vertical = 24.dp),
                         state = listState,
                         contentPadding = PaddingValues(horizontal = sectionPadding),

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
@@ -7,16 +7,8 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -30,17 +22,14 @@ internal fun LazyAvatarRow(
     onAvatarSelected: (AvatarUi) -> Unit,
     onAvatarOptionClicked: (Avatar, AvatarOption) -> Unit,
     horizontalArrangement: Arrangement.Horizontal,
+    parentBounds: Rect,
     state: LazyListState,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    var parentBounds by remember { mutableStateOf(Rect(Offset.Zero, Size.Zero)) }
-
     LazyRow(
         horizontalArrangement = horizontalArrangement,
-        modifier = modifier.onGloballyPositioned { coordinates ->
-            parentBounds = coordinates.boundsInRoot()
-        },
+        modifier = modifier,
         state = state,
         contentPadding = contentPadding,
     ) {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
@@ -161,6 +161,8 @@ private fun calculatePopupXOffset(
     }
 
     return maxBounds?.let { bounds ->
-        offset.coerceIn(bounds.left.toInt(), (bounds.right - popupSize.width).toInt())
+        val minimumValue = bounds.left
+        val maximumValue = (bounds.right - popupSize.width).coerceAtLeast(minimumValue)
+        offset.coerceIn(minimumValue.toInt(), maximumValue.toInt())
     } ?: offset
 }


### PR DESCRIPTION
Closes #468 

### Description

There's a crash in `horizontal` layout type when there are 1 or 2 avatars (the key here is to not fill the whole width of the screen). 

The `popupDrawArea` was incorrectly assigned based on the `LazyRow` component rather than the whole `HorizontalAvatarsSection`.  We could change the `width` of the `LazyRow` and fix it this way, but I think using the whole section is a proper possible draw area for the Popup. 

Additionally, I've added some modifications to never create an invalid range like (40, 4).

Crash: 

https://github.com/user-attachments/assets/ef24f244-933b-426c-adae-71d42a39412a

With the fix:


https://github.com/user-attachments/assets/32773b1f-8f02-4661-a805-c301f7173cf2



### Testing Steps

1. Make sure you have 1 or 2 avatars only
2. Open the QE with a horizontal layout
3. Try to open Avatar's contextual menu
4. Make sure there's no crash, and the popup is properly positioned
