### PR TITLE
Rename imageId to avatarId in AvatarService to match with other functions

### DIFF
--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -168,7 +168,7 @@ class AvatarRepositoryTest {
         val imageId = "imageId"
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
-            avatarService.deleteAvatarCatching(imageId = "imageId", oauthToken = "token")
+            avatarService.deleteAvatarCatching(avatarId = "imageId", oauthToken = "token")
         } returns GravatarResult.Success(Unit)
 
         val result = avatarRepository.deleteAvatar(email, imageId)
@@ -182,7 +182,7 @@ class AvatarRepositoryTest {
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
             avatarService.deleteAvatarCatching(
-                imageId = "imageId",
+                avatarId = "imageId",
                 oauthToken = "token",
             )
         } returns GravatarResult.Failure(ErrorType.Server)

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -174,14 +174,14 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
     /**
      * Deletes the avatar with the given ID.
      *
-     * @param imageId The ID of the avatar to delete
+     * @param avatarId The ID of the avatar to delete
      * @param oauthToken The OAuth token to use for authentication
      */
-    public suspend fun deleteAvatar(imageId: String, oauthToken: String): Unit = runThrowingExceptionRequest {
+    public suspend fun deleteAvatar(avatarId: String, oauthToken: String): Unit = runThrowingExceptionRequest {
         withContext(GravatarSdkDI.dispatcherIO) {
             val service = GravatarSdkDI.getGravatarV3Service(okHttpClient, oauthToken)
 
-            val response = service.deleteAvatar(imageId)
+            val response = service.deleteAvatar(avatarId)
 
             if (response.isSuccessful) {
                 Unit
@@ -201,12 +201,12 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
      * This method will catch any exception that occurs during
      * the execution and return it as a [GravatarResult.Failure].
      *
-     * @param imageId The ID of the avatar to delete
+     * @param avatarId The ID of the avatar to delete
      * @param oauthToken The OAuth token to use for authentication
      * @return The result of the operation
      */
-    public suspend fun deleteAvatarCatching(imageId: String, oauthToken: String): GravatarResult<Unit, ErrorType> =
+    public suspend fun deleteAvatarCatching(avatarId: String, oauthToken: String): GravatarResult<Unit, ErrorType> =
         runCatchingRequest {
-            deleteAvatar(imageId, oauthToken)
+            deleteAvatar(avatarId, oauthToken)
         }
 }


### PR DESCRIPTION
### Description

I've noticed the name `imageId` in the `AvatarService` delete function is inconsistent with other functions. This hasn't been released yet, so it's the last time to change it. 

This is not something that would be caught by the binary check plugin, but if the named param was used this would be a breaking change. 

### Testing Steps

CI should be enough, smoke test Avatar deletion in the QE.