### PR TITLE
QuickEditor: Don't start the OAuth flow automatically for new users

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/DataStoreProfileStorage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/DataStoreProfileStorage.kt
@@ -22,9 +22,9 @@ internal class DataStoreProfileStorage(
     }
 
     @Suppress("SwallowedException")
-    override suspend fun getLoginIntroShown(emailHast: String): Boolean = withContext(dispatcher) {
+    override suspend fun getLoginIntroShown(emailHash: String): Boolean = withContext(dispatcher) {
         try {
-            dataStore.data.first()[booleanPreferencesKey(emailHast.loginIntroShownKey)] ?: false
+            dataStore.data.first()[booleanPreferencesKey(emailHash.loginIntroShownKey)] ?: false
         } catch (exception: IOException) {
             false
         }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/DataStoreProfileStorage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/DataStoreProfileStorage.kt
@@ -1,0 +1,35 @@
+package com.gravatar.quickeditor.data.storage
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import java.io.IOException
+
+internal class DataStoreProfileStorage(
+    private val dataStore: DataStore<Preferences>,
+    private val dispatcher: CoroutineDispatcher,
+) : ProfileStorage {
+    private val loginIntroShownKeyPrefix = "login_intro_shown"
+
+    override suspend fun setLoginIntroShown(emailHash: String): Unit = withContext(dispatcher) {
+        dataStore.edit { preferences ->
+            preferences[booleanPreferencesKey(emailHash.loginIntroShownKey)] = true
+        }
+    }
+
+    @Suppress("SwallowedException")
+    override suspend fun getLoginIntroShown(emailHast: String): Boolean = withContext(dispatcher) {
+        try {
+            dataStore.data.first()[booleanPreferencesKey(emailHast.loginIntroShownKey)] ?: false
+        } catch (exception: IOException) {
+            false
+        }
+    }
+
+    private val String.loginIntroShownKey: String
+        get() = "${loginIntroShownKeyPrefix}_$this"
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/ProfileStorage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/ProfileStorage.kt
@@ -1,0 +1,7 @@
+package com.gravatar.quickeditor.data.storage
+
+internal interface ProfileStorage {
+    suspend fun setLoginIntroShown(emailHash: String)
+
+    suspend fun getLoginIntroShown(emailHast: String): Boolean
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/ProfileStorage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/ProfileStorage.kt
@@ -3,5 +3,5 @@ package com.gravatar.quickeditor.data.storage
 internal interface ProfileStorage {
     suspend fun setLoginIntroShown(emailHash: String)
 
-    suspend fun getLoginIntroShown(emailHast: String): Boolean
+    suspend fun getLoginIntroShown(emailHash: String): Boolean
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/DataStoreProfileStorageTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/DataStoreProfileStorageTest.kt
@@ -1,0 +1,77 @@
+package com.gravatar.quickeditor.data.storage
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.gravatar.quickeditor.ui.CoroutineTestRule
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class DataStoreProfileStorageTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule: CoroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var profileStorage: DataStoreProfileStorage
+
+    private val emailHash = "emailHash"
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile("test_preferences") },
+        )
+        profileStorage = DataStoreProfileStorage(
+            dataStore = dataStore,
+            dispatcher = testDispatcher,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        runBlocking {
+            dataStore.edit { it.clear() }
+        }
+    }
+
+    @Test
+    fun `given emailHash when setLoginIntroShown then loginIntroShown is true`() = runTest {
+        profileStorage.setLoginIntroShown(emailHash)
+
+        val key = booleanPreferencesKey("login_intro_shown_$emailHash")
+        val preferences = dataStore.data.first()
+        assertEquals(true, preferences[key])
+    }
+
+    @Test
+    fun `given login intro shown when getLoginIntroShown then return true`() = runTest {
+        val key = booleanPreferencesKey("login_intro_shown_$emailHash")
+        dataStore.edit { it[key] = true }
+
+        val result = profileStorage.getLoginIntroShown(emailHash)
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `given emailHash when getLoginIntroShown and key does not exist then return false`() = runTest {
+        val result = profileStorage.getLoginIntroShown(emailHash)
+        assertEquals(false, result)
+    }
+}


### PR DESCRIPTION
Closes #495

### Description

The 2nd PR for the new login intro page. This one implements the preferences storage to store the user flag whether a certain user (email) saw the login intro screen and decided to continue. 

Once such a flag is stored, the QE will automatically start the OAuth flow the next time it's required. 


https://github.com/user-attachments/assets/c2834745-4f7a-4b3d-b0af-a0bb40fcd8d2


### Testing Steps

1. Start the Demo app
2. Logout the user
3. Open the QE
4. Confirm the login intro is shown
5. Reopen the QE
6. Confirm the login intro is shown
7. Tap Continue and finish the OAuth flow
8. Clode the QE
9. Logout the user
10. Open the QE
11. Confirm the OAuth flow was started automatically
