### PR TITLE
Switch serialization library from `moshi-reflection` to `moshi-codegen`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     // Roborazzi
     alias(libs.plugins.roborazzi) apply false
     alias(libs.plugins.binary.compatibility.validator)
+    alias(libs.plugins.ksp) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ dokka = "1.9.20"
 junit = "4.13.2"
 kotlin = "1.9.25"
 kotlinCoroutines = "1.7.3"
+ksp = "1.9.25-1.0.20"
 ktlint = "12.1.0"
 ktx = "1.13.1"
 material = "1.12.0"
@@ -68,7 +69,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
-moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
+moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
@@ -89,6 +90,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi" }
 parcelize = { id = "kotlin-parcelize" }
 publish-to-s3 = { id = "com.automattic.android.publish-to-s3", version.ref = "publishToS3" }

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -180,7 +180,6 @@ public final class com/gravatar/extensions/UserProfileExtensionsKt {
 }
 
 public final class com/gravatar/restapi/models/AssociatedResponse {
-	public synthetic fun <init> (ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAssociated ()Z
 	public fun hashCode ()I
@@ -195,12 +194,20 @@ public final class com/gravatar/restapi/models/AssociatedResponse$Builder {
 	public final synthetic fun setAssociated (Ljava/lang/Boolean;)V
 }
 
+public final class com/gravatar/restapi/models/AssociatedResponseJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/AssociatedResponse;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/AssociatedResponse;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/AssociatedResponseKt {
 	public static final synthetic fun AssociatedResponse (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/AssociatedResponse;
 }
 
 public final class com/gravatar/restapi/models/Avatar {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/net/URI;Lcom/gravatar/restapi/models/Avatar$Rating;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAltText ()Ljava/lang/String;
 	public final fun getImageId ()Ljava/lang/String;
@@ -246,12 +253,20 @@ public final class com/gravatar/restapi/models/Avatar$Rating : java/lang/Enum {
 	public static fun values ()[Lcom/gravatar/restapi/models/Avatar$Rating;
 }
 
+public final class com/gravatar/restapi/models/AvatarJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/Avatar;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/Avatar;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/AvatarKt {
 	public static final synthetic fun Avatar (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/Avatar;
 }
 
 public final class com/gravatar/restapi/models/CryptoWalletAddress {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Ljava/lang/String;
 	public final fun getLabel ()Ljava/lang/String;
@@ -270,12 +285,20 @@ public final class com/gravatar/restapi/models/CryptoWalletAddress$Builder {
 	public final synthetic fun setLabel (Ljava/lang/String;)V
 }
 
+public final class com/gravatar/restapi/models/CryptoWalletAddressJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/CryptoWalletAddress;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/CryptoWalletAddress;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/CryptoWalletAddressKt {
 	public static final synthetic fun CryptoWalletAddress (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/CryptoWalletAddress;
 }
 
 public final class com/gravatar/restapi/models/Error {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getError ()Ljava/lang/String;
@@ -294,12 +317,20 @@ public final class com/gravatar/restapi/models/Error$Builder {
 	public final synthetic fun setError (Ljava/lang/String;)V
 }
 
+public final class com/gravatar/restapi/models/ErrorJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/Error;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/Error;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/ErrorKt {
 	public static final synthetic fun Error (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/Error;
 }
 
 public final class com/gravatar/restapi/models/GalleryImage {
-	public synthetic fun <init> (Ljava/net/URI;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAltText ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/net/URI;
@@ -318,12 +349,20 @@ public final class com/gravatar/restapi/models/GalleryImage$Builder {
 	public final synthetic fun setUrl (Ljava/net/URI;)V
 }
 
+public final class com/gravatar/restapi/models/GalleryImageJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/GalleryImage;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/GalleryImage;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/GalleryImageKt {
 	public static final synthetic fun GalleryImage (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/GalleryImage;
 }
 
 public final class com/gravatar/restapi/models/Interest {
-	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getId ()I
 	public final fun getName ()Ljava/lang/String;
@@ -342,12 +381,20 @@ public final class com/gravatar/restapi/models/Interest$Builder {
 	public final synthetic fun setName (Ljava/lang/String;)V
 }
 
+public final class com/gravatar/restapi/models/InterestJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/Interest;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/Interest;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/InterestKt {
 	public static final synthetic fun Interest (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/Interest;
 }
 
 public final class com/gravatar/restapi/models/Language {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
@@ -374,12 +421,20 @@ public final class com/gravatar/restapi/models/Language$Builder {
 	public final synthetic fun setPrimary (Ljava/lang/Boolean;)V
 }
 
+public final class com/gravatar/restapi/models/LanguageJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/Language;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/Language;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/LanguageKt {
 	public static final synthetic fun Language (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/Language;
 }
 
 public final class com/gravatar/restapi/models/Link {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/net/URI;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/net/URI;
@@ -398,12 +453,20 @@ public final class com/gravatar/restapi/models/Link$Builder {
 	public final synthetic fun setUrl (Ljava/net/URI;)V
 }
 
+public final class com/gravatar/restapi/models/LinkJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/Link;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/Link;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/LinkKt {
 	public static final synthetic fun Link (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/Link;
 }
 
 public final class com/gravatar/restapi/models/Profile {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lcom/gravatar/restapi/models/ProfilePayments;Lcom/gravatar/restapi/models/ProfileContactInfo;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarAltText ()Ljava/lang/String;
 	public final fun getAvatarUrl ()Ljava/net/URI;
@@ -523,7 +586,7 @@ public final class com/gravatar/restapi/models/Profile$Builder {
 }
 
 public final class com/gravatar/restapi/models/ProfileContactInfo {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCalendar ()Ljava/net/URI;
 	public final fun getCellPhone ()Ljava/lang/String;
@@ -558,8 +621,26 @@ public final class com/gravatar/restapi/models/ProfileContactInfo$Builder {
 	public final synthetic fun setWorkPhone (Ljava/lang/String;)V
 }
 
+public final class com/gravatar/restapi/models/ProfileContactInfoJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/ProfileContactInfo;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/ProfileContactInfo;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/ProfileContactInfoKt {
 	public static final synthetic fun ProfileContactInfo (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/ProfileContactInfo;
+}
+
+public final class com/gravatar/restapi/models/ProfileJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/Profile;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/Profile;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/gravatar/restapi/models/ProfileKt {
@@ -567,7 +648,6 @@ public final class com/gravatar/restapi/models/ProfileKt {
 }
 
 public final class com/gravatar/restapi/models/ProfilePayments {
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCryptoWallets ()Ljava/util/List;
 	public final fun getLinks ()Ljava/util/List;
@@ -584,6 +664,15 @@ public final class com/gravatar/restapi/models/ProfilePayments$Builder {
 	public final synthetic fun setCryptoWallets (Ljava/util/List;)V
 	public final fun setLinks (Ljava/util/List;)Lcom/gravatar/restapi/models/ProfilePayments$Builder;
 	public final synthetic fun setLinks (Ljava/util/List;)V
+}
+
+public final class com/gravatar/restapi/models/ProfilePaymentsJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/ProfilePayments;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/ProfilePayments;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/gravatar/restapi/models/ProfilePaymentsKt {
@@ -609,7 +698,6 @@ public final class com/gravatar/restapi/models/Rating$Companion {
 }
 
 public final class com/gravatar/restapi/models/SetEmailAvatarRequest {
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmailHash ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -624,12 +712,21 @@ public final class com/gravatar/restapi/models/SetEmailAvatarRequest$Builder {
 	public final synthetic fun setEmailHash (Ljava/lang/String;)V
 }
 
+public final class com/gravatar/restapi/models/SetEmailAvatarRequestJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/SetEmailAvatarRequest;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/SetEmailAvatarRequest;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/SetEmailAvatarRequestKt {
 	public static final synthetic fun SetEmailAvatarRequest (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/SetEmailAvatarRequest;
 }
 
 public final class com/gravatar/restapi/models/UpdateAvatarRequest {
-	public synthetic fun <init> (Lcom/gravatar/restapi/models/Rating;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAltText ()Ljava/lang/String;
 	public final fun getRating ()Lcom/gravatar/restapi/models/Rating;
@@ -648,12 +745,20 @@ public final class com/gravatar/restapi/models/UpdateAvatarRequest$Builder {
 	public final synthetic fun setRating (Lcom/gravatar/restapi/models/Rating;)V
 }
 
+public final class com/gravatar/restapi/models/UpdateAvatarRequestJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/UpdateAvatarRequest;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/UpdateAvatarRequest;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/restapi/models/UpdateAvatarRequestKt {
 	public static final synthetic fun UpdateAvatarRequest (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/restapi/models/UpdateAvatarRequest;
 }
 
 public final class com/gravatar/restapi/models/VerifiedAccount {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/net/URI;Ljava/net/URI;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getServiceIcon ()Ljava/net/URI;
 	public final fun getServiceLabel ()Ljava/lang/String;
@@ -682,6 +787,15 @@ public final class com/gravatar/restapi/models/VerifiedAccount$Builder {
 	public final synthetic fun setServiceType (Ljava/lang/String;)V
 	public final fun setUrl (Ljava/net/URI;)Lcom/gravatar/restapi/models/VerifiedAccount$Builder;
 	public final synthetic fun setUrl (Ljava/net/URI;)V
+}
+
+public final class com/gravatar/restapi/models/VerifiedAccountJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lcom/gravatar/restapi/models/VerifiedAccount;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lcom/gravatar/restapi/models/VerifiedAccount;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/gravatar/restapi/models/VerifiedAccountKt {

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.publish.to.s3)
     alias(libs.plugins.openapi.generator)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.ksp)
 }
 
 val sdkVersion = providers.exec {
@@ -73,10 +74,10 @@ android {
 
 dependencies {
     api(libs.okhttp)
-    implementation(libs.moshi.kotlin)
     implementation(libs.retrofit)
     implementation(libs.retrofit.moshi.converter)
     implementation(libs.kotlinx.coroutines)
+    ksp(libs.moshi.kotlin.codegen)
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk.android)
@@ -115,6 +116,7 @@ openApiGenerate {
             "groupId" to "com.gravatar",
             "packageName" to "com.gravatar.restapi",
             "useCoroutines" to "true",
+            "moshiCodeGen" to "true",
         ),
     )
     importMappings.set(

--- a/gravatar/openapi/templates/data_class.mustache
+++ b/gravatar/openapi/templates/data_class.mustache
@@ -61,7 +61,7 @@ import java.util.Objects
 @Deprecated(message = "This schema is deprecated.")
 {{/isDeprecated}}
 {{>additionalModelTypeAnnotations}}
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{#discriminator}}interface{{/discriminator}}{{^discriminator}}{{^nonPublicApi}}public {{/nonPublicApi}}class{{/discriminator}} {{classname}}{{^discriminator}} private constructor(
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{#discriminator}}interface{{/discriminator}}{{^discriminator}}{{^nonPublicApi}}public {{/nonPublicApi}}class{{/discriminator}} {{classname}}{{^discriminator}} internal constructor(
 
 {{#allVars}}
 {{#required}}{{>data_class_req_var}}{{/required}}{{^required}}{{>data_class_opt_var}}{{/required}}{{^-last}},{{/-last}}

--- a/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
+++ b/gravatar/src/main/java/com/gravatar/di/container/GravatarSdkContainer.kt
@@ -7,7 +7,6 @@ import com.gravatar.services.interceptors.AuthenticationInterceptor
 import com.gravatar.services.interceptors.AvatarUploadTimeoutInterceptor
 import com.gravatar.services.interceptors.SdkVersionInterceptor
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
@@ -22,7 +21,6 @@ internal class GravatarSdkContainer private constructor() {
     }
 
     internal val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
         .add(URIJsonAdapter())
         .build()
 

--- a/gravatar/src/main/java/com/gravatar/restapi/models/AssociatedResponse.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/AssociatedResponse.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -15,8 +16,8 @@ import java.util.Objects
  *
  * @param associated Whether the entity is associated with the account.
  */
-
-public class AssociatedResponse private constructor(
+@JsonClass(generateAdapter = true)
+public class AssociatedResponse internal constructor(
     // Whether the entity is associated with the account.
     @Json(name = "associated")
     public val associated: kotlin.Boolean,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Avatar.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Avatar.kt
@@ -21,8 +21,8 @@ import java.util.Objects
  * @param updatedDate Date and time when the image was last updated.
  * @param selected Whether the image is currently selected as the provided selected email's avatar.
  */
-
-public class Avatar private constructor(
+@JsonClass(generateAdapter = true)
+public class Avatar internal constructor(
     // Unique identifier for the image.
     @Json(name = "image_id")
     public val imageId: kotlin.String,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/CryptoWalletAddress.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/CryptoWalletAddress.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -16,8 +17,8 @@ import java.util.Objects
  * @param label The label for the crypto currency.
  * @param address The wallet address for the crypto currency.
  */
-
-public class CryptoWalletAddress private constructor(
+@JsonClass(generateAdapter = true)
+public class CryptoWalletAddress internal constructor(
     // The label for the crypto currency.
     @Json(name = "label")
     public val label: kotlin.String,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Error.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Error.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -16,8 +17,8 @@ import java.util.Objects
  * @param error The error message
  * @param code The error code for the error message
  */
-
-public class Error private constructor(
+@JsonClass(generateAdapter = true)
+public class Error internal constructor(
     // The error message
     @Json(name = "error")
     public val error: kotlin.String,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/GalleryImage.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/GalleryImage.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -16,8 +17,8 @@ import java.util.Objects
  * @param url The URL to the image.
  * @param altText The image alt text.
  */
-
-public class GalleryImage private constructor(
+@JsonClass(generateAdapter = true)
+public class GalleryImage internal constructor(
     // The URL to the image.
     @Json(name = "url")
     public val url: java.net.URI,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Interest.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Interest.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -16,8 +17,8 @@ import java.util.Objects
  * @param id The unique identifier for the interest.
  * @param name The name of the interest.
  */
-
-public class Interest private constructor(
+@JsonClass(generateAdapter = true)
+public class Interest internal constructor(
     // The unique identifier for the interest.
     @Json(name = "id")
     public val id: kotlin.Int,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Language.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Language.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -18,8 +19,8 @@ import java.util.Objects
  * @param isPrimary Whether the language is the user's primary language.
  * @param order The order of the language in the user's profile.
  */
-
-public class Language private constructor(
+@JsonClass(generateAdapter = true)
+public class Language internal constructor(
     // The language code.
     @Json(name = "code")
     public val code: kotlin.String,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Link.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Link.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -16,8 +17,8 @@ import java.util.Objects
  * @param label The label for the link.
  * @param url The URL to the link.
  */
-
-public class Link private constructor(
+@JsonClass(generateAdapter = true)
+public class Link internal constructor(
     // The label for the link.
     @Json(name = "label")
     public val label: kotlin.String,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/Profile.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/Profile.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -41,8 +42,8 @@ import java.util.Objects
  * @param lastProfileEdit The date and time (UTC) the user last edited their profile. This is only provided in authenticated API requests.
  * @param registrationDate The date the user registered their account. This is only provided in authenticated API requests.
  */
-
-public class Profile private constructor(
+@JsonClass(generateAdapter = true)
+public class Profile internal constructor(
     // The SHA256 hash of the user's primary email address.
     @Json(name = "hash")
     public val hash: kotlin.String,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/ProfileContactInfo.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/ProfileContactInfo.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -20,8 +21,8 @@ import java.util.Objects
  * @param contactForm The URL to the user's contact form.
  * @param calendar The URL to the user's calendar.
  */
-
-public class ProfileContactInfo private constructor(
+@JsonClass(generateAdapter = true)
+public class ProfileContactInfo internal constructor(
     // The user's home phone number.
     @Json(name = "home_phone")
     public val homePhone: kotlin.String? = null,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/ProfilePayments.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/ProfilePayments.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -16,8 +17,8 @@ import java.util.Objects
  * @param links A list of payment URLs the user has added to their profile.
  * @param cryptoWallets A list of crypto currencies the user accepts.
  */
-
-public class ProfilePayments private constructor(
+@JsonClass(generateAdapter = true)
+public class ProfilePayments internal constructor(
     // A list of payment URLs the user has added to their profile.
     @Json(name = "links")
     public val links: kotlin.collections.List<Link>,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/SetEmailAvatarRequest.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/SetEmailAvatarRequest.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -15,8 +16,8 @@ import java.util.Objects
  *
  * @param emailHash The email SHA256 hash to set the avatar for.
  */
-
-public class SetEmailAvatarRequest private constructor(
+@JsonClass(generateAdapter = true)
+public class SetEmailAvatarRequest internal constructor(
     // The email SHA256 hash to set the avatar for.
     @Json(name = "email_hash")
     public val emailHash: kotlin.String,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/UpdateAvatarRequest.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/UpdateAvatarRequest.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -16,8 +17,8 @@ import java.util.Objects
  * @param rating Rating associated with the image.
  * @param altText Alternative text description of the image.
  */
-
-public class UpdateAvatarRequest private constructor(
+@JsonClass(generateAdapter = true)
+public class UpdateAvatarRequest internal constructor(
     // Rating associated with the image.
     @Json(name = "rating")
     public val rating: Rating? = null,

--- a/gravatar/src/main/java/com/gravatar/restapi/models/VerifiedAccount.kt
+++ b/gravatar/src/main/java/com/gravatar/restapi/models/VerifiedAccount.kt
@@ -8,6 +8,7 @@
 package com.gravatar.restapi.models
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Objects
 
 /**
@@ -19,8 +20,8 @@ import java.util.Objects
  * @param url The URL to the user's profile on the service.
  * @param isHidden Whether the verified account is hidden from the user's profile.
  */
-
-public class VerifiedAccount private constructor(
+@JsonClass(generateAdapter = true)
+public class VerifiedAccount internal constructor(
     // The type of the service.
     @Json(name = "service_type")
     public val serviceType: kotlin.String,

--- a/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
+++ b/gravatar/src/test/java/com/gravatar/services/ErrorTypeTest.kt
@@ -8,7 +8,6 @@ import com.gravatar.HttpResponseCode.INVALID_REQUEST
 import com.gravatar.HttpResponseCode.SERVER_ERRORS
 import com.gravatar.restapi.models.Error
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
@@ -19,7 +18,6 @@ import java.net.UnknownHostException
 
 class ErrorTypeTest {
     private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
         .build()
 
     private val errorBody = """


### PR DESCRIPTION
Closes #480

### Description

Our SDK uses [Moshi](https://href.li/?https://github.com/square/moshi) for serialization/deserialization duties. The problem is that we were using the [reflection](https://href.li/?https://github.com/square/moshi?tab=readme-ov-file#reflection) version of Moshi which, as the documentation mention:

> The reflection adapter transitively depends on the kotlin-reflect library which is a 2.5 MiB .jar file.

That makes the final APK notably increase its size just by adding our library as a dependency. 

Moshi documentation also specifies:

> prefer reflection to convert both private and protected properties

As we don't need that, we can switch the [codegen](https://href.li/?https://github.com/square/moshi?tab=readme-ov-file#codegen) version and remove the size increase in the final APK. Also, Moshi documentation says:

> Prefer codegen for better performance and to avoid the kotlin-reflect dependency

### Testing Steps

Everything should work exactly as before.

- Smoke test all tabs of the `demo-app`. 
