### PR TITLE
Notify 3rd party when selected avatar is deleted

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -300,6 +300,7 @@ internal class AvatarPickerViewModel(
                 }
                 when (avatarRepository.deleteAvatar(email, avatarId)) {
                     is GravatarResult.Success -> {
+                        _actions.send(AvatarPickerAction.AvatarSelected)
                         _uiState.update { currentState ->
                             currentState.copy(
                                 avatarUpdates = if (isSelectedAvatar) {

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -838,6 +838,9 @@ class AvatarPickerViewModelTest {
                 awaitItem(),
             )
         }
+        viewModel.actions.test {
+            assertEquals(AvatarPickerAction.AvatarSelected, awaitItem())
+        }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
Closes #478

### Description

When the selected avatar is deleted we should notify the third-party app about that change. 

This PR fixes that. 

| Before | After |
|---|---|
| ![notify_before](https://github.com/user-attachments/assets/77d1747f-a4c6-4053-a9a3-5ad862410457) | ![notify_after](https://github.com/user-attachments/assets/9a4cbcd8-e13d-473e-a63c-1ebc7c87cec8) |

### Testing Steps
1. Run the QE
2. Select an avatar
3. Delete that avatar
4. Confirm the Avatar was updated in the Demo app