### PR TITLE
QuickEditor: Only invoke onAvatarSelected when selected avatar is deleted

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -396,7 +396,7 @@ internal class AvatarPickerViewModel(
     }
 
     private suspend fun notifyAvatarDeletedSuccessfully(isSelectedAvatar: Boolean) {
-        _actions.send(AvatarPickerAction.AvatarSelected)
+        if (isSelectedAvatar) _actions.send(AvatarPickerAction.AvatarSelected)
         _uiState.update { currentState ->
             currentState.copy(
                 avatarUpdates = if (isSelectedAvatar) {

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -846,6 +846,9 @@ class AvatarPickerViewModelTest {
                 awaitItem(),
             )
         }
+        viewModel.actions.test {
+            assertEquals(AvatarPickerAction.AvatarSelected, awaitItem())
+        }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -883,7 +886,7 @@ class AvatarPickerViewModelTest {
             )
         }
         viewModel.actions.test {
-            assertEquals(AvatarPickerAction.AvatarSelected, awaitItem())
+            expectNoEvents()
         }
     }
 


### PR DESCRIPTION
Closes #507

### Description

The `onAvatarSelected` callback would be invoked regardless of whether the deleted avatar was selected or not. This is not correct, we should only invoke it for the selected avatar.

### Testing Steps
1. Run the QE
2. Delete an unselected Avatar
3. Confirm the callback was not invoked (there shouldn't be an update in the demo app and no snack)