### PR TITLE
Do not fire API call when rating and altText unchanged

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -79,6 +79,9 @@ internal class AvatarPickerViewModel(
     private fun updateAvatar(avatarId: String, rating: Avatar.Rating? = null, altText: String? = null) {
         viewModelScope.launch {
             val oldAvatar: Avatar? = _uiState.value.emailAvatars?.avatars?.find { it.imageId == avatarId }
+            if (!oldAvatar.shouldUpdateRating(rating) && !oldAvatar.shouldUpdateAltText(altText)) {
+                return@launch
+            }
             val updateType = AvatarUpdateType.RATING
             _uiState.update { currentState ->
                 val emailAvatars = currentState.emailAvatars?.copy(
@@ -447,6 +450,14 @@ internal class AvatarPickerViewModel(
                 else -> SectionError.Unknown
             }
         }
+
+    private fun Avatar?.shouldUpdateRating(newRating: Avatar.Rating?): Boolean {
+        return newRating != null && this?.rating != newRating
+    }
+
+    private fun Avatar?.shouldUpdateAltText(newAltText: String?): Boolean {
+        return newAltText != null && this?.altText != newAltText
+    }
 }
 
 internal class AvatarPickerViewModelFactory(


### PR DESCRIPTION
Closes #491 

### Description

We don't need to fire the PATCH API call when the rating and the alt text are the same. This PR implements an early check to return before making that call. 

### Testing Steps

1. Run the QE
2. Open the Avatar's menu and tap `Change rating`
3. Tap the already selected rating
4. Confirm no confirmation Snack is shown