### PR TITLE
QuickEditor: Modify the way PickerPopup calculates its position

### DIFF
--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -219,6 +219,13 @@ public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$S
 	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
 }
 
+public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$UploadImageButtonKt {
+	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/components/ComposableSingletons$UploadImageButtonKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/gravatar/quickeditor/ui/components/ComposableSingletons$UploadImageGridButtonKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/components/ComposableSingletons$UploadImageGridButtonKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarMoreOptionsPickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/AvatarMoreOptionsPickerPopup.kt
@@ -7,10 +7,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.gravatar.quickeditor.R
 import com.gravatar.ui.GravatarTheme
@@ -18,15 +16,13 @@ import com.gravatar.ui.GravatarTheme
 @Composable
 internal fun AvatarMoreOptionsPickerPopup(
     anchorAlignment: Alignment.Horizontal,
-    anchorBounds: Rect,
-    popupDrawArea: Rect? = null,
+    offset: DpOffset,
     onDismissRequest: () -> Unit,
     onAvatarOptionClicked: (AvatarOption) -> Unit,
 ) {
     PickerPopup(
         anchorAlignment = anchorAlignment,
-        anchorBounds = anchorBounds,
-        popupDrawArea = popupDrawArea,
+        offset = offset,
         onDismissRequest = onDismissRequest,
         popupItems = listOf(
             PickerPopupItem(
@@ -75,8 +71,8 @@ private fun AvatarMoreOptionsPickerPopupPreview() {
         ) {
             AvatarMoreOptionsPickerPopup(
                 anchorAlignment = Alignment.Start,
+                offset = DpOffset.Zero,
                 onDismissRequest = {},
-                anchorBounds = Rect(Offset(0f, 300f), Size(1f, 1f)),
                 onAvatarOptionClicked = {},
             )
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/HorizontalAvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/HorizontalAvatarsSection.kt
@@ -12,17 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -43,8 +33,6 @@ internal fun HorizontalAvatarsSection(
     onTakePhotoClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var popupVisible by remember { mutableStateOf(false) }
-    var popupAnchorBounds: Rect by remember { mutableStateOf(Rect(Offset.Zero, Size.Zero)) }
     val listState = rememberLazyListState()
 
     LaunchedEffect(state.scrollToIndex) {
@@ -90,32 +78,12 @@ internal fun HorizontalAvatarsSection(
                         contentPadding = PaddingValues(horizontal = sectionPadding),
                     )
                 }
-                QEButton(
-                    buttonText = stringResource(id = R.string.gravatar_qe_avatar_picker_upload_image),
-                    onClick = { popupVisible = true },
+                UploadImageButton(
+                    onTakePhotoClick = onTakePhotoClick,
+                    onChoosePhotoClick = onChoosePhotoClick,
                     enabled = state.uploadButtonEnabled,
                     modifier = Modifier
-                        .padding(horizontal = sectionPadding)
-                        .onGloballyPositioned { layoutCoordinates ->
-                            popupAnchorBounds = layoutCoordinates.boundsInRoot()
-                        },
-                )
-            }
-            if (popupVisible) {
-                MediaPickerPopup(
-                    anchorAlignment = Alignment.CenterHorizontally,
-                    onDismissRequest = {
-                        popupVisible = false
-                    },
-                    anchorBounds = popupAnchorBounds,
-                    onChoosePhotoClick = {
-                        popupVisible = false
-                        onChoosePhotoClick()
-                    },
-                    onTakePhotoClick = {
-                        popupVisible = false
-                        onTakePhotoClick()
-                    },
+                        .padding(horizontal = sectionPadding),
                 )
             }
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/LazyAvatarList.kt
@@ -7,16 +7,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -34,20 +25,15 @@ internal fun LazyAvatarRow(
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    var parentBounds by remember { mutableStateOf(Rect(Offset.Zero, Size.Zero)) }
-
     LazyRow(
         horizontalArrangement = horizontalArrangement,
-        modifier = modifier.onGloballyPositioned { coordinates ->
-            parentBounds = coordinates.boundsInRoot()
-        },
+        modifier = modifier,
         state = state,
         contentPadding = contentPadding,
     ) {
         items(items = avatars, key = { it.avatarId }) { avatarModel ->
             Avatar(
                 avatar = avatarModel,
-                parentBounds = parentBounds,
                 onAvatarSelected = { onAvatarSelected(avatarModel) },
                 onAvatarOptionClicked = { avatar, option -> onAvatarOptionClicked(avatar, option) },
                 size = avatarSize,
@@ -65,7 +51,6 @@ internal val avatarSize = 96.dp
 internal fun Avatar(
     avatar: AvatarUi,
     size: Dp,
-    parentBounds: Rect? = null,
     onAvatarSelected: () -> Unit,
     onAvatarOptionClicked: (Avatar, AvatarOption) -> Unit,
     modifier: Modifier,
@@ -77,7 +62,6 @@ internal fun Avatar(
                 imageUrl = avatar.imageUrlWithSize(sizePx),
                 isSelected = avatar.isSelected,
                 loadingState = avatar.loadingState,
-                parentBounds = parentBounds,
                 onAvatarClicked = { onAvatarSelected() },
                 onAvatarOptionClicked = { onAvatarOptionClicked(avatar.avatar, it) },
                 modifier = modifier,
@@ -88,7 +72,6 @@ internal fun Avatar(
             imageUrl = avatar.uri.toString(),
             isSelected = false,
             loadingState = avatar.loadingState,
-            parentBounds = parentBounds,
             onAvatarClicked = { onAvatarSelected() },
             modifier = modifier,
         )

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/MediaPickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/MediaPickerPopup.kt
@@ -7,10 +7,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.gravatar.quickeditor.R
 import com.gravatar.ui.GravatarTheme
@@ -18,15 +16,15 @@ import com.gravatar.ui.GravatarTheme
 @Composable
 internal fun MediaPickerPopup(
     anchorAlignment: Alignment.Horizontal,
-    anchorBounds: Rect,
+    offset: DpOffset,
     onDismissRequest: () -> Unit,
     onChoosePhotoClick: () -> Unit,
     onTakePhotoClick: () -> Unit,
 ) {
     PickerPopup(
         anchorAlignment = anchorAlignment,
-        anchorBounds = anchorBounds,
         onDismissRequest = onDismissRequest,
+        offset = offset,
         popupItems = listOf(
             PickerPopupItem(
                 text = R.string.gravatar_qe_avatar_picker_choose_a_photo,
@@ -55,8 +53,8 @@ private fun MediaPickerPopupPreview() {
         ) {
             MediaPickerPopup(
                 anchorAlignment = Alignment.Start,
+                offset = DpOffset.Zero,
                 onDismissRequest = {},
-                anchorBounds = Rect(Offset(0f, 300f), Size(1f, 1f)),
                 onChoosePhotoClick = {},
                 onTakePhotoClick = {},
             )

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
@@ -141,12 +141,14 @@ internal data class PickerPopupPositionProvider(
             IntOffset(offset.x.toPx().toInt(), offset.y.toPx().toInt())
         }
 
+        val displayPadding = with(density) { 16.dp.toPx().toInt() }
+
         // Compute horizontal position.
         val toRight = anchorBounds.left
         val toLeft = anchorBounds.right - popupContentSize.width
 
-        val toDisplayRight = windowSize.width - popupContentSize.width
-        val toDisplayLeft = 0
+        val toDisplayRight = windowSize.width - popupContentSize.width - displayPadding
+        val toDisplayLeft = 0 + displayPadding
 
         val x = (
             if (alignment == Alignment.Start) {
@@ -155,7 +157,7 @@ internal data class PickerPopupPositionProvider(
                     toLeft,
                     // If the anchor gets outside of the window on the left, we want to position
                     // toDisplayLeft for proximity to the anchor. Otherwise, toDisplayRight.
-                    if (anchorBounds.left >= 0) toDisplayRight else toDisplayLeft,
+                    if (anchorBounds.left >= displayPadding) toDisplayRight else toDisplayLeft,
                 )
             } else if (alignment == Alignment.End) {
                 sequenceOf(
@@ -163,13 +165,13 @@ internal data class PickerPopupPositionProvider(
                     toRight,
                     // If the anchor gets outside of the window on the right, we want to position
                     // toDisplayRight for proximity to the anchor. Otherwise, toDisplayLeft.
-                    if (anchorBounds.right <= windowSize.width) toDisplayLeft else toDisplayRight,
+                    if (anchorBounds.right <= windowSize.width - displayPadding) toDisplayLeft else toDisplayRight,
                 )
             } else { // middle
                 sequenceOf(anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2)
             }
         ).firstOrNull {
-            it >= 0 && it + popupContentSize.width <= windowSize.width
+            it >= displayPadding && it + popupContentSize.width <= windowSize.width - displayPadding
         } ?: toLeft
 
         // Compute vertical position.

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.scaleIn
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -15,40 +14,35 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
-import com.composables.core.Dialog
-import com.composables.core.DialogPanel
-import com.composables.core.Scrim
-import com.composables.core.rememberDialogState
 
 @Composable
 internal fun PickerPopup(
     anchorAlignment: Alignment.Horizontal,
-    anchorBounds: Rect,
-    popupDrawArea: Rect? = null,
+    offset: DpOffset,
     onDismissRequest: () -> Unit,
     popupItems: List<PickerPopupItem>,
 ) {
     PickerPopup(
         anchorAlignment = anchorAlignment,
-        anchorBounds = anchorBounds,
-        popupDrawArea = popupDrawArea,
+        dpOffset = offset,
         onDismissRequest = onDismissRequest,
         popupItems = popupItems,
         state = remember {
@@ -63,59 +57,43 @@ internal fun PickerPopup(
 @Composable
 private fun PickerPopup(
     anchorAlignment: Alignment.Horizontal,
-    anchorBounds: Rect,
-    popupDrawArea: Rect? = null,
+    dpOffset: DpOffset,
     onDismissRequest: () -> Unit,
     popupItems: List<PickerPopupItem>,
     state: MutableTransitionState<Boolean>,
 ) {
+    val density = LocalDensity.current
+    val positionProvider = remember(density) { PickerPopupPositionProvider(density, anchorAlignment, dpOffset) }
     val cornerRadius = 8.dp
-    // full screen background
-    Dialog(state = rememberDialogState(initiallyVisible = true)) {
-        Scrim(scrimColor = Color.Black.copy(alpha = 0.2f))
-        DialogPanel(
-            modifier = Modifier
-                .fillMaxSize(),
-        ) {
-            var popupSize by remember { mutableStateOf(IntSize.Zero) }
 
-            Popup(
-                alignment = Alignment.TopStart,
-                onDismissRequest = onDismissRequest,
-                offset = IntOffset(
-                    calculatePopupXOffset(anchorAlignment, anchorBounds, popupDrawArea, popupSize),
-                    (anchorBounds.top - popupSize.height - 10.dp.dpToPx()).toInt(),
-                ),
-                properties = PopupProperties(focusable = true),
+    Popup(
+        onDismissRequest = onDismissRequest,
+        popupPositionProvider = positionProvider,
+        properties = PopupProperties(focusable = true),
+    ) {
+        AnimatedVisibility(
+            visibleState = state,
+            enter = scaleIn(animationSpec = spring(stiffness = Spring.StiffnessMedium)),
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth(0.6f),
+                shape = RoundedCornerShape(cornerRadius),
+                tonalElevation = 3.dp,
+                shadowElevation = 2.dp,
             ) {
-                AnimatedVisibility(
-                    visibleState = state,
-                    enter = scaleIn(animationSpec = spring(stiffness = Spring.StiffnessMedium)),
-                ) {
-                    Surface(
-                        modifier = Modifier
-                            .fillMaxWidth(0.6f)
-                            .onGloballyPositioned {
-                                popupSize = it.size
-                            },
-                        shape = RoundedCornerShape(cornerRadius),
-                        tonalElevation = 3.dp,
-                        shadowElevation = 2.dp,
-                    ) {
-                        LazyColumn {
-                            itemsIndexed(popupItems) { index, item ->
-                                PopupButton(
-                                    text = stringResource(item.text),
-                                    iconRes = item.iconRes,
-                                    contentDescription = stringResource(item.contentDescription),
-                                    shape = popupButtonShape(index, popupItems.size, cornerRadius),
-                                    color = item.color,
-                                    onClick = item.onClick,
-                                )
-                                if (index < popupItems.size - 1) {
-                                    HorizontalDivider()
-                                }
-                            }
+                LazyColumn {
+                    itemsIndexed(popupItems) { index, item ->
+                        PopupButton(
+                            text = stringResource(item.text),
+                            iconRes = item.iconRes,
+                            contentDescription = stringResource(item.contentDescription),
+                            shape = popupButtonShape(index, popupItems.size, cornerRadius),
+                            color = item.color,
+                            onClick = item.onClick,
+                        )
+                        if (index < popupItems.size - 1) {
+                            HorizontalDivider()
                         }
                     }
                 }
@@ -137,9 +115,6 @@ private fun popupButtonShape(index: Int, totalItems: Int, cornerRadius: Dp): Rou
     }
 }
 
-@Composable
-private fun Dp.dpToPx() = with(LocalDensity.current) { this@dpToPx.toPx() }
-
 internal data class PickerPopupItem(
     @StringRes val text: Int,
     @DrawableRes val iconRes: Int,
@@ -148,19 +123,64 @@ internal data class PickerPopupItem(
     val onClick: () -> Unit,
 )
 
-private fun calculatePopupXOffset(
-    anchorAlignment: Alignment.Horizontal,
-    anchorBounds: Rect,
-    maxBounds: Rect? = null,
-    popupSize: IntSize,
-): Int {
-    val offset = when (anchorAlignment) {
-        Alignment.Start -> anchorBounds.left.toInt()
-        Alignment.End -> (anchorBounds.right - popupSize.width).toInt()
-        else -> (anchorBounds.left.toInt() + anchorBounds.width.toInt() / 2) - (popupSize.width / 2)
-    }
+// Code modified from Compose-Unstyled Menu.kt to prioritize positioning above the anchor
+// https://github.com/composablehorizons/compose-unstyled/blob/c62bab5babdabceb634ec66de05f5370c161b66d/core/src/commonMain/kotlin/Menu.kt
+@Immutable
+internal data class PickerPopupPositionProvider(
+    val density: Density,
+    val alignment: Alignment.Horizontal,
+    val offset: DpOffset = DpOffset.Zero,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val intOffset: IntOffset = with(density) {
+            IntOffset(offset.x.toPx().toInt(), offset.y.toPx().toInt())
+        }
 
-    return maxBounds?.let { bounds ->
-        offset.coerceIn(bounds.left.toInt(), (bounds.right - popupSize.width).toInt())
-    } ?: offset
+        // Compute horizontal position.
+        val toRight = anchorBounds.left
+        val toLeft = anchorBounds.right - popupContentSize.width
+
+        val toDisplayRight = windowSize.width - popupContentSize.width
+        val toDisplayLeft = 0
+
+        val x = (
+            if (alignment == Alignment.Start) {
+                sequenceOf(
+                    toRight,
+                    toLeft,
+                    // If the anchor gets outside of the window on the left, we want to position
+                    // toDisplayLeft for proximity to the anchor. Otherwise, toDisplayRight.
+                    if (anchorBounds.left >= 0) toDisplayRight else toDisplayLeft,
+                )
+            } else if (alignment == Alignment.End) {
+                sequenceOf(
+                    toLeft,
+                    toRight,
+                    // If the anchor gets outside of the window on the right, we want to position
+                    // toDisplayRight for proximity to the anchor. Otherwise, toDisplayLeft.
+                    if (anchorBounds.right <= windowSize.width) toDisplayLeft else toDisplayRight,
+                )
+            } else { // middle
+                sequenceOf(anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2)
+            }
+        ).firstOrNull {
+            it >= 0 && it + popupContentSize.width <= windowSize.width
+        } ?: toLeft
+
+        // Compute vertical position.
+        val toBottom = maxOf(anchorBounds.bottom + intOffset.y, 0)
+        val toTop = anchorBounds.top - intOffset.y - popupContentSize.height
+        val toCenter = anchorBounds.top - intOffset.y - popupContentSize.height / 2
+        val toDisplayBottom = windowSize.height - intOffset.y - popupContentSize.height
+        val y = sequenceOf(toTop, toBottom, toCenter, toDisplayBottom).firstOrNull {
+            it >= 0 && it + popupContentSize.height <= windowSize.height
+        } ?: toTop
+
+        return IntOffset(x, y)
+    }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/PickerPopup.kt
@@ -130,6 +130,7 @@ internal data class PickerPopupPositionProvider(
     val density: Density,
     val alignment: Alignment.Horizontal,
     val offset: DpOffset = DpOffset.Zero,
+    val displayPadding: Dp = 16.dp,
 ) : PopupPositionProvider {
     override fun calculatePosition(
         anchorBounds: IntRect,
@@ -141,7 +142,7 @@ internal data class PickerPopupPositionProvider(
             IntOffset(offset.x.toPx().toInt(), offset.y.toPx().toInt())
         }
 
-        val displayPadding = with(density) { 16.dp.toPx().toInt() }
+        val displayPadding = with(density) { displayPadding.toPx().toInt() }
 
         // Compute horizontal position.
         val toRight = anchorBounds.left

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/SelectableAvatar.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/SelectableAvatar.kt
@@ -23,15 +23,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.gravatar.quickeditor.R
@@ -43,14 +39,12 @@ internal fun SelectableAvatar(
     imageUrl: String,
     isSelected: Boolean,
     loadingState: AvatarLoadingState,
-    parentBounds: Rect? = null,
     onAvatarClicked: () -> Unit,
     onAvatarOptionClicked: ((AvatarOption) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val cornerRadius = 8.dp
     var moreOptionsPopupVisible by remember { mutableStateOf(false) }
-    var popupAnchorBounds: Rect by remember { mutableStateOf(Rect(Offset.Zero, Size.Zero)) }
     Box(
         modifier = modifier
             .aspectRatio(1f)
@@ -67,10 +61,6 @@ internal fun SelectableAvatar(
             )
             .clickable {
                 onAvatarClicked()
-            }
-            .onGloballyPositioned { layoutCoordinates ->
-                popupAnchorBounds = layoutCoordinates
-                    .boundsInRoot()
             },
     ) {
         AsyncImage(
@@ -92,8 +82,7 @@ internal fun SelectableAvatar(
         if (moreOptionsPopupVisible) {
             AvatarMoreOptionsPickerPopup(
                 anchorAlignment = Alignment.Start,
-                anchorBounds = popupAnchorBounds,
-                popupDrawArea = parentBounds,
+                offset = DpOffset(0.dp, 10.dp),
                 onDismissRequest = { moreOptionsPopupVisible = false },
                 onAvatarOptionClicked = { avatarOption ->
                     moreOptionsPopupVisible = false

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/UploadImageButton.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/UploadImageButton.kt
@@ -1,0 +1,64 @@
+package com.gravatar.quickeditor.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.gravatar.quickeditor.R
+import com.gravatar.ui.GravatarTheme
+
+@Composable
+internal fun UploadImageButton(
+    onChoosePhotoClick: () -> Unit,
+    onTakePhotoClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var popupVisible by remember { mutableStateOf(false) }
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        QEButton(
+            buttonText = stringResource(id = R.string.gravatar_qe_avatar_picker_upload_image),
+            onClick = { popupVisible = true },
+            enabled = enabled,
+            modifier = modifier,
+        )
+        if (popupVisible) {
+            MediaPickerPopup(
+                anchorAlignment = Alignment.CenterHorizontally,
+                offset = DpOffset(0.dp, 10.dp),
+                onDismissRequest = { popupVisible = false },
+                onChoosePhotoClick = {
+                    popupVisible = false
+                    onChoosePhotoClick()
+                },
+                onTakePhotoClick = {
+                    popupVisible = false
+                    onTakePhotoClick()
+                },
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 360, heightDp = 200)
+@Composable
+private fun UploadImageButtonPreview() {
+    GravatarTheme {
+        UploadImageButton(
+            onChoosePhotoClick = {},
+            onTakePhotoClick = {},
+            enabled = true,
+        )
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/UploadImageGridButton.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/UploadImageGridButton.kt
@@ -2,6 +2,7 @@ package com.gravatar.quickeditor.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -14,31 +15,59 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.gravatar.quickeditor.R
 import com.gravatar.ui.GravatarTheme
 
 @Composable
-internal fun UploadImageGridButton(onClick: () -> Unit, enabled: Boolean, modifier: Modifier = Modifier) {
-    IconButton(
-        onClick = onClick,
-        enabled = enabled,
-        modifier = modifier
-            .border(
-                1.dp,
-                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f),
-                RoundedCornerShape(8.dp),
+internal fun UploadImageGridButton(
+    onChoosePhotoClick: () -> Unit,
+    onTakePhotoClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var popupVisible by remember { androidx.compose.runtime.mutableStateOf(false) }
+    Box(modifier = modifier) {
+        IconButton(
+            onClick = { popupVisible = true },
+            enabled = enabled,
+            modifier = Modifier
+                .border(
+                    1.dp,
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f),
+                    RoundedCornerShape(8.dp),
+                )
+                .aspectRatio(1f),
+            colors = IconButtonDefaults.iconButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = stringResource(R.string.gravatar_qe_upload_image_content_description),
             )
-            .aspectRatio(1f),
-        colors = IconButtonDefaults.iconButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
-    ) {
-        Icon(
-            imageVector = Icons.Filled.Add,
-            contentDescription = stringResource(R.string.gravatar_qe_upload_image_content_description),
-        )
+        }
+        if (popupVisible) {
+            MediaPickerPopup(
+                anchorAlignment = Alignment.Start,
+                offset = DpOffset(0.dp, 10.dp),
+                onDismissRequest = { popupVisible = false },
+                onChoosePhotoClick = {
+                    popupVisible = false
+                    onChoosePhotoClick()
+                },
+                onTakePhotoClick = {
+                    popupVisible = false
+                    onTakePhotoClick()
+                },
+            )
+        }
     }
 }
 
@@ -52,7 +81,8 @@ private fun UploadImageGridButtonPreview() {
                 .padding(10.dp),
         ) {
             UploadImageGridButton(
-                onClick = {},
+                onTakePhotoClick = {},
+                onChoosePhotoClick = {},
                 enabled = true,
                 modifier = Modifier.size(avatarSize),
             )

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/VerticalAvatarsSection.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/VerticalAvatarsSection.kt
@@ -14,23 +14,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.gravatar.quickeditor.R
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarUi
@@ -49,16 +35,10 @@ internal fun VerticalAvatarsSection(
     onTakePhotoClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var popupVisible by remember { mutableStateOf(false) }
-    var popupAnchorBounds: Rect by remember { mutableStateOf(Rect(Offset.Zero, Size.Zero)) }
-    var parentBounds by remember { mutableStateOf(Rect(Offset.Zero, Size.Zero)) }
     val gridState = rememberLazyGridState()
-
-    val density = LocalDensity.current
-    val layoutDirection = LocalLayoutDirection.current
-
     val contentPadding = PaddingValues(16.dp)
     val itemSpacing = 8.dp
+
     Surface(modifier = modifier) {
         Box {
             LazyVerticalGrid(
@@ -67,9 +47,7 @@ internal fun VerticalAvatarsSection(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.surfaceContainerHighest,
                     shape = RoundedCornerShape(8.dp),
-                ).onGloballyPositioned { coordinates ->
-                    parentBounds = coordinates.boundsInRoot().getPaddedBounds(contentPadding, density, layoutDirection)
-                },
+                ),
                 state = gridState,
                 contentPadding = contentPadding,
                 horizontalArrangement = Arrangement.spacedBy(itemSpacing),
@@ -101,15 +79,10 @@ internal fun VerticalAvatarsSection(
                     item(
                         span = { GridItemSpan(maxLineSpan) },
                     ) {
-                        QEButton(
-                            buttonText = stringResource(id = R.string.gravatar_qe_avatar_picker_upload_image),
-                            onClick = { popupVisible = true },
+                        UploadImageButton(
+                            onTakePhotoClick = onTakePhotoClick,
+                            onChoosePhotoClick = onChoosePhotoClick,
                             enabled = state.uploadButtonEnabled,
-                            modifier = Modifier
-                                .onGloballyPositioned { layoutCoordinates ->
-                                    popupAnchorBounds = layoutCoordinates
-                                        .boundsInRoot()
-                                },
                         )
                     }
                 } else {
@@ -117,19 +90,14 @@ internal fun VerticalAvatarsSection(
                         span = { GridItemSpan(1) },
                     ) {
                         UploadImageGridButton(
-                            onClick = { popupVisible = true },
+                            onChoosePhotoClick = onChoosePhotoClick,
+                            onTakePhotoClick = onTakePhotoClick,
                             enabled = state.uploadButtonEnabled,
-                            modifier = Modifier
-                                .onGloballyPositioned { layoutCoordinates ->
-                                    popupAnchorBounds = layoutCoordinates
-                                        .boundsInRoot()
-                                },
                         )
                     }
                     items(items = state.avatars, key = { it.avatarId }) { avatarModel ->
                         Avatar(
                             avatar = avatarModel,
-                            parentBounds = parentBounds,
                             onAvatarSelected = { onAvatarSelected(avatarModel) },
                             onAvatarOptionClicked = { avatar, option -> onAvatarOptionClicked(avatar, option) },
                             size = avatarSize,
@@ -138,43 +106,8 @@ internal fun VerticalAvatarsSection(
                     }
                 }
             }
-            if (popupVisible) {
-                val isGridButton = state.avatars.isNotEmpty()
-                MediaPickerPopup(
-                    anchorAlignment = if (isGridButton) Alignment.Start else Alignment.CenterHorizontally,
-                    onDismissRequest = { popupVisible = false },
-                    anchorBounds = popupAnchorBounds,
-                    onChoosePhotoClick = {
-                        popupVisible = false
-                        onChoosePhotoClick()
-                    },
-                    onTakePhotoClick = {
-                        popupVisible = false
-                        onTakePhotoClick()
-                    },
-                )
-            }
         }
     }
-}
-
-private fun Rect.getPaddedBounds(
-    paddingValues: PaddingValues,
-    density: Density,
-    layoutDirection: LayoutDirection,
-): Rect {
-    // Convert PaddingValues to Px
-    val startPaddingPx = with(density) { paddingValues.calculateLeftPadding(layoutDirection).toPx() }
-    val topPaddingPx = with(density) { paddingValues.calculateTopPadding().toPx() }
-    val endPaddingPx = with(density) { paddingValues.calculateRightPadding(layoutDirection).toPx() }
-    val bottomPaddingPx = with(density) { paddingValues.calculateBottomPadding().toPx() }
-
-    return Rect(
-        left = this.left + startPaddingPx,
-        top = this.top + topPaddingPx,
-        right = this.right - endPaddingPx,
-        bottom = this.bottom - bottomPaddingPx,
-    )
 }
 
 @Composable

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/UploadImageGridButtonTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/components/UploadImageGridButtonTest.kt
@@ -12,7 +12,8 @@ class UploadImageGridButtonTest : RoborazziTest() {
     fun uploadImageGridButtonEnabled() = gravatarScreenshotTest {
         Surface {
             UploadImageGridButton(
-                onClick = {},
+                onTakePhotoClick = {},
+                onChoosePhotoClick = {},
                 enabled = true,
                 modifier = Modifier.size(avatarSize),
             )
@@ -23,7 +24,8 @@ class UploadImageGridButtonTest : RoborazziTest() {
     fun uploadImageGridButtonDisabled() = gravatarScreenshotTest {
         Surface {
             UploadImageGridButton(
-                onClick = {},
+                onTakePhotoClick = {},
+                onChoosePhotoClick = {},
                 enabled = false,
                 modifier = Modifier.size(avatarSize),
             )


### PR DESCRIPTION
Closes #457

### Description

The issue mentions that we should extract the `AvatarMoreOptionsPickerPopup` from `SelectableAvatar`. The root of that idea was all the arguments we had to pass for the popup position calculation. 
While working on #237 I noticed the issue and how it could be changed. This PR is a result of that. 

In short, we now use a version of `PopupPositionProvider`, it is a modified version of the code from the Composable Unstyled to make sure we prioritize showing the Popup above the anchor not below it (the original is for the Dropdown component). To make it work I had to also remove the `Dialog` from the `PickerPopup` as we need to have it in the same Box parent as the anchor, so we can't do the absolute positioning like before.  

Removing the `Dialog` means we no longer have the dimmed background, but this is not something that is in the spec for Menu components in Material 3, so this should be ok. 

With the updated code we can now have the button together with the Popup without any extra arguments like `anchorbounds` or `maxDrawingArea`.  Thanks to this we could have the `UploadImageButton` wrapped with the Popup and placed wherever we need without duplicating the Popup code. 

### Testing Steps
Test the `AvatarMoreOptionsPickerPopup` and the `MediaPickerPopup` in all possible scenarios: 
- horizontal, 
- vertical (empty list and non-empty).
