### PR TITLE
Remove Alt text option from Avatar's contextual menu

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarMoreOptionsPickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarMoreOptionsPickerPopup.kt
@@ -30,14 +30,6 @@ internal fun AvatarMoreOptionsPickerPopup(
         onDismissRequest = onDismissRequest,
         popupItems = listOf(
             PickerPopupItem(
-                text = R.string.gravatar_qe_selectable_avatar_more_options_alt_text,
-                iconRes = R.drawable.gravatar_avatar_more_options_alt_text,
-                contentDescription = R.string.gravatar_qe_selectable_avatar_more_options_alt_text_content_description,
-                onClick = {
-                    onAvatarOptionClicked(AvatarOption.ALT_TEXT)
-                },
-            ),
-            PickerPopupItem(
                 text = R.string.gravatar_qe_selectable_avatar_more_options_download_image,
                 iconRes = R.drawable.gravatar_avatar_more_options_download,
                 contentDescription = R.string.gravatar_qe_selectable_avatar_more_options_download_image,

--- a/gravatar-quickeditor/src/main/res/drawable/gravatar_avatar_more_options_alt_text.xml
+++ b/gravatar-quickeditor/src/main/res/drawable/gravatar_avatar_more_options_alt_text.xml
@@ -1,6 +1,8 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:width="24dp"
     android:height="24dp"
+    tools:ignore="UnusedResources"
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="gravatar_qe_gravatar">Gravatar</string>
     <string name="gravatar_qe_selectable_avatar_content_description">Avatar Image</string>
     <string name="gravatar_qe_selectable_avatar_more_options_content_description">More Options</string>
-    <string name="gravatar_qe_selectable_avatar_more_options_alt_text">Alt Text</string>
-    <string name="gravatar_qe_selectable_avatar_more_options_alt_text_content_description">Alternative Text</string>
+    <string name="gravatar_qe_selectable_avatar_more_options_alt_text" tools:ignore="UnusedResources">Alt Text</string>
+    <string name="gravatar_qe_selectable_avatar_more_options_alt_text_content_description" tools:ignore="UnusedResources">Alternative Text</string>
     <string name="gravatar_qe_selectable_avatar_more_options_delete">Delete</string>
     <string name="gravatar_qe_selectable_avatar_more_options_delete_content_description">Delete Avatar</string>
     <string name="gravatar_qe_selectable_avatar_more_options_download_image">Download image</string>


### PR DESCRIPTION


### Description

This clears the unused option. It was added temporarily, but we're planning to make a 2.2.0 release with just the `download` 
 and `delete` option. 
 
 Should we remove the icon and string resources as well? 
 
 
<img width="373" alt="Screenshot 2024-11-29 at 14 59 47" src="https://github.com/user-attachments/assets/280e7d2c-5798-40b0-82b6-f1eca5f18a62">


### Testing Steps

Run the QE and confirm `Alt text` option is not available.
