### PR TITLE
QuickEditor: Implement the Avatar's rating change in the AvatarPicker

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -74,6 +74,21 @@ internal class AvatarRepository(
             }
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
     }
+
+    suspend fun updateAvatar(
+        email: Email,
+        avatarId: String,
+        rating: Avatar.Rating? = null,
+        altText: String? = null,
+    ): GravatarResult<Avatar, QuickEditorError> = withContext(dispatcher) {
+        val token = tokenStorage.getToken(email.hash().toString())
+        token?.let {
+            when (val result = avatarService.updateAvatarCatching(avatarId, token, rating, altText)) {
+                is GravatarResult.Success -> GravatarResult.Success(result.value)
+                is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
+            }
+        } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
+    }
 }
 
 internal data class EmailAvatars(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -325,7 +325,7 @@ private fun openDownloadManagerSettings(context: Context) {
     }
 }
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 private fun AvatarPickerAction.handle(
     viewModel: AvatarPickerViewModel,
     cropperLauncher: CropperLauncher,
@@ -397,6 +397,26 @@ private fun AvatarPickerAction.handle(
                 )
             }
         }
+
+        is AvatarPickerAction.AvatarUpdateFailed -> {
+            scope.launch {
+                snackState.showQESnackbar(
+                    message = context.getString(this@handle.type.errorStringRes),
+                    withDismissAction = true,
+                    snackbarType = SnackbarType.Error,
+                )
+            }
+        }
+
+        is AvatarPickerAction.AvatarUpdated -> {
+            scope.launch {
+                snackState.showQESnackbar(
+                    message = context.getString(this@handle.type.successStringRes),
+                    withDismissAction = true,
+                    snackbarType = SnackbarType.Info,
+                )
+            }
+        }
     }
 }
 
@@ -437,6 +457,16 @@ private val SectionError.buttonTextRes: Int
         SectionError.ServerError,
         SectionError.Unknown,
         -> R.string.gravatar_qe_avatar_picker_error_retry_cta
+    }
+
+private val AvatarUpdateType.successStringRes: Int
+    @StringRes get() = when (this) {
+        AvatarUpdateType.RATING -> R.string.gravatar_qe_avatar_picker_rating_update_success
+    }
+
+private val AvatarUpdateType.errorStringRes: Int
+    @StringRes get() = when (this) {
+        AvatarUpdateType.RATING -> R.string.gravatar_qe_avatar_picker_rating_update_error
     }
 
 private val SectionError.event: AvatarPickerEvent

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerAction.kt
@@ -17,4 +17,12 @@ internal sealed class AvatarPickerAction {
     data object DownloadManagerNotAvailable : AvatarPickerAction()
 
     data class AvatarDeletionFailed(val avatarId: String) : AvatarPickerAction()
+
+    data class AvatarUpdated(val type: AvatarUpdateType) : AvatarPickerAction()
+
+    data class AvatarUpdateFailed(val type: AvatarUpdateType) : AvatarPickerAction()
+}
+
+internal enum class AvatarUpdateType {
+    RATING,
 }

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -62,4 +62,6 @@
     <string name="gravatar_qe_avatar_rating_r">R (Restricted)</string>
     <string name="gravatar_qe_avatar_rating_x">X (Extreme)</string>
     <string name="gravatar_qe_avatar_rating_selected_content_description">Selected</string>
+    <string name="gravatar_qe_avatar_picker_rating_update_success">Avatar rating was changed successfully.</string>
+    <string name="gravatar_qe_avatar_picker_rating_update_error">Oops, something didn\'t quite work out while trying to rate your avatar.</string>
 </resources>

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -699,6 +699,10 @@ public final class com/gravatar/services/AvatarService {
 	public final fun retrieveCatching (Ljava/lang/String;Lcom/gravatar/types/Hash;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAvatar (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAvatarCatching (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateAvatar (Ljava/lang/String;Ljava/lang/String;Lcom/gravatar/restapi/models/Avatar$Rating;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateAvatar$default (Lcom/gravatar/services/AvatarService;Ljava/lang/String;Ljava/lang/String;Lcom/gravatar/restapi/models/Avatar$Rating;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateAvatarCatching (Ljava/lang/String;Ljava/lang/String;Lcom/gravatar/restapi/models/Avatar$Rating;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateAvatarCatching$default (Lcom/gravatar/services/AvatarService;Ljava/lang/String;Ljava/lang/String;Lcom/gravatar/restapi/models/Avatar$Rating;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun upload (Ljava/io/File;Ljava/lang/String;Lcom/gravatar/types/Hash;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun upload$default (Lcom/gravatar/services/AvatarService;Ljava/io/File;Ljava/lang/String;Lcom/gravatar/types/Hash;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun uploadCatching (Ljava/io/File;Ljava/lang/String;Lcom/gravatar/types/Hash;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
+++ b/gravatar/src/main/java/com/gravatar/services/AvatarService.kt
@@ -3,7 +3,9 @@ package com.gravatar.services
 import com.gravatar.di.container.GravatarSdkContainer.Companion.instance
 import com.gravatar.logger.Logger
 import com.gravatar.restapi.models.Avatar
+import com.gravatar.restapi.models.Rating
 import com.gravatar.restapi.models.SetEmailAvatarRequest
+import com.gravatar.restapi.models.UpdateAvatarRequest
 import com.gravatar.types.Hash
 import kotlinx.coroutines.withContext
 import okhttp3.MultipartBody
@@ -209,4 +211,71 @@ public class AvatarService(private val okHttpClient: OkHttpClient? = null) {
         runCatchingRequest {
             deleteAvatar(imageId, oauthToken)
         }
+
+    /**
+     * Updates the avatar rating and/or alt text.
+     *
+     * @param avatarId The ID of the avatar to update
+     * @param oauthToken The OAuth token to use for authentication
+     * @param avatarRating The new rating for the avatar
+     * @param altText The new alt text for the avatar
+     * @return The updated avatar
+     */
+    public suspend fun updateAvatar(
+        avatarId: String,
+        oauthToken: String,
+        avatarRating: Avatar.Rating? = null,
+        altText: String? = null,
+    ): Avatar = runThrowingExceptionRequest {
+        withContext(GravatarSdkDI.dispatcherIO) {
+            val service = GravatarSdkDI.getGravatarV3Service(okHttpClient, oauthToken)
+
+            val response = service.updateAvatar(
+                avatarId,
+                UpdateAvatarRequest {
+                    rating = avatarRating?.toRating
+                    this.altText = altText
+                },
+            )
+
+            if (response.isSuccessful) {
+                response.body() ?: error("Response body is null")
+            } else {
+                // Log the response body for debugging purposes if the response is not successful
+                Logger.w(
+                    LOG_TAG,
+                    "Network call unsuccessful trying to update Gravatar avatar rating: $response.body",
+                )
+                throw HttpException(response)
+            }
+        }
+    }
+
+    /**
+     * Updates the avatar rating and/or alt text.
+     * This method will catch any exception that occurs during
+     * the execution and return it as a [GravatarResult.Failure].
+     *
+     * @param avatarId The ID of the avatar to update
+     * @param oauthToken The OAuth token to use for authentication
+     * @param avatarRating The new rating for the avatar
+     * @param altText The new alt text for the avatar
+     * @return The updated avatar
+     */
+    public suspend fun updateAvatarCatching(
+        avatarId: String,
+        oauthToken: String,
+        avatarRating: Avatar.Rating? = null,
+        altText: String? = null,
+    ): GravatarResult<Avatar, ErrorType> = runCatchingRequest {
+        updateAvatar(avatarId, oauthToken, avatarRating, altText)
+    }
 }
+
+private val Avatar.Rating.toRating: Rating
+    get() = when (this) {
+        Avatar.Rating.G -> Rating.G
+        Avatar.Rating.PG -> Rating.PG
+        Avatar.Rating.R -> Rating.R
+        Avatar.Rating.X -> Rating.X
+    }


### PR DESCRIPTION
Closes #237

### Description

The 2nd PR integrates the API request with the Avatar rating changes coming from the UI. 

I've made the code in a way that will be easily expandable by the next `altText` modification without adding much code in the ViewModel, since those are handled by one API request. 


https://github.com/user-attachments/assets/e103d589-fdc4-4de3-8f89-8c6a83fb8e4b

### Testing Steps
1. Run the QE
2. Tap on the Avatar's `...` button and then `Change rating`
3. Tap a different one that's not selected
4. Confirm the Snack was shown informing about successful change
5. Tap on the Avatar's `...` button and then `Change rating`
6. Confirm the rating from step 3 is selected
7. Mock the PATCH network request so it fails
8. Tap on the Avatar's `...` button and then `Change rating`
9. Tap a different one that's not selected
10. Confirm the Snack was shown informing about an error
11. Tap on the Avatar's `...` button and then `Change rating`
12.. Confirm the rating is still the same as it was before step 9
