### PR TITLE
QuickEditor: Make ColorScheme configurable via GravatarColorScheme param

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -2,6 +2,7 @@ package com.gravatar.demoapp.ui
 
 import android.content.Intent
 import android.widget.Toast
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -14,16 +15,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -55,6 +62,7 @@ import com.gravatar.demoapp.ui.components.GravatarPasswordInput
 import com.gravatar.quickeditor.GravatarQuickEditor
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
+import com.gravatar.quickeditor.ui.editor.GravatarColorScheme
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
@@ -75,12 +83,17 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     var cacheBuster: String? by remember { mutableStateOf(null) }
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val scrollState: ScrollState = rememberScrollState()
     var pickerContentLayout: AvatarPickerContentLayout by rememberSaveable(
         stateSaver = AvatarPickerContentLayoutSaver,
     ) {
         mutableStateOf(AvatarPickerContentLayout.Horizontal)
     }
+    var pickerColorScheme: GravatarColorScheme by rememberSaveable {
+        mutableStateOf(GravatarColorScheme.SYSTEM)
+    }
+
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     Box(
         modifier = Modifier
@@ -89,6 +102,7 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
     ) {
         Column(
             modifier = modifier
+                .verticalScroll(scrollState)
                 .align(Alignment.TopCenter)
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -107,28 +121,18 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                 Checkbox(checked = useToken, onCheckedChange = { useToken = it })
             }
             Row(
-                horizontalArrangement = Arrangement.Start,
                 modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                RadioButton(
-                    selected = pickerContentLayout == AvatarPickerContentLayout.Horizontal,
-                    onClick = { pickerContentLayout = AvatarPickerContentLayout.Horizontal },
+                ContentLayoutDropdown(
+                    selectedContentLayout = pickerContentLayout,
+                    onContentLayoutSelected = { pickerContentLayout = it },
+                    modifier = Modifier.weight(1f),
                 )
-                Text(
-                    text = "Horizontal",
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .clickable { pickerContentLayout = AvatarPickerContentLayout.Horizontal },
-                )
-                RadioButton(
-                    selected = pickerContentLayout == AvatarPickerContentLayout.Vertical,
-                    onClick = { pickerContentLayout = AvatarPickerContentLayout.Vertical },
-                )
-                Text(
-                    text = "Vertical",
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .clickable { pickerContentLayout = AvatarPickerContentLayout.Vertical },
+                ColorSchemeDropdown(
+                    selectedColorScheme = pickerColorScheme,
+                    onColorSchemeSelected = { pickerColorScheme = it },
+                    modifier = Modifier.weight(1f),
                 )
             }
             UpdateAvatarComposable(
@@ -195,6 +199,7 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                 gravatarQuickEditorParams = GravatarQuickEditorParams {
                     email = Email(userEmail)
                     avatarPickerContentLayout = pickerContentLayout
+                    colorScheme = pickerColorScheme
                 },
                 authenticationMethod = authenticationMethod,
                 onAvatarSelected = remember {
@@ -241,6 +246,91 @@ private fun UpdateAvatarComposable(
                 placeholder = rememberVectorPainter(Icons.Rounded.AccountCircle),
             )
             Text(text = stringResource(R.string.update_avatar_button_label))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ContentLayoutDropdown(
+    selectedContentLayout: AvatarPickerContentLayout,
+    onContentLayoutSelected: (AvatarPickerContentLayout) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val contentLayoutOptions = listOf(
+        AvatarPickerContentLayout.Horizontal,
+        AvatarPickerContentLayout.Vertical,
+    )
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        TextField(
+            readOnly = true,
+            value = selectedContentLayout.toString(),
+            onValueChange = { },
+            label = { Text("Content Layout") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.exposedDropdownSize(),
+        ) {
+            contentLayoutOptions.forEach { selectionOption ->
+                DropdownMenuItem(text = { Text(text = selectionOption.toString()) }, onClick = {
+                    onContentLayoutSelected(selectionOption)
+                    expanded = false
+                })
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ColorSchemeDropdown(
+    selectedColorScheme: GravatarColorScheme,
+    onColorSchemeSelected: (GravatarColorScheme) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val colorSchemeOptions = listOf(
+        GravatarColorScheme.LIGHT,
+        GravatarColorScheme.DARK,
+        GravatarColorScheme.SYSTEM,
+    )
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        TextField(
+            readOnly = true,
+            value = selectedColorScheme.toString(),
+            onValueChange = { },
+            label = { Text("Color Scheme") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.exposedDropdownSize(),
+        ) {
+            colorSchemeOptions.forEach { selectionOption ->
+                DropdownMenuItem(text = { Text(text = selectionOption.toString()) }, onClick = {
+                    onColorSchemeSelected(selectionOption)
+                    expanded = false
+                })
+            }
         }
     }
 }

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -62,8 +62,8 @@ import com.gravatar.demoapp.ui.components.GravatarPasswordInput
 import com.gravatar.quickeditor.GravatarQuickEditor
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
-import com.gravatar.quickeditor.ui.editor.GravatarColorScheme
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
+import com.gravatar.quickeditor.ui.editor.GravatarUiMode
 import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
 import com.gravatar.types.Email
@@ -89,8 +89,8 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
     ) {
         mutableStateOf(AvatarPickerContentLayout.Horizontal)
     }
-    var pickerColorScheme: GravatarColorScheme by rememberSaveable {
-        mutableStateOf(GravatarColorScheme.SYSTEM)
+    var pickerUiMode: GravatarUiMode by rememberSaveable {
+        mutableStateOf(GravatarUiMode.SYSTEM)
     }
 
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -129,9 +129,9 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                     onContentLayoutSelected = { pickerContentLayout = it },
                     modifier = Modifier.weight(1f),
                 )
-                ColorSchemeDropdown(
-                    selectedColorScheme = pickerColorScheme,
-                    onColorSchemeSelected = { pickerColorScheme = it },
+                UiModeDropdown(
+                    selectedUiMode = pickerUiMode,
+                    onUiModeSelected = { pickerUiMode = it },
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -199,7 +199,7 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                 gravatarQuickEditorParams = GravatarQuickEditorParams {
                     email = Email(userEmail)
                     avatarPickerContentLayout = pickerContentLayout
-                    colorScheme = pickerColorScheme
+                    uiMode = pickerUiMode
                 },
                 authenticationMethod = authenticationMethod,
                 onAvatarSelected = remember {
@@ -294,16 +294,16 @@ private fun ContentLayoutDropdown(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ColorSchemeDropdown(
-    selectedColorScheme: GravatarColorScheme,
-    onColorSchemeSelected: (GravatarColorScheme) -> Unit,
+private fun UiModeDropdown(
+    selectedUiMode: GravatarUiMode,
+    onUiModeSelected: (GravatarUiMode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val colorSchemeOptions = listOf(
-        GravatarColorScheme.LIGHT,
-        GravatarColorScheme.DARK,
-        GravatarColorScheme.SYSTEM,
+    val uiModeOptions = listOf(
+        GravatarUiMode.LIGHT,
+        GravatarUiMode.DARK,
+        GravatarUiMode.SYSTEM,
     )
 
     ExposedDropdownMenuBox(
@@ -313,9 +313,9 @@ private fun ColorSchemeDropdown(
     ) {
         TextField(
             readOnly = true,
-            value = selectedColorScheme.toString(),
+            value = selectedUiMode.toString(),
             onValueChange = { },
-            label = { Text("Color Scheme") },
+            label = { Text("UI mode") },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier
                 .menuAnchor(),
@@ -325,9 +325,9 @@ private fun ColorSchemeDropdown(
             onDismissRequest = { expanded = false },
             modifier = Modifier.exposedDropdownSize(),
         ) {
-            colorSchemeOptions.forEach { selectionOption ->
+            uiModeOptions.forEach { selectionOption ->
                 DropdownMenuItem(text = { Text(text = selectionOption.toString()) }, onClick = {
-                    onColorSchemeSelected(selectionOption)
+                    onUiModeSelected(selectionOption)
                     expanded = false
                 })
             }

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -329,6 +329,15 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/gravatar/quickeditor/ui/editor/GravatarColorScheme : java/lang/Enum {
+	public static final field DARK Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
+	public static final field LIGHT Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
+	public static final field SYSTEM Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
+	public static fun values ()[Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
+}
+
 public abstract class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorDismissReason {
 	public static final field $stable I
 }
@@ -360,10 +369,11 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorDismiss
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public synthetic fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
+	public final fun getColorScheme ()Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -375,9 +385,12 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$
 	public fun <init> ()V
 	public final fun build ()Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
+	public final fun getColorScheme ()Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
 	public final fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)V
+	public final fun setColorScheme (Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
+	public final synthetic fun setColorScheme (Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;)V
 	public final fun setEmail (Lcom/gravatar/types/Email;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setEmail (Lcom/gravatar/types/Email;)V
 }

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -329,15 +329,6 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/gravatar/quickeditor/ui/editor/GravatarColorScheme : java/lang/Enum {
-	public static final field DARK Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
-	public static final field LIGHT Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
-	public static final field SYSTEM Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
-	public static fun values ()[Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
-}
-
 public abstract class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorDismissReason {
 	public static final field $stable I
 }
@@ -369,12 +360,12 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorDismiss
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public synthetic fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
-	public final fun getColorScheme ()Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
+	public final fun getUiMode ()Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -385,14 +376,14 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$
 	public fun <init> ()V
 	public final fun build ()Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
-	public final fun getColorScheme ()Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
+	public final fun getUiMode ()Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
 	public final fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)V
-	public final fun setColorScheme (Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
-	public final synthetic fun setColorScheme (Lcom/gravatar/quickeditor/ui/editor/GravatarColorScheme;)V
 	public final fun setEmail (Lcom/gravatar/types/Email;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setEmail (Lcom/gravatar/types/Email;)V
+	public final fun setUiMode (Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
+	public final synthetic fun setUiMode (Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Creator : android/os/Parcelable$Creator {
@@ -405,6 +396,15 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$
 
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParamsKt {
 	public static final synthetic fun GravatarQuickEditorParams (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
+}
+
+public final class com/gravatar/quickeditor/ui/editor/GravatarUiMode : java/lang/Enum {
+	public static final field DARK Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
+	public static final field LIGHT Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
+	public static final field SYSTEM Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
+	public static fun values ()[Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
 }
 
 public final class com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheetKt {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarColorScheme.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarColorScheme.kt
@@ -1,0 +1,10 @@
+package com.gravatar.quickeditor.ui.editor
+
+/**
+ * The color scheme to be used in the Quick Editor.
+ */
+public enum class GravatarColorScheme {
+    LIGHT,
+    DARK,
+    SYSTEM,
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
@@ -10,21 +10,27 @@ import java.util.Objects
  *
  * @property email The email of the user
  * @property avatarPickerContentLayout The layout direction used in the Avatar Picker.
+ * @property colorScheme The color scheme to be used in the Quick Editor.
  */
 @Parcelize
 public class GravatarQuickEditorParams private constructor(
     public val email: Email,
     public val avatarPickerContentLayout: AvatarPickerContentLayout,
+    public val colorScheme: GravatarColorScheme = GravatarColorScheme.SYSTEM,
 ) : Parcelable {
-    override fun toString(): String =
-        "GravatarQuickEditorParams(email='$email', avatarPickerContentLayout=$avatarPickerContentLayout)"
+    override fun toString(): String = "GravatarQuickEditorParams(" +
+        "email='$email', " +
+        "avatarPickerContentLayout=$avatarPickerContentLayout, " +
+        "colorScheme=$colorScheme" +
+        ")"
 
     override fun hashCode(): Int = Objects.hash(email, avatarPickerContentLayout)
 
     override fun equals(other: Any?): Boolean {
         return other is GravatarQuickEditorParams &&
             email == other.email &&
-            avatarPickerContentLayout == other.avatarPickerContentLayout
+            avatarPickerContentLayout == other.avatarPickerContentLayout &&
+            colorScheme == other.colorScheme
     }
 
     /**
@@ -44,6 +50,12 @@ public class GravatarQuickEditorParams private constructor(
         public var avatarPickerContentLayout: AvatarPickerContentLayout = AvatarPickerContentLayout.Horizontal
 
         /**
+         * The color scheme to be used in the Quick Editor
+         */
+        @set:JvmSynthetic // Hide 'void' setter from Java
+        public var colorScheme: GravatarColorScheme = GravatarColorScheme.SYSTEM
+
+        /**
          * Sets the content layout direction used in the Avatar Picker
          */
         public fun setAvatarPickerContentLayout(avatarPickerContentLayout: AvatarPickerContentLayout): Builder =
@@ -55,11 +67,17 @@ public class GravatarQuickEditorParams private constructor(
         public fun setEmail(email: Email): Builder = apply { this.email = email }
 
         /**
+         * Sets the color scheme to be used in the Quick Editor
+         */
+        public fun setColorScheme(colorScheme: GravatarColorScheme): Builder = apply { this.colorScheme = colorScheme }
+
+        /**
          * Builds the GravatarQuickEditorParams object
          */
         public fun build(): GravatarQuickEditorParams = GravatarQuickEditorParams(
             email!!,
             avatarPickerContentLayout,
+            colorScheme,
         )
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
@@ -10,18 +10,18 @@ import java.util.Objects
  *
  * @property email The email of the user
  * @property avatarPickerContentLayout The layout direction used in the Avatar Picker.
- * @property colorScheme The color scheme to be used in the Quick Editor.
+ * @property uiMode The UI mode to be used in the Quick Editor.
  */
 @Parcelize
 public class GravatarQuickEditorParams private constructor(
     public val email: Email,
     public val avatarPickerContentLayout: AvatarPickerContentLayout,
-    public val colorScheme: GravatarColorScheme = GravatarColorScheme.SYSTEM,
+    public val uiMode: GravatarUiMode = GravatarUiMode.SYSTEM,
 ) : Parcelable {
     override fun toString(): String = "GravatarQuickEditorParams(" +
         "email='$email', " +
         "avatarPickerContentLayout=$avatarPickerContentLayout, " +
-        "colorScheme=$colorScheme" +
+        "uiMode=$uiMode" +
         ")"
 
     override fun hashCode(): Int = Objects.hash(email, avatarPickerContentLayout)
@@ -30,7 +30,7 @@ public class GravatarQuickEditorParams private constructor(
         return other is GravatarQuickEditorParams &&
             email == other.email &&
             avatarPickerContentLayout == other.avatarPickerContentLayout &&
-            colorScheme == other.colorScheme
+            uiMode == other.uiMode
     }
 
     /**
@@ -50,10 +50,10 @@ public class GravatarQuickEditorParams private constructor(
         public var avatarPickerContentLayout: AvatarPickerContentLayout = AvatarPickerContentLayout.Horizontal
 
         /**
-         * The color scheme to be used in the Quick Editor
+         * The UI mode to be used in the Quick Editor
          */
         @set:JvmSynthetic // Hide 'void' setter from Java
-        public var colorScheme: GravatarColorScheme = GravatarColorScheme.SYSTEM
+        public var uiMode: GravatarUiMode = GravatarUiMode.SYSTEM
 
         /**
          * Sets the content layout direction used in the Avatar Picker
@@ -67,9 +67,9 @@ public class GravatarQuickEditorParams private constructor(
         public fun setEmail(email: Email): Builder = apply { this.email = email }
 
         /**
-         * Sets the color scheme to be used in the Quick Editor
+         * Sets the UI mode to be used in the Quick Editor
          */
-        public fun setColorScheme(colorScheme: GravatarColorScheme): Builder = apply { this.colorScheme = colorScheme }
+        public fun setUiMode(uiMode: GravatarUiMode): Builder = apply { this.uiMode = uiMode }
 
         /**
          * Builds the GravatarQuickEditorParams object
@@ -77,7 +77,7 @@ public class GravatarQuickEditorParams private constructor(
         public fun build(): GravatarQuickEditorParams = GravatarQuickEditorParams(
             email!!,
             avatarPickerContentLayout,
-            colorScheme,
+            uiMode,
         )
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarUiMode.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarUiMode.kt
@@ -3,7 +3,7 @@ package com.gravatar.quickeditor.ui.editor
 /**
  * The color scheme to be used in the Quick Editor.
  */
-public enum class GravatarColorScheme {
+public enum class GravatarUiMode {
     LIGHT,
     DARK,
     SYSTEM,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.gravatar.quickeditor.ui.editor.bottomsheet
 
+import android.content.res.Configuration
 import android.graphics.Color
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -25,6 +26,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowInsetsControllerCompat
@@ -43,6 +45,7 @@ import com.gravatar.quickeditor.ui.components.QEDragHandle
 import com.gravatar.quickeditor.ui.components.QETopBar
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
+import com.gravatar.quickeditor.ui.editor.GravatarColorScheme
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorPage
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
@@ -93,6 +96,7 @@ internal fun GravatarQuickEditorBottomSheet(
         GravatarModalBottomSheet(
             onDismiss = onDismiss,
             modalBottomSheetState = modalBottomSheetState,
+            colorScheme = gravatarQuickEditorParams.colorScheme,
         ) {
             when (authenticationMethod) {
                 is AuthenticationMethod.Bearer -> {
@@ -120,6 +124,7 @@ internal fun GravatarQuickEditorBottomSheet(
 @Composable
 private fun GravatarModalBottomSheet(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
+    colorScheme: GravatarColorScheme,
     modalBottomSheetState: ModalBottomSheetState,
     content: @Composable () -> Unit,
 ) {
@@ -132,53 +137,74 @@ private fun GravatarModalBottomSheet(
         }
     }
 
-    GravatarTheme {
-        ModalBottomSheet(
-            state = modalBottomSheetState,
-        ) {
-            Scrim(
-                modifier = Modifier.clickable { modalBottomSheetState.currentDetent = Hidden },
-                scrimColor = MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f),
-            )
-            Sheet(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
-                    .background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
-                    .widthIn(max = 640.dp)
-                    .fillMaxWidth()
-                    .padding(
-                        WindowInsets.navigationBars
-                            .only(WindowInsetsSides.Vertical)
-                            .asPaddingValues(),
-                    ),
+    val configuration = Configuration(LocalConfiguration.current).apply {
+        uiMode = when (colorScheme) {
+            GravatarColorScheme.LIGHT -> Configuration.UI_MODE_NIGHT_NO
+            GravatarColorScheme.DARK -> Configuration.UI_MODE_NIGHT_YES
+            GravatarColorScheme.SYSTEM -> uiMode
+        }
+    }
+    CompositionLocalProvider(
+        LocalConfiguration provides configuration,
+    ) {
+        GravatarTheme {
+            ModalBottomSheet(
+                state = modalBottomSheetState,
             ) {
-                val window = LocalModalWindow.current
-                val isDarkTheme = isSystemInDarkTheme()
-                LaunchedEffect(Unit) {
-                    window.navigationBarColor = Color.TRANSPARENT
-                    WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
-                        !isDarkTheme
-                }
-                Surface(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    tonalElevation = 1.dp,
+                // Modal content must be taking the uiMode from Activity and doesn't respect
+                // the above set CompositionLocalProvider
+                CompositionLocalProvider(
+                    LocalConfiguration provides configuration,
                 ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
+                    Scrim(
+                        modifier = Modifier.clickable { modalBottomSheetState.currentDetent = Hidden },
+                        scrimColor = MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f),
+                    )
+                    Sheet(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+                            .background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
+                            .widthIn(max = 640.dp)
+                            .fillMaxWidth()
+                            .padding(
+                                WindowInsets.navigationBars
+                                    .only(WindowInsetsSides.Vertical)
+                                    .asPaddingValues(),
+                            ),
                     ) {
-                        QEDragHandle()
-                        QETopBar(
-                            onDoneClick = {
-                                coroutineScope.launch {
-                                    modalBottomSheetState.currentDetent = Hidden
+                        val window = LocalModalWindow.current
+                        val isDarkTheme = isSystemInDarkTheme()
+                        LaunchedEffect(Unit) {
+                            window.navigationBarColor = Color.TRANSPARENT
+                            WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
+                                !isDarkTheme
+                        }
+                        Surface(
+                            modifier = Modifier
+                                .fillMaxWidth(),
+                            tonalElevation = 1.dp,
+                        ) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            ) {
+                                QEDragHandle()
+                                CompositionLocalProvider(
+                                    LocalConfiguration provides configuration,
+                                ) {
+                                    QETopBar(
+                                        onDoneClick = {
+                                            coroutineScope.launch {
+                                                modalBottomSheetState.currentDetent = Hidden
+                                            }
+                                        },
+                                        onGravatarIconClick = {
+                                            uriHandler.openUri(GravatarConstants.GRAVATAR_SIGN_IN_URL)
+                                        },
+                                    )
                                 }
-                            },
-                            onGravatarIconClick = {
-                                uriHandler.openUri(GravatarConstants.GRAVATAR_SIGN_IN_URL)
-                            },
-                        )
-                        content()
+                                content()
+                            }
+                        }
                     }
                 }
             }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -45,10 +45,10 @@ import com.gravatar.quickeditor.ui.components.QEDragHandle
 import com.gravatar.quickeditor.ui.components.QETopBar
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
-import com.gravatar.quickeditor.ui.editor.GravatarColorScheme
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorPage
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
+import com.gravatar.quickeditor.ui.editor.GravatarUiMode
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.LocalGravatarTheme
 import com.gravatar.ui.mainGravatarTheme
@@ -96,7 +96,7 @@ internal fun GravatarQuickEditorBottomSheet(
         GravatarModalBottomSheet(
             onDismiss = onDismiss,
             modalBottomSheetState = modalBottomSheetState,
-            colorScheme = gravatarQuickEditorParams.colorScheme,
+            colorScheme = gravatarQuickEditorParams.uiMode,
         ) {
             when (authenticationMethod) {
                 is AuthenticationMethod.Bearer -> {
@@ -124,7 +124,7 @@ internal fun GravatarQuickEditorBottomSheet(
 @Composable
 private fun GravatarModalBottomSheet(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
-    colorScheme: GravatarColorScheme,
+    colorScheme: GravatarUiMode,
     modalBottomSheetState: ModalBottomSheetState,
     content: @Composable () -> Unit,
 ) {
@@ -139,9 +139,9 @@ private fun GravatarModalBottomSheet(
 
     val configuration = Configuration(LocalConfiguration.current).apply {
         uiMode = when (colorScheme) {
-            GravatarColorScheme.LIGHT -> Configuration.UI_MODE_NIGHT_NO
-            GravatarColorScheme.DARK -> Configuration.UI_MODE_NIGHT_YES
-            GravatarColorScheme.SYSTEM -> uiMode
+            GravatarUiMode.LIGHT -> Configuration.UI_MODE_NIGHT_NO
+            GravatarUiMode.DARK -> Configuration.UI_MODE_NIGHT_YES
+            GravatarUiMode.SYSTEM -> uiMode
         }
     }
     CompositionLocalProvider(
@@ -188,20 +188,16 @@ private fun GravatarModalBottomSheet(
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             ) {
                                 QEDragHandle()
-                                CompositionLocalProvider(
-                                    LocalConfiguration provides configuration,
-                                ) {
-                                    QETopBar(
-                                        onDoneClick = {
-                                            coroutineScope.launch {
-                                                modalBottomSheetState.currentDetent = Hidden
-                                            }
-                                        },
-                                        onGravatarIconClick = {
-                                            uriHandler.openUri(GravatarConstants.GRAVATAR_SIGN_IN_URL)
-                                        },
-                                    )
-                                }
+                                QETopBar(
+                                    onDoneClick = {
+                                        coroutineScope.launch {
+                                            modalBottomSheetState.currentDetent = Hidden
+                                        }
+                                    },
+                                    onGravatarIconClick = {
+                                        uriHandler.openUri(GravatarConstants.GRAVATAR_SIGN_IN_URL)
+                                    },
+                                )
                                 content()
                             }
                         }


### PR DESCRIPTION
Closes #473 

### Description

This PR adds an additional param `GravatarColorScheme` that allows forcing Light or Dark color schemes within the Quick Editor. 

The passed param is used to set a proper `Configuration.uiMode` that's provided via `CompositionLocalProvider`. 
Thanks @hamorillo for the tip.


https://github.com/user-attachments/assets/f1672fe3-88aa-443f-b9c7-13a402980f5d


### Testing Steps

1. Start the demo app
2. Select a different ColorScheme than is currently set system-wise
3. Launch the QE
4. Confirm the color scheme is correct
5. Repeat with different color scheme
