### PR TITLE
QuickEditor: Remove delay before notifying the avatar change

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -20,7 +20,6 @@ import com.gravatar.services.ProfileService
 import com.gravatar.types.Email
 import com.gravatar.ui.components.ComponentState
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -38,10 +37,6 @@ internal class AvatarPickerViewModel(
     private val imageDownloader: ImageDownloader,
     private val fileUtils: FileUtils,
 ) : ViewModel() {
-    private companion object {
-        const val AVATAR_SWITCH_DELAY = 800L
-    }
-
     private val _uiState =
         MutableStateFlow(AvatarPickerUiState(email = email, avatarPickerContentLayout = avatarPickerContentLayout))
     val uiState: StateFlow<AvatarPickerUiState> = _uiState.asStateFlow()
@@ -140,9 +135,6 @@ internal class AvatarPickerViewModel(
                 }
                 when (avatarRepository.selectAvatar(email, avatarId)) {
                     is GravatarResult.Success -> {
-                        // Delay to wait until the server has updated the selected avatar before updating the UI
-                        // Hopefully, we can remove this delay soon
-                        delay(AVATAR_SWITCH_DELAY)
                         _uiState.update { currentState ->
                             currentState.copy(
                                 emailAvatars = currentState.emailAvatars?.copy(selectedAvatarId = avatarId),


### PR DESCRIPTION
Closes #474

### Description

The backend has been updated, and we don't need to wait any longer before notifying the avatar switch. The avatar switch is immediate now. We are ready to remove the delay introduced in #350. More concretely in this [commit](https://github.com/Automattic/Gravatar-SDK-Android/pull/350/commits/1aca9c43b7f134334f27aaa248bf14d3ea8f0782).

### Testing Steps

- Open the QE and switch between avatars. Verify everything works smoothly; you can see the new avatar in the profile card.
