### PR TITLE
QuickEditor: AltText - Save the avatars list locally in the AvatarsRespository instead of in the `AvatarPickerViewModel`

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
@@ -91,12 +91,13 @@ internal class QuickEditorContainer private constructor(
         FileUtils(context)
     }
 
-    val avatarRepository: AvatarRepository
-        get() = AvatarRepository(
+    val avatarRepository: AvatarRepository by lazy {
+        AvatarRepository(
             avatarService = avatarService,
             tokenStorage = tokenStorage,
             dispatcher = Dispatchers.IO,
         )
+    }
 
     val imageDownloader: ImageDownloader by lazy { ImageDownloader(context = context) }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/QuickEditorContainer.kt
@@ -13,6 +13,7 @@ import com.gravatar.quickeditor.data.FileUtils
 import com.gravatar.quickeditor.data.ImageDownloader
 import com.gravatar.quickeditor.data.datastore.createEncryptedFileWithFallbackReset
 import com.gravatar.quickeditor.data.repository.AvatarRepository
+import com.gravatar.quickeditor.data.storage.AvatarStorage
 import com.gravatar.quickeditor.data.storage.DataStoreProfileStorage
 import com.gravatar.quickeditor.data.storage.DataStoreTokenStorage
 import com.gravatar.quickeditor.data.storage.InMemoryTokenStorage
@@ -91,13 +92,17 @@ internal class QuickEditorContainer private constructor(
         FileUtils(context)
     }
 
-    val avatarRepository: AvatarRepository by lazy {
-        AvatarRepository(
+    private val avatarStorage: AvatarStorage by lazy {
+        AvatarStorage()
+    }
+
+    val avatarRepository: AvatarRepository
+        get() = AvatarRepository(
             avatarService = avatarService,
             tokenStorage = tokenStorage,
+            avatarStorage = avatarStorage,
             dispatcher = Dispatchers.IO,
         )
-    }
 
     val imageDownloader: ImageDownloader by lazy { ImageDownloader(context = context) }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -9,6 +9,8 @@ import com.gravatar.services.AvatarService
 import com.gravatar.services.GravatarResult
 import com.gravatar.types.Email
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.withContext
 
 internal class AvatarRepository(
@@ -16,18 +18,26 @@ internal class AvatarRepository(
     private val tokenStorage: TokenStorage,
     private val dispatcher: CoroutineDispatcher,
 ) {
+    fun getAvatarsFlow(email: Email) = avatarsFlow(email).asSharedFlow()
+
+    private val avatarsFlows = mutableMapOf<String, MutableSharedFlow<EmailAvatars>>()
+
+    private fun avatarsFlow(email: Email): MutableSharedFlow<EmailAvatars> =
+        avatarsFlows.getOrPut(email.hash().toString()) { MutableSharedFlow(replay = 1) }
+
     suspend fun getAvatars(email: Email): GravatarResult<EmailAvatars, QuickEditorError> = withContext(dispatcher) {
         val token = tokenStorage.getToken(email.hash().toString())
         token?.let {
             when (val avatarsResult = avatarService.retrieveCatching(token, email.hash())) {
                 is GravatarResult.Success -> {
-                    val avatars = avatarsResult.value
-                    GravatarResult.Success(
+                    val emailAvatars = avatarsResult.value.let { avatars ->
                         EmailAvatars(
                             avatars,
                             avatars.firstOrNull { it.selected == true }?.imageId,
-                        ),
-                    )
+                        )
+                    }
+                    avatarsFlow(email).emit(emailAvatars)
+                    GravatarResult.Success(emailAvatars)
                 }
 
                 is GravatarResult.Failure -> {
@@ -84,10 +94,32 @@ internal class AvatarRepository(
         val token = tokenStorage.getToken(email.hash().toString())
         token?.let {
             when (val result = avatarService.updateAvatarCatching(avatarId, token, rating, altText)) {
-                is GravatarResult.Success -> GravatarResult.Success(result.value)
+                is GravatarResult.Success -> {
+                    updateAvatarFlow(email, result.value)
+                    GravatarResult.Success(result.value)
+                }
+
                 is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
             }
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
+    }
+
+    private suspend fun updateAvatarFlow(email: Email, avatarToUpdate: Avatar) {
+        avatarsFlow(email).let { avatarsFlow ->
+            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.copy(
+                    avatars = it.avatars.map { avatar ->
+                        if (avatar.imageId == avatarToUpdate.imageId) {
+                            avatarToUpdate
+                        } else {
+                            avatar
+                        }
+                    },
+                )
+            }
+
+            emailAvatars?.let { avatarsFlow.emit(it) }
+        }
     }
 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -133,7 +133,25 @@ internal class AvatarRepository(
         val token = tokenStorage.getToken(email.hash().toString())
         token?.let {
             when (val result = avatarService.deleteAvatarCatching(avatarId, token)) {
-                is GravatarResult.Success -> GravatarResult.Success(Unit)
+                is GravatarResult.Success -> {
+                    avatarsFlow(email).let { avatarsFlow ->
+                        val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                            it.copy(
+                                avatars = it.avatars.filter { avatar ->
+                                    avatar.imageId != avatarId
+                                },
+                                selectedAvatarId = if (it.selectedAvatarId == avatarId) {
+                                    null
+                                } else {
+                                    it.selectedAvatarId
+                                },
+                            )
+                        }
+
+                        emailAvatars?.let { avatarsFlow.emit(it) }
+                    }
+                    GravatarResult.Success(Unit)
+                }
                 is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
             }
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -21,19 +21,13 @@ internal class AvatarRepository(
 ) {
     fun getAvatarsFlow(email: Email) = avatarStorage.avatarsFlow(email).asSharedFlow()
 
-    suspend fun getAvatars(email: Email): GravatarResult<EmailAvatars, QuickEditorError> = withContext(dispatcher) {
+    suspend fun getAvatars(email: Email): GravatarResult<List<Avatar>, QuickEditorError> = withContext(dispatcher) {
         val token = tokenStorage.getToken(email.hash().toString())
         token?.let {
             when (val avatarsResult = avatarService.retrieveCatching(token, email.hash())) {
                 is GravatarResult.Success -> {
-                    val emailAvatars = avatarsResult.value.let { avatars ->
-                        EmailAvatars(
-                            avatars,
-                            avatars.firstOrNull { it.selected == true }?.imageId,
-                        )
-                    }
-                    avatarStorage.storeAvatars(emailAvatars, email)
-                    GravatarResult.Success(emailAvatars)
+                    avatarStorage.storeAvatars(avatarsResult.value, email)
+                    GravatarResult.Success(avatarsResult.value)
                 }
 
                 is GravatarResult.Failure -> {
@@ -111,8 +105,3 @@ internal class AvatarRepository(
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
     }
 }
-
-internal data class EmailAvatars(
-    val avatars: List<Avatar>,
-    val selectedAvatarId: String?,
-)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -21,7 +21,7 @@ internal class AvatarRepository(
 ) {
     fun getAvatarsFlow(email: Email) = avatarStorage.avatarsFlow(email).asSharedFlow()
 
-    suspend fun getAvatars(email: Email): GravatarResult<List<Avatar>, QuickEditorError> = withContext(dispatcher) {
+    suspend fun refreshAvatars(email: Email): GravatarResult<List<Avatar>, QuickEditorError> = withContext(dispatcher) {
         val token = tokenStorage.getToken(email.hash().toString())
         token?.let {
             when (val avatarsResult = avatarService.retrieveCatching(token, email.hash())) {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -7,6 +7,7 @@ import com.gravatar.quickeditor.data.storage.TokenStorage
 import com.gravatar.quickeditor.ui.avatarpicker.copy
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.services.AvatarService
+import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import com.gravatar.types.Email
 import kotlinx.coroutines.CoroutineDispatcher
@@ -55,22 +56,7 @@ internal class AvatarRepository(
         token?.let {
             when (val result = avatarService.setAvatarCatching(email.hash().toString(), avatarId, token)) {
                 is GravatarResult.Success -> {
-                    avatarsFlow(email).let { avatarsFlow ->
-                        val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                            it.copy(
-                                avatars = it.avatars.map { avatar ->
-                                    if (avatar.imageId == avatarId) {
-                                        avatar.copy(selected = true)
-                                    } else {
-                                        avatar.copy(selected = false)
-                                    }
-                                },
-                                selectedAvatarId = avatarId,
-                            )
-                        }
-
-                        emailAvatars?.let { avatarsFlow.emit(it) }
-                    }
+                    updateAvatarSelectionLocally(email, avatarId)
                     GravatarResult.Success(Unit)
                 }
 
@@ -88,37 +74,7 @@ internal class AvatarRepository(
                     val result = avatarService.uploadCatching(avatarUri.toFile(), token, hash)
                 ) {
                     is GravatarResult.Success -> {
-                        avatarsFlow(email).let { avatarsFlow ->
-                            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                                val avatars = buildList {
-                                    add(result.value)
-                                    it.avatars.filter { avatar ->
-                                        avatar.imageId != result.value.imageId
-                                    }.let { avatars ->
-                                        addAll(
-                                            if (result.value.selected == true) {
-                                                avatars.map { avatar ->
-                                                    avatar.copy(selected = false)
-                                                }
-                                            } else {
-                                                avatars
-                                            },
-                                        )
-                                    }
-                                }
-                                it.copy(
-                                    avatars = avatars,
-                                    selectedAvatarId = if (result.value.selected == true) {
-                                        result.value.imageId
-                                    } else {
-                                        it.selectedAvatarId
-                                    },
-                                )
-                            }
-
-                            emailAvatars?.let { avatarsFlow.emit(it) }
-                        }
-
+                        updateAvatarUploadedLocally(email, result)
                         GravatarResult.Success(result.value)
                     }
 
@@ -134,22 +90,7 @@ internal class AvatarRepository(
         token?.let {
             when (val result = avatarService.deleteAvatarCatching(avatarId, token)) {
                 is GravatarResult.Success -> {
-                    avatarsFlow(email).let { avatarsFlow ->
-                        val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                            it.copy(
-                                avatars = it.avatars.filter { avatar ->
-                                    avatar.imageId != avatarId
-                                },
-                                selectedAvatarId = if (it.selectedAvatarId == avatarId) {
-                                    null
-                                } else {
-                                    it.selectedAvatarId
-                                },
-                            )
-                        }
-
-                        emailAvatars?.let { avatarsFlow.emit(it) }
-                    }
+                    deleteAvatarLocally(email, avatarId)
                     GravatarResult.Success(Unit)
                 }
                 is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
@@ -167,7 +108,7 @@ internal class AvatarRepository(
         token?.let {
             when (val result = avatarService.updateAvatarCatching(avatarId, token, rating, altText)) {
                 is GravatarResult.Success -> {
-                    updateAvatarFlow(email, result.value)
+                    updateAvatarLocally(email, result.value)
                     GravatarResult.Success(result.value)
                 }
 
@@ -176,7 +117,78 @@ internal class AvatarRepository(
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
     }
 
-    private suspend fun updateAvatarFlow(email: Email, avatarToUpdate: Avatar) {
+    private suspend fun updateAvatarSelectionLocally(email: Email, avatarId: String) {
+        avatarsFlow(email).let { avatarsFlow ->
+            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.copy(
+                    avatars = it.avatars.map { avatar ->
+                        if (avatar.imageId == avatarId) {
+                            avatar.copy(selected = true)
+                        } else {
+                            avatar.copy(selected = false)
+                        }
+                    },
+                    selectedAvatarId = avatarId,
+                )
+            }
+
+            emailAvatars?.let { avatarsFlow.emit(it) }
+        }
+    }
+
+    private suspend fun updateAvatarUploadedLocally(email: Email, result: GravatarResult.Success<Avatar, ErrorType>) {
+        avatarsFlow(email).let { avatarsFlow ->
+            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                val avatars = buildList {
+                    add(result.value)
+                    it.avatars.filter { avatar ->
+                        avatar.imageId != result.value.imageId
+                    }.let { avatars ->
+                        addAll(
+                            if (result.value.selected == true) {
+                                avatars.map { avatar ->
+                                    avatar.copy(selected = false)
+                                }
+                            } else {
+                                avatars
+                            },
+                        )
+                    }
+                }
+                it.copy(
+                    avatars = avatars,
+                    selectedAvatarId = if (result.value.selected == true) {
+                        result.value.imageId
+                    } else {
+                        it.selectedAvatarId
+                    },
+                )
+            }
+
+            emailAvatars?.let { avatarsFlow.emit(it) }
+        }
+    }
+
+    private suspend fun deleteAvatarLocally(email: Email, avatarId: String) {
+        avatarsFlow(email).let { avatarsFlow ->
+            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.copy(
+                    avatars = it.avatars.filter { avatar ->
+                        avatar.imageId != avatarId
+                    },
+                    selectedAvatarId = if (it.selectedAvatarId == avatarId) {
+                        null
+                    } else {
+                        it.selectedAvatarId
+                    },
+                )
+            }
+
+            emailAvatars?.let { avatarsFlow.emit(it) }
+        }
+    }
+
+    private suspend fun updateAvatarLocally(email: Email, avatarToUpdate: Avatar) {
         avatarsFlow(email).let { avatarsFlow ->
             val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
                 it.copy(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.core.net.toFile
 import com.gravatar.quickeditor.data.models.QuickEditorError
 import com.gravatar.quickeditor.data.storage.TokenStorage
+import com.gravatar.quickeditor.ui.avatarpicker.copy
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.services.AvatarService
 import com.gravatar.services.GravatarResult
@@ -53,7 +54,25 @@ internal class AvatarRepository(
         val token = tokenStorage.getToken(email.hash().toString())
         token?.let {
             when (val result = avatarService.setAvatarCatching(email.hash().toString(), avatarId, token)) {
-                is GravatarResult.Success -> GravatarResult.Success(Unit)
+                is GravatarResult.Success -> {
+                    avatarsFlow(email).let { avatarsFlow ->
+                        val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                            it.copy(
+                                avatars = it.avatars.map { avatar ->
+                                    if (avatar.imageId == avatarId) {
+                                        avatar.copy(selected = true)
+                                    } else {
+                                        avatar.copy(selected = false)
+                                    }
+                                },
+                                selectedAvatarId = avatarId,
+                            )
+                        }
+
+                        emailAvatars?.let { avatarsFlow.emit(it) }
+                    }
+                    GravatarResult.Success(Unit)
+                }
                 is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
             }
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -44,7 +44,7 @@ internal class AvatarRepository(
         token?.let {
             when (val result = avatarService.setAvatarCatching(email.hash().toString(), avatarId, token)) {
                 is GravatarResult.Success -> {
-                    avatarStorage.markAvatarAsSelected(email, avatarId)
+                    avatarStorage.selectAvatar(avatarId = avatarId, email = email)
                     GravatarResult.Success(Unit)
                 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -73,6 +73,7 @@ internal class AvatarRepository(
                     }
                     GravatarResult.Success(Unit)
                 }
+
                 is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
             }
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
@@ -86,7 +87,41 @@ internal class AvatarRepository(
                 when (
                     val result = avatarService.uploadCatching(avatarUri.toFile(), token, hash)
                 ) {
-                    is GravatarResult.Success -> GravatarResult.Success(result.value)
+                    is GravatarResult.Success -> {
+                        avatarsFlow(email).let { avatarsFlow ->
+                            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                                val avatars = buildList {
+                                    add(result.value)
+                                    it.avatars.filter { avatar ->
+                                        avatar.imageId != result.value.imageId
+                                    }.let { avatars ->
+                                        addAll(
+                                            if (result.value.selected == true) {
+                                                avatars.map { avatar ->
+                                                    avatar.copy(selected = false)
+                                                }
+                                            } else {
+                                                avatars
+                                            },
+                                        )
+                                    }
+                                }
+                                it.copy(
+                                    avatars = avatars,
+                                    selectedAvatarId = if (result.value.selected == true) {
+                                        result.value.imageId
+                                    } else {
+                                        it.selectedAvatarId
+                                    },
+                                )
+                            }
+
+                            emailAvatars?.let { avatarsFlow.emit(it) }
+                        }
+
+                        GravatarResult.Success(result.value)
+                    }
+
                     is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
                 }
             } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -19,7 +19,7 @@ internal class AvatarRepository(
     private val avatarStorage: AvatarStorage,
     private val dispatcher: CoroutineDispatcher,
 ) {
-    fun getAvatarsFlow(email: Email) = avatarStorage.avatarsFlow(email).asSharedFlow()
+    fun getAvatars(email: Email) = avatarStorage.avatarsFlow(email).asSharedFlow()
 
     suspend fun refreshAvatars(email: Email): GravatarResult<List<Avatar>, QuickEditorError> = withContext(dispatcher) {
         val token = tokenStorage.getToken(email.hash().toString())

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -3,29 +3,23 @@ package com.gravatar.quickeditor.data.repository
 import android.net.Uri
 import androidx.core.net.toFile
 import com.gravatar.quickeditor.data.models.QuickEditorError
+import com.gravatar.quickeditor.data.storage.AvatarStorage
 import com.gravatar.quickeditor.data.storage.TokenStorage
-import com.gravatar.quickeditor.ui.avatarpicker.copy
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.services.AvatarService
-import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import com.gravatar.types.Email
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.withContext
 
 internal class AvatarRepository(
     private val avatarService: AvatarService,
     private val tokenStorage: TokenStorage,
+    private val avatarStorage: AvatarStorage,
     private val dispatcher: CoroutineDispatcher,
 ) {
-    fun getAvatarsFlow(email: Email) = avatarsFlow(email).asSharedFlow()
-
-    private val avatarsFlows = mutableMapOf<String, MutableSharedFlow<EmailAvatars>>()
-
-    private fun avatarsFlow(email: Email): MutableSharedFlow<EmailAvatars> =
-        avatarsFlows.getOrPut(email.hash().toString()) { MutableSharedFlow(replay = 1) }
+    fun getAvatarsFlow(email: Email) = avatarStorage.avatarsFlow(email).asSharedFlow()
 
     suspend fun getAvatars(email: Email): GravatarResult<EmailAvatars, QuickEditorError> = withContext(dispatcher) {
         val token = tokenStorage.getToken(email.hash().toString())
@@ -38,7 +32,7 @@ internal class AvatarRepository(
                             avatars.firstOrNull { it.selected == true }?.imageId,
                         )
                     }
-                    avatarsFlow(email).emit(emailAvatars)
+                    avatarStorage.storeAvatars(emailAvatars, email)
                     GravatarResult.Success(emailAvatars)
                 }
 
@@ -56,7 +50,7 @@ internal class AvatarRepository(
         token?.let {
             when (val result = avatarService.setAvatarCatching(email.hash().toString(), avatarId, token)) {
                 is GravatarResult.Success -> {
-                    updateAvatarSelectionLocally(email, avatarId)
+                    avatarStorage.markAvatarAsSelected(email, avatarId)
                     GravatarResult.Success(Unit)
                 }
 
@@ -74,7 +68,7 @@ internal class AvatarRepository(
                     val result = avatarService.uploadCatching(avatarUri.toFile(), token, hash)
                 ) {
                     is GravatarResult.Success -> {
-                        updateAvatarUploadedLocally(email, result)
+                        avatarStorage.addAvatar(email, result.value)
                         GravatarResult.Success(result.value)
                     }
 
@@ -90,7 +84,7 @@ internal class AvatarRepository(
         token?.let {
             when (val result = avatarService.deleteAvatarCatching(avatarId, token)) {
                 is GravatarResult.Success -> {
-                    deleteAvatarLocally(email, avatarId)
+                    avatarStorage.deleteAvatar(email, avatarId)
                     GravatarResult.Success(Unit)
                 }
                 is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
@@ -108,102 +102,13 @@ internal class AvatarRepository(
         token?.let {
             when (val result = avatarService.updateAvatarCatching(avatarId, token, rating, altText)) {
                 is GravatarResult.Success -> {
-                    updateAvatarLocally(email, result.value)
+                    avatarStorage.updateAvatar(email, result.value)
                     GravatarResult.Success(result.value)
                 }
 
                 is GravatarResult.Failure -> GravatarResult.Failure(QuickEditorError.Request(result.error))
             }
         } ?: GravatarResult.Failure(QuickEditorError.TokenNotFound)
-    }
-
-    private suspend fun updateAvatarSelectionLocally(email: Email, avatarId: String) {
-        avatarsFlow(email).let { avatarsFlow ->
-            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                it.copy(
-                    avatars = it.avatars.map { avatar ->
-                        if (avatar.imageId == avatarId) {
-                            avatar.copy(selected = true)
-                        } else {
-                            avatar.copy(selected = false)
-                        }
-                    },
-                    selectedAvatarId = avatarId,
-                )
-            }
-
-            emailAvatars?.let { avatarsFlow.emit(it) }
-        }
-    }
-
-    private suspend fun updateAvatarUploadedLocally(email: Email, result: GravatarResult.Success<Avatar, ErrorType>) {
-        avatarsFlow(email).let { avatarsFlow ->
-            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                val avatars = buildList {
-                    add(result.value)
-                    it.avatars.filter { avatar ->
-                        avatar.imageId != result.value.imageId
-                    }.let { avatars ->
-                        addAll(
-                            if (result.value.selected == true) {
-                                avatars.map { avatar ->
-                                    avatar.copy(selected = false)
-                                }
-                            } else {
-                                avatars
-                            },
-                        )
-                    }
-                }
-                it.copy(
-                    avatars = avatars,
-                    selectedAvatarId = if (result.value.selected == true) {
-                        result.value.imageId
-                    } else {
-                        it.selectedAvatarId
-                    },
-                )
-            }
-
-            emailAvatars?.let { avatarsFlow.emit(it) }
-        }
-    }
-
-    private suspend fun deleteAvatarLocally(email: Email, avatarId: String) {
-        avatarsFlow(email).let { avatarsFlow ->
-            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                it.copy(
-                    avatars = it.avatars.filter { avatar ->
-                        avatar.imageId != avatarId
-                    },
-                    selectedAvatarId = if (it.selectedAvatarId == avatarId) {
-                        null
-                    } else {
-                        it.selectedAvatarId
-                    },
-                )
-            }
-
-            emailAvatars?.let { avatarsFlow.emit(it) }
-        }
-    }
-
-    private suspend fun updateAvatarLocally(email: Email, avatarToUpdate: Avatar) {
-        avatarsFlow(email).let { avatarsFlow ->
-            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                it.copy(
-                    avatars = it.avatars.map { avatar ->
-                        if (avatar.imageId == avatarToUpdate.imageId) {
-                            avatarToUpdate
-                        } else {
-                            avatar
-                        }
-                    },
-                )
-            }
-
-            emailAvatars?.let { avatarsFlow.emit(it) }
-        }
     }
 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/AvatarStorage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/AvatarStorage.kt
@@ -15,7 +15,7 @@ internal class AvatarStorage {
         avatarsFlow(email).emit(avatars)
     }
 
-    internal suspend fun markAvatarAsSelected(email: Email, avatarId: String) {
+    internal suspend fun selectAvatar(avatarId: String, email: Email) {
         avatarsFlow(email).let { avatarsFlow ->
             val avatars = avatarsFlow.replayCache.lastOrNull()?.let {
                 it.map { avatar ->

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/AvatarStorage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/AvatarStorage.kt
@@ -1,0 +1,107 @@
+package com.gravatar.quickeditor.data.storage
+
+import com.gravatar.quickeditor.data.repository.EmailAvatars
+import com.gravatar.quickeditor.ui.avatarpicker.copy
+import com.gravatar.restapi.models.Avatar
+import com.gravatar.types.Email
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+internal class AvatarStorage {
+    private val avatarsFlows = mutableMapOf<String, MutableSharedFlow<EmailAvatars>>()
+
+    internal fun avatarsFlow(email: Email): MutableSharedFlow<EmailAvatars> =
+        avatarsFlows.getOrPut(email.hash().toString()) { MutableSharedFlow(replay = 1) }
+
+    internal suspend fun storeAvatars(emailAvatars: EmailAvatars, email: Email) {
+        avatarsFlow(email).emit(emailAvatars)
+    }
+
+    internal suspend fun markAvatarAsSelected(email: Email, avatarId: String) {
+        avatarsFlow(email).let { avatarsFlow ->
+            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.copy(
+                    avatars = it.avatars.map { avatar ->
+                        if (avatar.imageId == avatarId) {
+                            avatar.copy(selected = true)
+                        } else {
+                            avatar.copy(selected = false)
+                        }
+                    },
+                    selectedAvatarId = avatarId,
+                )
+            }
+
+            emailAvatars?.let { avatarsFlow.emit(it) }
+        }
+    }
+
+    internal suspend fun addAvatar(email: Email, avatar: Avatar) {
+        avatarsFlow(email).let { avatarsFlow ->
+            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                val avatars = buildList {
+                    add(avatar)
+                    it.avatars.filter { avatarToFilter ->
+                        avatarToFilter.imageId != avatar.imageId
+                    }.let { avatars ->
+                        addAll(
+                            if (avatar.selected == true) {
+                                avatars.map { avatar ->
+                                    avatar.copy(selected = false)
+                                }
+                            } else {
+                                avatars
+                            },
+                        )
+                    }
+                }
+                it.copy(
+                    avatars = avatars,
+                    selectedAvatarId = if (avatar.selected == true) {
+                        avatar.imageId
+                    } else {
+                        it.selectedAvatarId
+                    },
+                )
+            }
+
+            emailAvatars?.let { avatarsFlow.emit(it) }
+        }
+    }
+
+    internal suspend fun deleteAvatar(email: Email, avatarId: String) {
+        avatarsFlow(email).let { avatarsFlow ->
+            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.copy(
+                    avatars = it.avatars.filter { avatar ->
+                        avatar.imageId != avatarId
+                    },
+                    selectedAvatarId = if (it.selectedAvatarId == avatarId) {
+                        null
+                    } else {
+                        it.selectedAvatarId
+                    },
+                )
+            }
+
+            emailAvatars?.let { avatarsFlow.emit(it) }
+        }
+    }
+
+    internal suspend fun updateAvatar(email: Email, avatarToUpdate: Avatar) {
+        avatarsFlow(email).let { avatarsFlow ->
+            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.copy(
+                    avatars = it.avatars.map { avatar ->
+                        if (avatar.imageId == avatarToUpdate.imageId) {
+                            avatarToUpdate
+                        } else {
+                            avatar
+                        }
+                    },
+                )
+            }
+
+            emailAvatars?.let { avatarsFlow.emit(it) }
+        }
+    }
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/AvatarStorage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/AvatarStorage.kt
@@ -1,46 +1,42 @@
 package com.gravatar.quickeditor.data.storage
 
-import com.gravatar.quickeditor.data.repository.EmailAvatars
 import com.gravatar.quickeditor.ui.avatarpicker.copy
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.types.Email
 import kotlinx.coroutines.flow.MutableSharedFlow
 
 internal class AvatarStorage {
-    private val avatarsFlows = mutableMapOf<String, MutableSharedFlow<EmailAvatars>>()
+    private val avatarsFlows = mutableMapOf<String, MutableSharedFlow<List<Avatar>>>()
 
-    internal fun avatarsFlow(email: Email): MutableSharedFlow<EmailAvatars> =
+    internal fun avatarsFlow(email: Email): MutableSharedFlow<List<Avatar>> =
         avatarsFlows.getOrPut(email.hash().toString()) { MutableSharedFlow(replay = 1) }
 
-    internal suspend fun storeAvatars(emailAvatars: EmailAvatars, email: Email) {
-        avatarsFlow(email).emit(emailAvatars)
+    internal suspend fun storeAvatars(avatars: List<Avatar>, email: Email) {
+        avatarsFlow(email).emit(avatars)
     }
 
     internal suspend fun markAvatarAsSelected(email: Email, avatarId: String) {
         avatarsFlow(email).let { avatarsFlow ->
-            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                it.copy(
-                    avatars = it.avatars.map { avatar ->
-                        if (avatar.imageId == avatarId) {
-                            avatar.copy(selected = true)
-                        } else {
-                            avatar.copy(selected = false)
-                        }
-                    },
-                    selectedAvatarId = avatarId,
-                )
+            val avatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.map { avatar ->
+                    if (avatar.imageId == avatarId) {
+                        avatar.copy(selected = true)
+                    } else {
+                        avatar.copy(selected = false)
+                    }
+                }
             }
 
-            emailAvatars?.let { avatarsFlow.emit(it) }
+            avatars?.let { avatarsFlow.emit(it) }
         }
     }
 
     internal suspend fun addAvatar(email: Email, avatar: Avatar) {
         avatarsFlow(email).let { avatarsFlow ->
-            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                val avatars = buildList {
+            val avatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                buildList {
                     add(avatar)
-                    it.avatars.filter { avatarToFilter ->
+                    it.filter { avatarToFilter ->
                         avatarToFilter.imageId != avatar.imageId
                     }.let { avatars ->
                         addAll(
@@ -54,54 +50,37 @@ internal class AvatarStorage {
                         )
                     }
                 }
-                it.copy(
-                    avatars = avatars,
-                    selectedAvatarId = if (avatar.selected == true) {
-                        avatar.imageId
-                    } else {
-                        it.selectedAvatarId
-                    },
-                )
             }
 
-            emailAvatars?.let { avatarsFlow.emit(it) }
+            avatars?.let { avatarsFlow.emit(it) }
         }
     }
 
     internal suspend fun deleteAvatar(email: Email, avatarId: String) {
         avatarsFlow(email).let { avatarsFlow ->
-            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                it.copy(
-                    avatars = it.avatars.filter { avatar ->
-                        avatar.imageId != avatarId
-                    },
-                    selectedAvatarId = if (it.selectedAvatarId == avatarId) {
-                        null
-                    } else {
-                        it.selectedAvatarId
-                    },
-                )
+            val avatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.filter { avatar ->
+                    avatar.imageId != avatarId
+                }
             }
 
-            emailAvatars?.let { avatarsFlow.emit(it) }
+            avatars?.let { avatarsFlow.emit(it) }
         }
     }
 
     internal suspend fun updateAvatar(email: Email, avatarToUpdate: Avatar) {
         avatarsFlow(email).let { avatarsFlow ->
-            val emailAvatars = avatarsFlow.replayCache.lastOrNull()?.let {
-                it.copy(
-                    avatars = it.avatars.map { avatar ->
-                        if (avatar.imageId == avatarToUpdate.imageId) {
-                            avatarToUpdate
-                        } else {
-                            avatar
-                        }
-                    },
-                )
+            val avatars = avatarsFlow.replayCache.lastOrNull()?.let {
+                it.map { avatar ->
+                    if (avatar.imageId == avatarToUpdate.imageId) {
+                        avatarToUpdate
+                    } else {
+                        avatar
+                    }
+                }
             }
 
-            emailAvatars?.let { avatarsFlow.emit(it) }
+            avatars?.let { avatarsFlow.emit(it) }
         }
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -51,7 +51,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gravatar.extensions.defaultProfile
 import com.gravatar.quickeditor.R
-import com.gravatar.quickeditor.data.repository.EmailAvatars
 import com.gravatar.quickeditor.ui.components.AlertBanner
 import com.gravatar.quickeditor.ui.components.AvatarDeletionConfirmationDialog
 import com.gravatar.quickeditor.ui.components.AvatarOption

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerUiState.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerUiState.kt
@@ -1,7 +1,6 @@
 package com.gravatar.quickeditor.ui.avatarpicker
 
 import android.net.Uri
-import com.gravatar.quickeditor.data.repository.EmailAvatars
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.restapi.models.Profile

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -296,7 +296,7 @@ internal class AvatarPickerViewModel(
         if (showLoading) {
             _uiState.update { currentState -> currentState.copy(isLoading = true) }
         }
-        when (val result = avatarRepository.getAvatars(email)) {
+        when (val result = avatarRepository.refreshAvatars(email)) {
             is GravatarResult.Success -> {
                 _uiState.update { currentState ->
                     val emailAvatars = result.value.toEmailAvatars()

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -51,6 +51,7 @@ internal class AvatarPickerViewModel(
     init {
         refresh()
         nonAvatarSelectedAlertObserver()
+        avatarsObserver()
     }
 
     fun onEvent(event: AvatarPickerEvent) {
@@ -435,6 +436,16 @@ internal class AvatarPickerViewModel(
             .launchIn(viewModelScope)
     }
 
+    private fun avatarsObserver() {
+        viewModelScope.launch {
+            avatarRepository.getAvatarsFlow(email).collect { emailAvatars ->
+                _uiState.update {
+                    it.copy(emailAvatars = emailAvatars)
+                }
+            }
+        }
+    }
+
     private fun launchAltTextEditor(avatarId: String) {
         viewModelScope.launch {
             _uiState.value.emailAvatars?.avatars?.firstOrNull { it.imageId == avatarId }?.let { avatar ->
@@ -483,13 +494,13 @@ private inline fun <T> List<T>.indexOfFirstOrNull(predicate: (T) -> Boolean): In
     return if (index == -1) null else index
 }
 
-internal fun Avatar.copy(rating: Avatar.Rating? = null): Avatar {
+internal fun Avatar.copy(rating: Avatar.Rating? = null, altText: String? = null): Avatar {
     return Avatar {
         imageId = this@copy.imageId
         imageUrl = this@copy.imageUrl
         updatedDate = this@copy.updatedDate
         selected = this@copy.selected
-        this.altText = this@copy.altText
+        this.altText = altText ?: this@copy.altText
         this.rating = rating ?: this@copy.rating
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -236,22 +236,8 @@ internal class AvatarPickerViewModel(
                         _actions.send(AvatarPickerAction.AvatarSelected)
                     }
                     _uiState.update { currentState ->
-                        val emailAvatars = currentState.emailAvatars?.copy(
-                            avatars = buildList {
-                                add(avatar)
-                                addAll(
-                                    currentState.emailAvatars.avatars.filter { it.imageId != avatar.imageId },
-                                )
-                            },
-                            selectedAvatarId = if (avatar.selected == true) {
-                                avatar.imageId
-                            } else {
-                                currentState.emailAvatars.selectedAvatarId
-                            },
-                        )
                         currentState.copy(
                             uploadingAvatar = null,
-                            emailAvatars = emailAvatars,
                             scrollToIndex = null,
                             avatarUpdates = if (avatar.selected == true) {
                                 currentState.avatarUpdates.inc()

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -422,7 +422,7 @@ internal class AvatarPickerViewModel(
 
     private fun collectAvatars() {
         viewModelScope.launch {
-            avatarRepository.getAvatarsFlow(email).collect { avatars ->
+            avatarRepository.getAvatars(email).collect { avatars ->
                 _uiState.update {
                     it.copy(emailAvatars = avatars.toEmailAvatars())
                 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -192,9 +192,7 @@ internal class AvatarPickerViewModel(
                 when (avatarRepository.selectAvatar(email, avatarId)) {
                     is GravatarResult.Success -> {
                         _uiState.update { currentState ->
-                            val emailAvatars = currentState.emailAvatars?.copy(selectedAvatarId = avatarId)
                             currentState.copy(
-                                emailAvatars = emailAvatars,
                                 selectingAvatarId = null,
                                 avatarUpdates = currentState.avatarUpdates.inc(),
                             )
@@ -494,12 +492,12 @@ private inline fun <T> List<T>.indexOfFirstOrNull(predicate: (T) -> Boolean): In
     return if (index == -1) null else index
 }
 
-internal fun Avatar.copy(rating: Avatar.Rating? = null, altText: String? = null): Avatar {
+internal fun Avatar.copy(rating: Avatar.Rating? = null, altText: String? = null, selected: Boolean? = null): Avatar {
     return Avatar {
         imageId = this@copy.imageId
         imageUrl = this@copy.imageUrl
         updatedDate = this@copy.updatedDate
-        selected = this@copy.selected
+        this.selected = selected ?: this@copy.selected
         this.altText = altText ?: this@copy.altText
         this.rating = rating ?: this@copy.rating
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -299,7 +299,7 @@ internal class AvatarPickerViewModel(
         when (val result = avatarRepository.getAvatars(email)) {
             is GravatarResult.Success -> {
                 _uiState.update { currentState ->
-                    val emailAvatars = result.value
+                    val emailAvatars = result.value.toEmailAvatars()
                     currentState.copy(
                         emailAvatars = emailAvatars,
                         scrollToIndex = if (scrollToSelected && emailAvatars.avatars.isNotEmpty()) {
@@ -422,9 +422,9 @@ internal class AvatarPickerViewModel(
 
     private fun avatarsObserver() {
         viewModelScope.launch {
-            avatarRepository.getAvatarsFlow(email).collect { emailAvatars ->
+            avatarRepository.getAvatarsFlow(email).collect { avatars ->
                 _uiState.update {
-                    it.copy(emailAvatars = emailAvatars)
+                    it.copy(emailAvatars = avatars.toEmailAvatars())
                 }
             }
         }
@@ -487,4 +487,16 @@ internal fun Avatar.copy(rating: Avatar.Rating? = null, altText: String? = null,
         this.altText = altText ?: this@copy.altText
         this.rating = rating ?: this@copy.rating
     }
+}
+
+internal data class EmailAvatars(
+    val avatars: List<Avatar>,
+    val selectedAvatarId: String?,
+)
+
+internal fun List<Avatar>.toEmailAvatars(): EmailAvatars {
+    return EmailAvatars(
+        avatars = this,
+        selectedAvatarId = firstOrNull { avatar -> avatar.selected == true }?.imageId,
+    )
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -51,7 +51,7 @@ internal class AvatarPickerViewModel(
     init {
         refresh()
         nonAvatarSelectedAlertObserver()
-        avatarsObserver()
+        collectAvatars()
     }
 
     fun onEvent(event: AvatarPickerEvent) {
@@ -420,7 +420,7 @@ internal class AvatarPickerViewModel(
             .launchIn(viewModelScope)
     }
 
-    private fun avatarsObserver() {
+    private fun collectAvatars() {
         viewModelScope.launch {
             avatarRepository.getAvatarsFlow(email).collect { avatars ->
                 _uiState.update {

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/AvatarTestUtils.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/AvatarTestUtils.kt
@@ -1,0 +1,18 @@
+package com.gravatar.quickeditor
+
+import com.gravatar.restapi.models.Avatar
+import java.net.URI
+
+internal fun createAvatar(
+    id: String,
+    isSelected: Boolean? = null,
+    rating: Avatar.Rating = Avatar.Rating.G,
+    altText: String = "alt",
+) = Avatar {
+    imageUrl = URI.create("https://gravatar.com/avatar/test")
+    imageId = id
+    this.rating = rating
+    this.altText = altText
+    updatedDate = ""
+    selected = isSelected
+}

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -179,6 +179,96 @@ class AvatarRepositoryTest {
     }
 
     @Test
+    fun `given token stored when avatar upload succeeds and imageId already in list then avatar is first element`() =
+        runTest {
+            val existingAvatar = createAvatar("3")
+            val newAvatar = createAvatar("3")
+            mockkStatic("androidx.core.net.UriKt")
+            val file = mockk<File>()
+            val uri = mockk<Uri> {
+                every { toFile() } returns file
+            }
+            coEvery { tokenStorage.getToken(any()) } returns "token"
+            coEvery {
+                avatarService.uploadCatching(any(), any(), any(), any())
+            } returns GravatarResult.Success(newAvatar)
+            initAvatarsFlowForEmail(email, listOf(createAvatar("1"), createAvatar("2"), existingAvatar))
+
+            val result = avatarRepository.uploadAvatar(email, uri)
+
+            assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(newAvatar), result)
+
+            avatarRepository.getAvatarsFlow(email).test {
+                assertEquals(
+                    EmailAvatars(
+                        listOf(newAvatar, createAvatar("1"), createAvatar("2")),
+                        null,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `given token stored when unselected avatar upload succeeds then selectedAvatarId remains the same`() = runTest {
+        val newAvatar = createAvatar("3", isSelected = false)
+        mockkStatic("androidx.core.net.UriKt")
+        val file = mockk<File>()
+        val uri = mockk<Uri> {
+            every { toFile() } returns file
+        }
+        coEvery { tokenStorage.getToken(any()) } returns "token"
+        coEvery {
+            avatarService.uploadCatching(any(), any(), any(), any())
+        } returns GravatarResult.Success(newAvatar)
+        initAvatarsFlowForEmail(email, listOf(createAvatar("1"), createAvatar("2", isSelected = true)))
+
+        val result = avatarRepository.uploadAvatar(email, uri)
+
+        assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(newAvatar), result)
+
+        avatarRepository.getAvatarsFlow(email).test {
+            assertEquals(
+                EmailAvatars(
+                    listOf(newAvatar, createAvatar("1"), createAvatar("2", isSelected = true)),
+                    "2",
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `given token stored when selected avatar upload succeeds then flow is updated with new selected avatar`() =
+        runTest {
+            val newAvatar = createAvatar("3", isSelected = true)
+            mockkStatic("androidx.core.net.UriKt")
+            val file = mockk<File>()
+            val uri = mockk<Uri> {
+                every { toFile() } returns file
+            }
+            coEvery { tokenStorage.getToken(any()) } returns "token"
+            coEvery {
+                avatarService.uploadCatching(any(), any(), any(), any())
+            } returns GravatarResult.Success(newAvatar)
+            initAvatarsFlowForEmail(email, listOf(createAvatar("1"), createAvatar("2", isSelected = true)))
+
+            val result = avatarRepository.uploadAvatar(email, uri)
+
+            assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(newAvatar), result)
+
+            avatarRepository.getAvatarsFlow(email).test {
+                assertEquals(
+                    EmailAvatars(
+                        listOf(newAvatar, createAvatar("1"), createAvatar("2", isSelected = false)),
+                        "3",
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
     fun `given token stored when avatar upload fails then Failure result`() = runTest {
         mockkStatic("androidx.core.net.UriKt")
         val file = mockk<File>()

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -103,7 +103,7 @@ class AvatarRepositoryTest {
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
         assertEquals(GravatarResult.Failure<String, QuickEditorError>(QuickEditorError.TokenNotFound), result)
-        coVerify(exactly = 0) { avatarStorage.markAvatarAsSelected(any(), any()) }
+        coVerify(exactly = 0) { avatarStorage.selectAvatar(any(), any()) }
     }
 
     @Test
@@ -113,7 +113,7 @@ class AvatarRepositoryTest {
         coEvery {
             avatarService.setAvatarCatching(any(), any(), any())
         } returns GravatarResult.Failure(ErrorType.Unknown())
-        coEvery { avatarStorage.markAvatarAsSelected(any(), any()) } returns Unit
+        coEvery { avatarStorage.selectAvatar(any(), any()) } returns Unit
 
         val result = avatarRepository.selectAvatar(email, avatar.imageId)
 
@@ -121,19 +121,19 @@ class AvatarRepositoryTest {
             GravatarResult.Failure<String, QuickEditorError>(QuickEditorError.Request(ErrorType.Unknown())),
             result,
         )
-        coVerify(exactly = 0) { avatarStorage.markAvatarAsSelected(email, avatar.imageId) }
+        coVerify(exactly = 0) { avatarStorage.selectAvatar(avatarId = avatar.imageId, email = email) }
     }
 
     @Test
     fun `given token stored when avatar selected succeeds then Success result`() = runTest {
         coEvery { avatarService.setAvatarCatching(any(), any(), any()) } returns GravatarResult.Success(Unit)
-        coEvery { avatarStorage.markAvatarAsSelected(email = email, avatarId = "avatarId") } returns Unit
+        coEvery { avatarStorage.selectAvatar(email = email, avatarId = "avatarId") } returns Unit
         initAvatarsFlowForEmail(email)
 
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
         assertEquals(GravatarResult.Success<Unit, QuickEditorError>(Unit), result)
-        coVerify { avatarStorage.markAvatarAsSelected(email, "avatarId") }
+        coVerify { avatarStorage.selectAvatar(avatarId = "avatarId", email = email) }
     }
 
     @Test

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -2,8 +2,8 @@ package com.gravatar.quickeditor.data.repository
 
 import android.net.Uri
 import androidx.core.net.toFile
-import app.cash.turbine.test
 import com.gravatar.quickeditor.data.models.QuickEditorError
+import com.gravatar.quickeditor.data.storage.AvatarStorage
 import com.gravatar.quickeditor.data.storage.DataStoreTokenStorage
 import com.gravatar.quickeditor.ui.CoroutineTestRule
 import com.gravatar.restapi.models.Avatar
@@ -12,6 +12,7 @@ import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import com.gravatar.types.Email
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -32,16 +33,22 @@ class AvatarRepositoryTest {
 
     private val avatarService = mockk<AvatarService>()
     private val tokenStorage = mockk<DataStoreTokenStorage>()
+    private val avatarStorage = mockk<AvatarStorage>()
 
     private lateinit var avatarRepository: AvatarRepository
 
     private val email = Email("email")
+
+    private companion object {
+        const val DEFAULT_TOKEN = "token"
+    }
 
     @Before
     fun setUp() {
         avatarRepository = AvatarRepository(
             avatarService = avatarService,
             tokenStorage = tokenStorage,
+            avatarStorage = avatarStorage,
             dispatcher = testDispatcher,
         )
     }
@@ -53,12 +60,12 @@ class AvatarRepositoryTest {
         val result = avatarRepository.getAvatars(email)
 
         assertEquals(GravatarResult.Failure<EmailAvatars, QuickEditorError>(QuickEditorError.TokenNotFound), result)
+        coVerify(exactly = 0) { avatarStorage.storeAvatars(any(), any()) }
     }
 
     @Test
     fun `given token stored when get avatars fails then Failure result`() = runTest {
-        coEvery { tokenStorage.getToken(any()) } returns "token"
-
+        coEvery { tokenStorage.getToken(any()) } returns DEFAULT_TOKEN
         coEvery { avatarService.retrieveCatching(any(), any()) } returns GravatarResult.Failure(ErrorType.Server)
 
         val result = avatarRepository.getAvatars(email)
@@ -67,18 +74,16 @@ class AvatarRepositoryTest {
             GravatarResult.Failure<EmailAvatars, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)),
             result,
         )
-
-        avatarRepository.getAvatarsFlow(email).test {
-            expectNoEvents()
-        }
+        coVerify(exactly = 0) { avatarStorage.storeAvatars(any(), any()) }
     }
 
     @Test
     fun `given token stored when get avatars succeed then Success result`() = runTest {
         val imageId = "2"
         val avatar = createAvatar(imageId, isSelected = true)
-        coEvery { tokenStorage.getToken(any()) } returns "token"
+        coEvery { tokenStorage.getToken(any()) } returns DEFAULT_TOKEN
         coEvery { avatarService.retrieveCatching(any(), any()) } returns GravatarResult.Success(listOf(avatar))
+        coEvery { avatarStorage.storeAvatars(any(), any()) } returns Unit
 
         val result = avatarRepository.getAvatars(email)
         val expectedEmailAvatars = EmailAvatars(listOf(avatar), imageId)
@@ -87,10 +92,7 @@ class AvatarRepositoryTest {
             GravatarResult.Success<EmailAvatars, QuickEditorError>(expectedEmailAvatars),
             result,
         )
-
-        avatarRepository.getAvatarsFlow(email).test {
-            assertEquals(expectedEmailAvatars, awaitItem())
-        }
+        coVerify { avatarStorage.storeAvatars(expectedEmailAvatars, email) }
     }
 
     @Test
@@ -100,20 +102,17 @@ class AvatarRepositoryTest {
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
         assertEquals(GravatarResult.Failure<String, QuickEditorError>(QuickEditorError.TokenNotFound), result)
-
-        avatarRepository.getAvatarsFlow(email).test {
-            expectNoEvents()
-        }
+        coVerify(exactly = 0) { avatarStorage.markAvatarAsSelected(any(), any()) }
     }
 
     @Test
     fun `given token stored when avatar selected fails then Failure result`() = runTest {
         val avatar = createAvatar("avatarId")
-        initAvatarsFlowForEmail(email, listOf(avatar))
-        coEvery { tokenStorage.getToken(any()) } returns "token"
+        initAvatarsFlowForEmail(email)
         coEvery {
             avatarService.setAvatarCatching(any(), any(), any())
         } returns GravatarResult.Failure(ErrorType.Unknown())
+        coEvery { avatarStorage.markAvatarAsSelected(any(), any()) } returns Unit
 
         val result = avatarRepository.selectAvatar(email, avatar.imageId)
 
@@ -121,32 +120,19 @@ class AvatarRepositoryTest {
             GravatarResult.Failure<String, QuickEditorError>(QuickEditorError.Request(ErrorType.Unknown())),
             result,
         )
-
-        avatarRepository.getAvatarsFlow(email).test {
-            skipItems(1) // Initial state after getAvatars
-        }
+        coVerify(exactly = 0) { avatarStorage.markAvatarAsSelected(email, avatar.imageId) }
     }
 
     @Test
     fun `given token stored when avatar selected succeeds then Success result`() = runTest {
-        val avatars = listOf(createAvatar("avatarId"), createAvatar("avatarId2", isSelected = true))
-        initAvatarsFlowForEmail(email, avatars)
-        coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery { avatarService.setAvatarCatching(any(), any(), any()) } returns GravatarResult.Success(Unit)
+        coEvery { avatarStorage.markAvatarAsSelected(email = email, avatarId = "avatarId") } returns Unit
+        initAvatarsFlowForEmail(email)
 
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
         assertEquals(GravatarResult.Success<Unit, QuickEditorError>(Unit), result)
-
-        avatarRepository.getAvatarsFlow(email).test {
-            assertEquals(
-                EmailAvatars(
-                    listOf(createAvatar("avatarId", isSelected = true), createAvatar("avatarId2", isSelected = false)),
-                    "avatarId",
-                ),
-                awaitItem(),
-            )
-        }
+        coVerify { avatarStorage.markAvatarAsSelected(email, "avatarId") }
     }
 
     @Test
@@ -160,6 +146,7 @@ class AvatarRepositoryTest {
         val result = avatarRepository.uploadAvatar(email, uri)
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.TokenNotFound), result)
+        coVerify(exactly = 0) { avatarStorage.addAvatar(any(), any()) }
     }
 
     @Test
@@ -170,103 +157,15 @@ class AvatarRepositoryTest {
         val uri = mockk<Uri> {
             every { toFile() } returns file
         }
-        coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery { avatarService.uploadCatching(any(), any(), any(), any()) } returns GravatarResult.Success(avatar)
+        coEvery { avatarStorage.addAvatar(email, avatar) } returns Unit
+        initAvatarsFlowForEmail(email)
 
         val result = avatarRepository.uploadAvatar(email, uri)
 
         assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(avatar), result)
+        coVerify { avatarStorage.addAvatar(email, avatar) }
     }
-
-    @Test
-    fun `given token stored when avatar upload succeeds and imageId already in list then avatar is first element`() =
-        runTest {
-            val existingAvatar = createAvatar("3")
-            val newAvatar = createAvatar("3")
-            mockkStatic("androidx.core.net.UriKt")
-            val file = mockk<File>()
-            val uri = mockk<Uri> {
-                every { toFile() } returns file
-            }
-            coEvery { tokenStorage.getToken(any()) } returns "token"
-            coEvery {
-                avatarService.uploadCatching(any(), any(), any(), any())
-            } returns GravatarResult.Success(newAvatar)
-            initAvatarsFlowForEmail(email, listOf(createAvatar("1"), createAvatar("2"), existingAvatar))
-
-            val result = avatarRepository.uploadAvatar(email, uri)
-
-            assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(newAvatar), result)
-
-            avatarRepository.getAvatarsFlow(email).test {
-                assertEquals(
-                    EmailAvatars(
-                        listOf(newAvatar, createAvatar("1"), createAvatar("2")),
-                        null,
-                    ),
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Test
-    fun `given token stored when unselected avatar upload succeeds then selectedAvatarId remains the same`() = runTest {
-        val newAvatar = createAvatar("3", isSelected = false)
-        mockkStatic("androidx.core.net.UriKt")
-        val file = mockk<File>()
-        val uri = mockk<Uri> {
-            every { toFile() } returns file
-        }
-        coEvery { tokenStorage.getToken(any()) } returns "token"
-        coEvery {
-            avatarService.uploadCatching(any(), any(), any(), any())
-        } returns GravatarResult.Success(newAvatar)
-        initAvatarsFlowForEmail(email, listOf(createAvatar("1"), createAvatar("2", isSelected = true)))
-
-        val result = avatarRepository.uploadAvatar(email, uri)
-
-        assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(newAvatar), result)
-
-        avatarRepository.getAvatarsFlow(email).test {
-            assertEquals(
-                EmailAvatars(
-                    listOf(newAvatar, createAvatar("1"), createAvatar("2", isSelected = true)),
-                    "2",
-                ),
-                awaitItem(),
-            )
-        }
-    }
-
-    @Test
-    fun `given token stored when selected avatar upload succeeds then flow is updated with new selected avatar`() =
-        runTest {
-            val newAvatar = createAvatar("3", isSelected = true)
-            mockkStatic("androidx.core.net.UriKt")
-            val file = mockk<File>()
-            val uri = mockk<Uri> {
-                every { toFile() } returns file
-            }
-            coEvery { tokenStorage.getToken(any()) } returns "token"
-            coEvery {
-                avatarService.uploadCatching(any(), any(), any(), any())
-            } returns GravatarResult.Success(newAvatar)
-            initAvatarsFlowForEmail(email, listOf(createAvatar("1"), createAvatar("2", isSelected = true)))
-
-            val result = avatarRepository.uploadAvatar(email, uri)
-
-            assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(newAvatar), result)
-
-            avatarRepository.getAvatarsFlow(email).test {
-                assertEquals(
-                    EmailAvatars(
-                        listOf(newAvatar, createAvatar("1"), createAvatar("2", isSelected = false)),
-                        "3",
-                    ),
-                    awaitItem(),
-                )
-            }
-        }
 
     @Test
     fun `given token stored when avatar upload fails then Failure result`() = runTest {
@@ -283,54 +182,37 @@ class AvatarRepositoryTest {
         val result = avatarRepository.uploadAvatar(email, uri)
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)), result)
+        coVerify(exactly = 0) { avatarStorage.addAvatar(any(), any()) }
     }
 
     @Test
     fun `given token stored when avatar delete succeeds then Success result`() = runTest {
         val imageId = "imageId"
-        coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
-            avatarService.deleteAvatarCatching(avatarId = "imageId", oauthToken = "token")
+            avatarService.deleteAvatarCatching(avatarId = "imageId", oauthToken = DEFAULT_TOKEN)
         } returns GravatarResult.Success(Unit)
-        initAvatarsFlowForEmail(email, listOf(createAvatar("1", isSelected = true), createAvatar("imageId")))
+        coEvery { avatarStorage.deleteAvatar(email, imageId) } returns Unit
+        initAvatarsFlowForEmail(email)
 
         val result = avatarRepository.deleteAvatar(email, imageId)
 
-        avatarRepository.getAvatarsFlow(email).test {
-            assertEquals(
-                EmailAvatars(
-                    listOf(createAvatar("1", isSelected = true)),
-                    "1",
-                ),
-                awaitItem(),
-            )
-        }
-
         assertEquals(GravatarResult.Success<Unit, QuickEditorError>(Unit), result)
+        coVerify { avatarStorage.deleteAvatar(email, imageId) }
     }
 
     @Test
     fun `given token stored when selected avatar delete succeeds then Success result`() = runTest {
         val imageId = "imageId"
-        coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
-            avatarService.deleteAvatarCatching(avatarId = "imageId", oauthToken = "token")
+            avatarService.deleteAvatarCatching(avatarId = "imageId", oauthToken = DEFAULT_TOKEN)
         } returns GravatarResult.Success(Unit)
-        initAvatarsFlowForEmail(email, listOf(createAvatar("1"), createAvatar("imageId", isSelected = true)))
+        coEvery { avatarStorage.deleteAvatar(email, imageId) } returns Unit
+        initAvatarsFlowForEmail(email)
 
         val result = avatarRepository.deleteAvatar(email, imageId)
 
-        avatarRepository.getAvatarsFlow(email).test {
-            assertEquals(
-                EmailAvatars(
-                    listOf(createAvatar("1")),
-                    null,
-                ),
-                awaitItem(),
-            )
-        }
-
         assertEquals(GravatarResult.Success<Unit, QuickEditorError>(Unit), result)
+        coVerify { avatarStorage.deleteAvatar(email, imageId) }
     }
 
     @Test
@@ -347,6 +229,7 @@ class AvatarRepositoryTest {
         val result = avatarRepository.deleteAvatar(email, imageId)
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)), result)
+        coVerify(exactly = 0) { avatarStorage.deleteAvatar(any(), any()) }
     }
 
     @Test
@@ -357,6 +240,7 @@ class AvatarRepositoryTest {
         val result = avatarRepository.deleteAvatar(email, imageId)
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.TokenNotFound), result)
+        coVerify(exactly = 0) { avatarStorage.deleteAvatar(any(), any()) }
     }
 
     @Test
@@ -366,19 +250,15 @@ class AvatarRepositoryTest {
         val result = avatarRepository.updateAvatar(email, "avatarId", Avatar.Rating.PG, "New Alt Text")
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.TokenNotFound), result)
-
-        avatarRepository.getAvatarsFlow(email).test {
-            expectNoEvents()
-        }
+        coVerify(exactly = 0) { avatarStorage.updateAvatar(any(), any()) }
     }
 
     @Test
     fun `given token stored when update avatar fails then Failure result`() = runTest {
-        initAvatarsFlowForEmail(email, listOf(createAvatar("avatarId")))
-        coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
             avatarService.updateAvatarCatching(any(), any(), any(), any())
         } returns GravatarResult.Failure(ErrorType.Server)
+        initAvatarsFlowForEmail(email)
 
         val result = avatarRepository.updateAvatar(email, "avatarId", Avatar.Rating.PG, "New Alt Text")
 
@@ -386,25 +266,22 @@ class AvatarRepositoryTest {
             GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)),
             result,
         )
-
-        avatarRepository.getAvatarsFlow(email).test {
-            skipItems(1) // Initial state after getAvatars
-        }
+        coVerify(exactly = 0) { avatarStorage.updateAvatar(any(), any()) }
     }
 
     @Test
     fun `given token stored when update avatar succeeds then Success result`() = runTest {
-        initAvatarsFlowForEmail(email, listOf(createAvatar("avatarId")))
+        initAvatarsFlowForEmail(email)
         val updatedAvatar = createAvatar(id = "avatarId", rating = Avatar.Rating.PG, altText = "New Alt Text")
-        coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
             avatarService.updateAvatarCatching(
                 avatarId = updatedAvatar.imageId,
-                oauthToken = "token",
+                oauthToken = DEFAULT_TOKEN,
                 avatarRating = updatedAvatar.rating,
                 altText = updatedAvatar.altText,
             )
         } returns GravatarResult.Success(updatedAvatar)
+        coEvery { avatarStorage.updateAvatar(email, updatedAvatar) } returns Unit
 
         val result = avatarRepository.updateAvatar(
             email,
@@ -414,15 +291,13 @@ class AvatarRepositoryTest {
         )
 
         assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(updatedAvatar), result)
-
-        avatarRepository.getAvatarsFlow(email).test {
-            assertEquals(EmailAvatars(listOf(updatedAvatar), null), awaitItem())
-        }
+        coVerify { avatarStorage.updateAvatar(email, updatedAvatar) }
     }
 
-    private suspend fun initAvatarsFlowForEmail(email: Email, avatars: List<Avatar>) {
-        coEvery { tokenStorage.getToken(any()) } returns "token"
+    private suspend fun initAvatarsFlowForEmail(email: Email, avatars: List<Avatar> = listOf()) {
+        coEvery { tokenStorage.getToken(any()) } returns DEFAULT_TOKEN
         coEvery { avatarService.retrieveCatching(any(), any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarStorage.storeAvatars(any(), any()) } returns Unit
 
         avatarRepository.getAvatars(email)
     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -58,7 +58,7 @@ class AvatarRepositoryTest {
     fun `given email when token not found then TokenNotFound result`() = runTest {
         coEvery { tokenStorage.getToken(any()) } returns null
 
-        val result = avatarRepository.getAvatars(email)
+        val result = avatarRepository.refreshAvatars(email)
 
         assertEquals(GravatarResult.Failure<EmailAvatars, QuickEditorError>(QuickEditorError.TokenNotFound), result)
         coVerify(exactly = 0) { avatarStorage.storeAvatars(any(), any()) }
@@ -69,7 +69,7 @@ class AvatarRepositoryTest {
         coEvery { tokenStorage.getToken(any()) } returns DEFAULT_TOKEN
         coEvery { avatarService.retrieveCatching(any(), any()) } returns GravatarResult.Failure(ErrorType.Server)
 
-        val result = avatarRepository.getAvatars(email)
+        val result = avatarRepository.refreshAvatars(email)
 
         assertEquals(
             GravatarResult.Failure<List<Avatar>, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)),
@@ -86,7 +86,7 @@ class AvatarRepositoryTest {
         coEvery { avatarService.retrieveCatching(any(), any()) } returns GravatarResult.Success(listOf(avatar))
         coEvery { avatarStorage.storeAvatars(any(), any()) } returns Unit
 
-        val result = avatarRepository.getAvatars(email)
+        val result = avatarRepository.refreshAvatars(email)
         val expectedAvatars = listOf(avatar)
 
         assertEquals(
@@ -300,7 +300,7 @@ class AvatarRepositoryTest {
         coEvery { avatarService.retrieveCatching(any(), any()) } returns GravatarResult.Success(avatars)
         coEvery { avatarStorage.storeAvatars(any(), any()) } returns Unit
 
-        avatarRepository.getAvatars(email)
+        avatarRepository.refreshAvatars(email)
     }
 
     private fun createAvatar(

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -100,31 +100,53 @@ class AvatarRepositoryTest {
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
         assertEquals(GravatarResult.Failure<String, QuickEditorError>(QuickEditorError.TokenNotFound), result)
+
+        avatarRepository.getAvatarsFlow(email).test {
+            expectNoEvents()
+        }
     }
 
     @Test
     fun `given token stored when avatar selected fails then Failure result`() = runTest {
+        val avatar = createAvatar("avatarId")
+        initAvatarsFlowForEmail(email, listOf(avatar))
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
             avatarService.setAvatarCatching(any(), any(), any())
         } returns GravatarResult.Failure(ErrorType.Unknown())
 
-        val result = avatarRepository.selectAvatar(email, "avatarId")
+        val result = avatarRepository.selectAvatar(email, avatar.imageId)
 
         assertEquals(
             GravatarResult.Failure<String, QuickEditorError>(QuickEditorError.Request(ErrorType.Unknown())),
             result,
         )
+
+        avatarRepository.getAvatarsFlow(email).test {
+            skipItems(1) // Initial state after getAvatars
+        }
     }
 
     @Test
     fun `given token stored when avatar selected succeeds then Success result`() = runTest {
+        val avatars = listOf(createAvatar("avatarId"), createAvatar("avatarId2", isSelected = true))
+        initAvatarsFlowForEmail(email, avatars)
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery { avatarService.setAvatarCatching(any(), any(), any()) } returns GravatarResult.Success(Unit)
 
         val result = avatarRepository.selectAvatar(email, "avatarId")
 
         assertEquals(GravatarResult.Success<Unit, QuickEditorError>(Unit), result)
+
+        avatarRepository.getAvatarsFlow(email).test {
+            assertEquals(
+                EmailAvatars(
+                    listOf(createAvatar("avatarId", isSelected = true), createAvatar("avatarId2", isSelected = false)),
+                    "avatarId",
+                ),
+                awaitItem(),
+            )
+        }
     }
 
     @Test

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -292,8 +292,43 @@ class AvatarRepositoryTest {
         coEvery {
             avatarService.deleteAvatarCatching(avatarId = "imageId", oauthToken = "token")
         } returns GravatarResult.Success(Unit)
+        initAvatarsFlowForEmail(email, listOf(createAvatar("1", isSelected = true), createAvatar("imageId")))
 
         val result = avatarRepository.deleteAvatar(email, imageId)
+
+        avatarRepository.getAvatarsFlow(email).test {
+            assertEquals(
+                EmailAvatars(
+                    listOf(createAvatar("1", isSelected = true)),
+                    "1",
+                ),
+                awaitItem(),
+            )
+        }
+
+        assertEquals(GravatarResult.Success<Unit, QuickEditorError>(Unit), result)
+    }
+
+    @Test
+    fun `given token stored when selected avatar delete succeeds then Success result`() = runTest {
+        val imageId = "imageId"
+        coEvery { tokenStorage.getToken(any()) } returns "token"
+        coEvery {
+            avatarService.deleteAvatarCatching(avatarId = "imageId", oauthToken = "token")
+        } returns GravatarResult.Success(Unit)
+        initAvatarsFlowForEmail(email, listOf(createAvatar("1"), createAvatar("imageId", isSelected = true)))
+
+        val result = avatarRepository.deleteAvatar(email, imageId)
+
+        avatarRepository.getAvatarsFlow(email).test {
+            assertEquals(
+                EmailAvatars(
+                    listOf(createAvatar("1")),
+                    null,
+                ),
+                awaitItem(),
+            )
+        }
 
         assertEquals(GravatarResult.Success<Unit, QuickEditorError>(Unit), result)
     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.gravatar.quickeditor.data.repository
 
 import android.net.Uri
 import androidx.core.net.toFile
+import app.cash.turbine.test
 import com.gravatar.quickeditor.data.models.QuickEditorError
 import com.gravatar.quickeditor.data.storage.DataStoreTokenStorage
 import com.gravatar.quickeditor.ui.CoroutineTestRule
@@ -66,6 +67,10 @@ class AvatarRepositoryTest {
             GravatarResult.Failure<EmailAvatars, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)),
             result,
         )
+
+        avatarRepository.getAvatarsFlow(email).test {
+            expectNoEvents()
+        }
     }
 
     @Test
@@ -76,11 +81,16 @@ class AvatarRepositoryTest {
         coEvery { avatarService.retrieveCatching(any(), any()) } returns GravatarResult.Success(listOf(avatar))
 
         val result = avatarRepository.getAvatars(email)
+        val expectedEmailAvatars = EmailAvatars(listOf(avatar), imageId)
 
         assertEquals(
-            GravatarResult.Success<EmailAvatars, QuickEditorError>(EmailAvatars(listOf(avatar), imageId)),
+            GravatarResult.Success<EmailAvatars, QuickEditorError>(expectedEmailAvatars),
             result,
         )
+
+        avatarRepository.getAvatarsFlow(email).test {
+            assertEquals(expectedEmailAvatars, awaitItem())
+        }
     }
 
     @Test
@@ -209,10 +219,15 @@ class AvatarRepositoryTest {
         val result = avatarRepository.updateAvatar(email, "avatarId", Avatar.Rating.PG, "New Alt Text")
 
         assertEquals(GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.TokenNotFound), result)
+
+        avatarRepository.getAvatarsFlow(email).test {
+            expectNoEvents()
+        }
     }
 
     @Test
     fun `given token stored when update avatar fails then Failure result`() = runTest {
+        initAvatarsFlowForEmail(email, listOf(createAvatar("avatarId")))
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
             avatarService.updateAvatarCatching(any(), any(), any(), any())
@@ -224,25 +239,57 @@ class AvatarRepositoryTest {
             GravatarResult.Failure<Unit, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)),
             result,
         )
+
+        avatarRepository.getAvatarsFlow(email).test {
+            skipItems(1) // Initial state after getAvatars
+        }
     }
 
     @Test
     fun `given token stored when update avatar succeeds then Success result`() = runTest {
+        initAvatarsFlowForEmail(email, listOf(createAvatar("avatarId")))
+        val updatedAvatar = createAvatar(id = "avatarId", rating = Avatar.Rating.PG, altText = "New Alt Text")
         coEvery { tokenStorage.getToken(any()) } returns "token"
         coEvery {
-            avatarService.updateAvatarCatching(any(), any(), any(), any())
-        } returns GravatarResult.Success(createAvatar("1"))
+            avatarService.updateAvatarCatching(
+                avatarId = updatedAvatar.imageId,
+                oauthToken = "token",
+                avatarRating = updatedAvatar.rating,
+                altText = updatedAvatar.altText,
+            )
+        } returns GravatarResult.Success(updatedAvatar)
 
-        val result = avatarRepository.updateAvatar(email, "avatarId", Avatar.Rating.PG, "New Alt Text")
+        val result = avatarRepository.updateAvatar(
+            email,
+            updatedAvatar.imageId,
+            updatedAvatar.rating,
+            updatedAvatar.altText,
+        )
 
-        assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(createAvatar("1")), result)
+        assertEquals(GravatarResult.Success<Avatar, QuickEditorError>(updatedAvatar), result)
+
+        avatarRepository.getAvatarsFlow(email).test {
+            assertEquals(EmailAvatars(listOf(updatedAvatar), null), awaitItem())
+        }
     }
 
-    private fun createAvatar(id: String, isSelected: Boolean = false) = Avatar {
+    private suspend fun initAvatarsFlowForEmail(email: Email, avatars: List<Avatar>) {
+        coEvery { tokenStorage.getToken(any()) } returns "token"
+        coEvery { avatarService.retrieveCatching(any(), any()) } returns GravatarResult.Success(avatars)
+
+        avatarRepository.getAvatars(email)
+    }
+
+    private fun createAvatar(
+        id: String,
+        isSelected: Boolean = false,
+        rating: Avatar.Rating = Avatar.Rating.G,
+        altText: String = "alt",
+    ) = Avatar {
         imageUrl = URI.create("https://gravatar.com/avatar/test")
         imageId = id
-        rating = Avatar.Rating.G
-        altText = "alt"
+        this.rating = rating
+        this.altText = altText
         updatedDate = ""
         selected = isSelected
     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -6,6 +6,7 @@ import com.gravatar.quickeditor.data.models.QuickEditorError
 import com.gravatar.quickeditor.data.storage.AvatarStorage
 import com.gravatar.quickeditor.data.storage.DataStoreTokenStorage
 import com.gravatar.quickeditor.ui.CoroutineTestRule
+import com.gravatar.quickeditor.ui.avatarpicker.EmailAvatars
 import com.gravatar.restapi.models.Avatar
 import com.gravatar.services.AvatarService
 import com.gravatar.services.ErrorType
@@ -71,7 +72,7 @@ class AvatarRepositoryTest {
         val result = avatarRepository.getAvatars(email)
 
         assertEquals(
-            GravatarResult.Failure<EmailAvatars, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)),
+            GravatarResult.Failure<List<Avatar>, QuickEditorError>(QuickEditorError.Request(ErrorType.Server)),
             result,
         )
         coVerify(exactly = 0) { avatarStorage.storeAvatars(any(), any()) }
@@ -86,13 +87,13 @@ class AvatarRepositoryTest {
         coEvery { avatarStorage.storeAvatars(any(), any()) } returns Unit
 
         val result = avatarRepository.getAvatars(email)
-        val expectedEmailAvatars = EmailAvatars(listOf(avatar), imageId)
+        val expectedAvatars = listOf(avatar)
 
         assertEquals(
-            GravatarResult.Success<EmailAvatars, QuickEditorError>(expectedEmailAvatars),
+            GravatarResult.Success<List<Avatar>, QuickEditorError>(expectedAvatars),
             result,
         )
-        coVerify { avatarStorage.storeAvatars(expectedEmailAvatars, email) }
+        coVerify { avatarStorage.storeAvatars(expectedAvatars, email) }
     }
 
     @Test

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
@@ -1,0 +1,156 @@
+package com.gravatar.quickeditor.data.storage
+
+import app.cash.turbine.test
+import com.gravatar.quickeditor.createAvatar
+import com.gravatar.quickeditor.data.repository.EmailAvatars
+import com.gravatar.types.Email
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class AvatarStorageTest {
+    private lateinit var avatarStorage: AvatarStorage
+
+    @Before
+    fun setUp() {
+        avatarStorage = AvatarStorage()
+    }
+
+    @Test
+    fun `given avatars when storeAvatars then avatarsFlow emits a avatars`() = runTest {
+        val email = Email("email")
+
+        // Given
+        val emailAvatars = EmailAvatars(
+            avatars = listOf(createAvatar(id = "imageId", isSelected = true)),
+            selectedAvatarId = "imageId",
+        )
+
+        // When
+        avatarStorage.storeAvatars(emailAvatars, email)
+
+        // Then
+        avatarStorage.avatarsFlow(email).test {
+            assertEquals(emailAvatars, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given avatarId when markAvatarAsSelected then avatarsFlow emits a avatars with selected avatar`() = runTest {
+        val email = Email("email")
+
+        // Given
+        val emailAvatars = EmailAvatars(
+            avatars = listOf(
+                createAvatar("otherAvatar", isSelected = true),
+                createAvatar(id = "imageId", isSelected = false),
+            ),
+            selectedAvatarId = "otherAvatar",
+        )
+        avatarStorage.storeAvatars(emailAvatars, email)
+
+        // When
+        avatarStorage.markAvatarAsSelected(email, "imageId")
+
+        // Then
+        avatarStorage.avatarsFlow(email).test {
+            assertEquals(
+                emailAvatars.copy(
+                    avatars = listOf(
+                        createAvatar("otherAvatar", isSelected = false),
+                        createAvatar(id = "imageId", isSelected = true),
+                    ),
+                    selectedAvatarId = "imageId",
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `given avatar when addAvatar then avatarsFlow emits a avatars with updated avatar`() = runTest {
+        val email = Email("email")
+
+        // Given
+        val emailAvatars = EmailAvatars(
+            avatars = listOf(
+                createAvatar("otherAvatar", isSelected = true),
+                createAvatar("imageId", isSelected = false),
+            ),
+            selectedAvatarId = "imageId",
+        )
+        avatarStorage.storeAvatars(emailAvatars, email)
+
+        // When
+        val updatedAvatar = createAvatar("imageId", isSelected = true)
+        avatarStorage.addAvatar(email, updatedAvatar)
+
+        // Then
+        avatarStorage.avatarsFlow(email).test {
+            assertEquals(
+                emailAvatars.copy(
+                    avatars = listOf(updatedAvatar, createAvatar("otherAvatar", isSelected = false)),
+                    selectedAvatarId = "imageId",
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `given avatarId when deleteAvatar then avatarsFlow emits a avatars without deleted avatar`() = runTest {
+        val email = Email("email")
+
+        // Given
+        val emailAvatars = EmailAvatars(
+            avatars = listOf(
+                createAvatar("otherAvatar", isSelected = false),
+                createAvatar("imageId", isSelected = true),
+            ),
+            selectedAvatarId = "imageId",
+        )
+        avatarStorage.storeAvatars(emailAvatars, email)
+
+        // When
+        avatarStorage.deleteAvatar(email, "imageId")
+
+        // Then
+        avatarStorage.avatarsFlow(email).test {
+            assertEquals(
+                emailAvatars.copy(
+                    avatars = listOf(createAvatar("otherAvatar", isSelected = false)),
+                    selectedAvatarId = null,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `given avatar when updateAvatar then avatarsFlow emits a avatars with updated avatar`() = runTest {
+        val email = Email("email")
+
+        // Given
+        val emailAvatars = EmailAvatars(
+            avatars = listOf(createAvatar("otherAvatar"), createAvatar("imageId", altText = "altText")),
+            selectedAvatarId = null,
+        )
+        avatarStorage.storeAvatars(emailAvatars, email)
+
+        // When
+        val updatedAvatar = createAvatar("imageId", altText = "newAltText")
+        avatarStorage.updateAvatar(email, updatedAvatar)
+
+        // Then
+        avatarStorage.avatarsFlow(email).test {
+            assertEquals(
+                emailAvatars.copy(
+                    avatars = listOf(createAvatar("otherAvatar"), updatedAvatar),
+                    selectedAvatarId = null,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+}

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
@@ -33,7 +33,7 @@ class AvatarStorageTest {
     }
 
     @Test
-    fun `given avatarId when markAvatarAsSelected then avatarsFlow emits a avatars with selected avatar`() = runTest {
+    fun `given avatarId when selectAvatar then avatarsFlow emits a avatars with selected avatar`() = runTest {
         val email = Email("email")
 
         // Given
@@ -44,7 +44,7 @@ class AvatarStorageTest {
         avatarStorage.storeAvatars(avatars, email)
 
         // When
-        avatarStorage.markAvatarAsSelected(email, "imageId")
+        avatarStorage.selectAvatar(avatarId = "imageId", email = email)
 
         // Then
         avatarStorage.avatarsFlow(email).test {

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
@@ -2,7 +2,6 @@ package com.gravatar.quickeditor.data.storage
 
 import app.cash.turbine.test
 import com.gravatar.quickeditor.createAvatar
-import com.gravatar.quickeditor.data.repository.EmailAvatars
 import com.gravatar.types.Email
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
@@ -22,17 +21,14 @@ class AvatarStorageTest {
         val email = Email("email")
 
         // Given
-        val emailAvatars = EmailAvatars(
-            avatars = listOf(createAvatar(id = "imageId", isSelected = true)),
-            selectedAvatarId = "imageId",
-        )
+        val avatars = listOf(createAvatar(id = "imageId", isSelected = true))
 
         // When
-        avatarStorage.storeAvatars(emailAvatars, email)
+        avatarStorage.storeAvatars(avatars, email)
 
         // Then
         avatarStorage.avatarsFlow(email).test {
-            assertEquals(emailAvatars, awaitItem())
+            assertEquals(avatars, awaitItem())
         }
     }
 
@@ -41,14 +37,11 @@ class AvatarStorageTest {
         val email = Email("email")
 
         // Given
-        val emailAvatars = EmailAvatars(
-            avatars = listOf(
-                createAvatar("otherAvatar", isSelected = true),
-                createAvatar(id = "imageId", isSelected = false),
-            ),
-            selectedAvatarId = "otherAvatar",
+        val avatars = listOf(
+            createAvatar("otherAvatar", isSelected = true),
+            createAvatar(id = "imageId", isSelected = false),
         )
-        avatarStorage.storeAvatars(emailAvatars, email)
+        avatarStorage.storeAvatars(avatars, email)
 
         // When
         avatarStorage.markAvatarAsSelected(email, "imageId")
@@ -56,12 +49,9 @@ class AvatarStorageTest {
         // Then
         avatarStorage.avatarsFlow(email).test {
             assertEquals(
-                emailAvatars.copy(
-                    avatars = listOf(
-                        createAvatar("otherAvatar", isSelected = false),
-                        createAvatar(id = "imageId", isSelected = true),
-                    ),
-                    selectedAvatarId = "imageId",
+                listOf(
+                    createAvatar("otherAvatar", isSelected = false),
+                    createAvatar(id = "imageId", isSelected = true),
                 ),
                 awaitItem(),
             )
@@ -73,14 +63,11 @@ class AvatarStorageTest {
         val email = Email("email")
 
         // Given
-        val emailAvatars = EmailAvatars(
-            avatars = listOf(
-                createAvatar("otherAvatar", isSelected = true),
-                createAvatar("imageId", isSelected = false),
-            ),
-            selectedAvatarId = "imageId",
+        val avatars = listOf(
+            createAvatar("otherAvatar", isSelected = true),
+            createAvatar("imageId", isSelected = false),
         )
-        avatarStorage.storeAvatars(emailAvatars, email)
+        avatarStorage.storeAvatars(avatars, email)
 
         // When
         val updatedAvatar = createAvatar("imageId", isSelected = true)
@@ -89,10 +76,7 @@ class AvatarStorageTest {
         // Then
         avatarStorage.avatarsFlow(email).test {
             assertEquals(
-                emailAvatars.copy(
-                    avatars = listOf(updatedAvatar, createAvatar("otherAvatar", isSelected = false)),
-                    selectedAvatarId = "imageId",
-                ),
+                listOf(updatedAvatar, createAvatar("otherAvatar", isSelected = false)),
                 awaitItem(),
             )
         }
@@ -103,14 +87,11 @@ class AvatarStorageTest {
         val email = Email("email")
 
         // Given
-        val emailAvatars = EmailAvatars(
-            avatars = listOf(
-                createAvatar("otherAvatar", isSelected = false),
-                createAvatar("imageId", isSelected = true),
-            ),
-            selectedAvatarId = "imageId",
+        val avatars = listOf(
+            createAvatar("otherAvatar", isSelected = false),
+            createAvatar("imageId", isSelected = true),
         )
-        avatarStorage.storeAvatars(emailAvatars, email)
+        avatarStorage.storeAvatars(avatars, email)
 
         // When
         avatarStorage.deleteAvatar(email, "imageId")
@@ -118,10 +99,7 @@ class AvatarStorageTest {
         // Then
         avatarStorage.avatarsFlow(email).test {
             assertEquals(
-                emailAvatars.copy(
-                    avatars = listOf(createAvatar("otherAvatar", isSelected = false)),
-                    selectedAvatarId = null,
-                ),
+                listOf(createAvatar("otherAvatar", isSelected = false)),
                 awaitItem(),
             )
         }
@@ -132,11 +110,8 @@ class AvatarStorageTest {
         val email = Email("email")
 
         // Given
-        val emailAvatars = EmailAvatars(
-            avatars = listOf(createAvatar("otherAvatar"), createAvatar("imageId", altText = "altText")),
-            selectedAvatarId = null,
-        )
-        avatarStorage.storeAvatars(emailAvatars, email)
+        val avatars = listOf(createAvatar("otherAvatar"), createAvatar("imageId", altText = "altText"))
+        avatarStorage.storeAvatars(avatars, email)
 
         // When
         val updatedAvatar = createAvatar("imageId", altText = "newAltText")
@@ -145,10 +120,7 @@ class AvatarStorageTest {
         // Then
         avatarStorage.avatarsFlow(email).test {
             assertEquals(
-                emailAvatars.copy(
-                    avatars = listOf(createAvatar("otherAvatar"), updatedAvatar),
-                    selectedAvatarId = null,
-                ),
+                listOf(createAvatar("otherAvatar"), updatedAvatar),
                 awaitItem(),
             )
         }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
@@ -17,7 +17,7 @@ class AvatarStorageTest {
     }
 
     @Test
-    fun `given avatars when storeAvatars then avatarsFlow emits a avatars`() = runTest {
+    fun `given avatars when storeAvatars then avatarsFlow emits avatars`() = runTest {
         val email = Email("email")
 
         // Given
@@ -33,7 +33,7 @@ class AvatarStorageTest {
     }
 
     @Test
-    fun `given avatarId when selectAvatar then avatarsFlow emits a avatars with selected avatar`() = runTest {
+    fun `given avatarId when selectAvatar then avatarsFlow emits avatars with selected avatar`() = runTest {
         val email = Email("email")
 
         // Given
@@ -59,7 +59,7 @@ class AvatarStorageTest {
     }
 
     @Test
-    fun `given avatar when addAvatar then avatarsFlow emits a avatars with updated avatar`() = runTest {
+    fun `given avatar when addAvatar then avatarsFlow emits avatars`() = runTest {
         val email = Email("email")
 
         // Given
@@ -83,7 +83,7 @@ class AvatarStorageTest {
     }
 
     @Test
-    fun `given avatarId when deleteAvatar then avatarsFlow emits a avatars without deleted avatar`() = runTest {
+    fun `given avatarId when deleteAvatar then avatarsFlow emits avatars without deleted avatar`() = runTest {
         val email = Email("email")
 
         // Given
@@ -106,7 +106,7 @@ class AvatarStorageTest {
     }
 
     @Test
-    fun `given avatar when updateAvatar then avatarsFlow emits a avatars with updated avatar`() = runTest {
+    fun `given avatar when updateAvatar then avatarsFlow emits avatars with updated avatar`() = runTest {
         val email = Email("email")
 
         // Given

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerTest.kt
@@ -1,7 +1,6 @@
 package com.gravatar.quickeditor.ui.avatarpicker
 
 import com.gravatar.extensions.defaultProfile
-import com.gravatar.quickeditor.data.repository.EmailAvatars
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.quickeditor.ui.gravatarScreenshotTest
 import com.gravatar.restapi.models.Avatar

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -67,14 +67,14 @@ class AvatarPickerViewModelTest {
     @Before
     fun setup() {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Failure(ErrorType.Unknown())
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emptyList())
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(emptyList())
         coEvery { avatarRepository.getAvatarsFlow(email) } returns avatarsFlow
     }
 
     @Test
     fun `given view model initialization when avatars request succeed then uiState is updated`() = runTest {
         val avatars = listOf(createAvatar(id = "1", isSelected = true), createAvatar("2"))
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -102,7 +102,7 @@ class AvatarPickerViewModelTest {
 
     @Test
     fun `given view model initialization when avatars request fails then uiState is updated`() = runTest {
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Failure(QuickEditorError.Unknown)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
         viewModel = initViewModel()
 
@@ -192,7 +192,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given avatar when selected successful then uiState is updated`() = runTest {
         val avatars = avatars.selectAvatarId("1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
 
@@ -234,7 +234,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given avatar when selected failure then uiState is updated`() = runTest {
         val avatars = avatars.selectAvatarId("1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
@@ -313,7 +313,7 @@ class AvatarPickerViewModelTest {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val uploadedAvatar = createAvatar("3")
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -357,7 +357,7 @@ class AvatarPickerViewModelTest {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -403,7 +403,7 @@ class AvatarPickerViewModelTest {
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Success(createAvatar("3"))
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -437,7 +437,7 @@ class AvatarPickerViewModelTest {
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -469,7 +469,7 @@ class AvatarPickerViewModelTest {
         val avatars = listOf(createAvatar("3", isSelected = true))
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
         viewModel = initViewModel()
@@ -531,7 +531,7 @@ class AvatarPickerViewModelTest {
         val avatars = avatars.selectAvatarId("1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -555,7 +555,7 @@ class AvatarPickerViewModelTest {
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -580,7 +580,7 @@ class AvatarPickerViewModelTest {
         val avatars = avatars.selectAvatarId("1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -607,7 +607,7 @@ class AvatarPickerViewModelTest {
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -631,7 +631,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given profile loaded when refresh then fetch profile not called`() = runTest {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Failure(QuickEditorError.Unknown)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Failure(QuickEditorError.Unknown)
         viewModel = initViewModel()
         advanceUntilIdle()
 
@@ -649,7 +649,7 @@ class AvatarPickerViewModelTest {
         val avatars = listOf(createAvatar("3", isSelected = false))
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
         val uploadedAvatar = createAvatar(id = "1", isSelected = true)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
 
@@ -707,7 +707,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given selected avatar when delete successful then uiState is updated`() = runTest {
         val avatars = avatars.selectAvatarId(avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns GravatarResult.Success(Unit)
 
@@ -758,7 +758,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given non selected avatar when delete successful then uiState is updated`() = runTest {
         val avatars = avatars.selectAvatarId(avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns GravatarResult.Success(Unit)
 
@@ -794,7 +794,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given selected avatar when delete fails then uiState is updated`() = runTest {
         val avatars = avatars.selectAvatarId(avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
@@ -833,7 +833,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given non selected avatar when delete fails then uiState is updated`() = runTest {
         val avatars = avatars.selectAvatarId(avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
@@ -876,7 +876,7 @@ class AvatarPickerViewModelTest {
             val uri = mockk<Uri>()
             every { fileUtils.deleteFile(any()) } returns Unit
             coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-            coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
+            coEvery { avatarRepository.refreshAvatars(any()) } returns GravatarResult.Success(avatars)
             val uploadedAvatar = createAvatar("3", isSelected = true)
             coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
 
@@ -938,7 +938,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given avatar already deleted when delete returns 404 then uiState is updated`() = runTest {
         val avatars = avatars.selectAvatarId(avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns
             GravatarResult.Failure(QuickEditorError.Request(ErrorType.NotFound))
@@ -980,7 +980,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given avatar when download queued then AvatarDownloadStarted sent`() = runTest {
         val avatars = avatars.selectAvatarId("1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
         coEvery { imageDownloader.downloadImage(any()) } returns GravatarResult.Success(Unit)
@@ -1000,7 +1000,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given avatar when download manager disabled then uiState updated`() = runTest {
         val emailAvatarsCopy = avatars.selectAvatarId("1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
         coEvery {
@@ -1022,7 +1022,7 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given avatar when download manager not available then DownloadManagerNotAvailable sent`() = runTest {
         val avatars = avatars.selectAvatarId("1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
         coEvery {
@@ -1047,7 +1047,7 @@ class AvatarPickerViewModelTest {
         val rating = Avatar.Rating.PG
         val oldAvatar = createAvatar(avatarId, isSelected = true)
         val avatars = listOf(oldAvatar)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val updatedAvatar = oldAvatar.copy(rating)
         coEvery {
@@ -1084,7 +1084,7 @@ class AvatarPickerViewModelTest {
         val rating = Avatar.Rating.PG
         val oldAvatar = createAvatar(avatarId, isSelected = true)
         val avatars = listOf(oldAvatar)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.updateAvatar(email, avatarId, rating)
@@ -1132,7 +1132,7 @@ class AvatarPickerViewModelTest {
         val altText = "New Alt"
         val oldAvatar = createAvatar(avatarId, isSelected = true, rating = rating, altText = altText)
         val avatars = listOf(oldAvatar)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.updateAvatar(email, avatarId, rating)
@@ -1171,7 +1171,7 @@ class AvatarPickerViewModelTest {
     fun `given AvatarAltTextTapped event when received then LaunchAvatarAltText action is launched`() = runTest {
         val avatar = createAvatar("1", isSelected = true)
         val avatars = listOf(avatar)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
+        coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
 
         viewModel = initViewModel()

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -340,69 +340,8 @@ class AvatarPickerViewModelTest {
             )
             assertEquals(
                 avatarPickerUiState.copy(
-                    emailAvatars = emailAvatarsCopy.copy(
-                        avatars = buildList {
-                            add(uploadedAvatar)
-                            addAll(emailAvatarsCopy.avatars)
-                        },
-                    ),
                     uploadingAvatar = null,
                     scrollToIndex = null,
-                ),
-                awaitItem(),
-            )
-        }
-        verify { fileUtils.deleteFile(uri) }
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun `given avatar returned when avatar with the same id then uiState is updated`() = runTest {
-        val uri = mockk<Uri>()
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        every { fileUtils.deleteFile(any()) } returns Unit
-        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        val uploadedAvatar = createAvatar("2")
-        coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
-
-        viewModel = initViewModel()
-
-        advanceUntilIdle()
-
-        viewModel.uiState.test {
-            expectMostRecentItem()
-            viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
-
-            assertEquals(
-                AvatarPickerUiState(
-                    email = email,
-                    emailAvatars = emailAvatarsCopy,
-                    error = null,
-                    profile = ComponentState.Loaded(profile),
-                    selectingAvatarId = null,
-                    uploadingAvatar = uri,
-                    scrollToIndex = 0,
-                    avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal,
-                    failedUploads = emptySet(),
-                ),
-                awaitItem(),
-            )
-            assertEquals(
-                AvatarPickerUiState(
-                    email = email,
-                    emailAvatars = emailAvatarsCopy.copy(
-                        avatars = buildList {
-                            add(uploadedAvatar)
-                            add(createAvatar("1"))
-                        },
-                    ),
-                    error = null,
-                    profile = ComponentState.Loaded(profile),
-                    selectingAvatarId = null,
-                    uploadingAvatar = null,
-                    scrollToIndex = null,
-                    avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal,
                 ),
                 awaitItem(),
             )
@@ -567,7 +506,6 @@ class AvatarPickerViewModelTest {
             )
             assertEquals(
                 avatarPickerUiState.copy(
-                    emailAvatars = emailAvatarsCopy.copy(avatars = listOf(createAvatar("1"), createAvatar("3"))),
                     uploadingAvatar = null,
                     scrollToIndex = null,
                 ),
@@ -726,10 +664,6 @@ class AvatarPickerViewModelTest {
         viewModel.uiState.test {
             expectMostRecentItem()
 
-            val emailAvatarsUpdated = emailAvatars.copy(
-                avatars = listOf(createAvatar("1", isSelected = true), createAvatar("3", isSelected = false)),
-                selectedAvatarId = "1",
-            )
             viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriOne))
 
             // State before upload starts
@@ -750,9 +684,10 @@ class AvatarPickerViewModelTest {
                 awaitItem(),
             )
             // State produced before finishing uploadAvatar
+            // Note that emailAvatars will be updated though the observer when the repository emits the new value
             avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsUpdated,
+                emailAvatars = emailAvatarsCopy,
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = null,
@@ -761,23 +696,6 @@ class AvatarPickerViewModelTest {
                 avatarPickerContentLayout = avatarPickerContentLayout,
                 avatarUpdates = 1,
                 nonSelectedAvatarAlertVisible = true,
-            )
-            assertEquals(
-                avatarPickerUiState,
-                awaitItem(),
-            )
-            // State produced (in reaction of the emailAvatars change) to update the avatar non selected alert
-            avatarPickerUiState = AvatarPickerUiState(
-                email = email,
-                emailAvatars = emailAvatarsUpdated,
-                error = null,
-                profile = ComponentState.Loaded(profile),
-                selectingAvatarId = null,
-                uploadingAvatar = null,
-                scrollToIndex = null,
-                avatarPickerContentLayout = avatarPickerContentLayout,
-                avatarUpdates = 1,
-                nonSelectedAvatarAlertVisible = false,
             )
             assertEquals(
                 avatarPickerUiState,
@@ -959,10 +877,11 @@ class AvatarPickerViewModelTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
+    @Suppress("LongMethod")
     fun `given alert banner dismissed when avatar upload successful then nonSelectedAvatarAlertVisible is hidden`() =
         runTest {
             val uri = mockk<Uri>()
-            val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = null)
+            var emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = null)
             every { fileUtils.deleteFile(any()) } returns Unit
             coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
             coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
@@ -995,13 +914,24 @@ class AvatarPickerViewModelTest {
                 )
                 assertEquals(
                     avatarPickerUiState.copy(
-                        emailAvatars = emailAvatarsCopy.copy(
-                            avatars = buildList {
-                                add(uploadedAvatar)
-                                addAll(emailAvatarsCopy.avatars)
-                            },
-                            selectedAvatarId = "3",
-                        ),
+                        uploadingAvatar = null,
+                        scrollToIndex = null,
+                        avatarUpdates = 1,
+                    ),
+                    awaitItem(),
+                )
+                // Avatars are updated by the avatars flow in the repository
+                emailAvatarsCopy = emailAvatarsCopy.copy(
+                    avatars = buildList {
+                        add(uploadedAvatar)
+                        addAll(emailAvatarsCopy.avatars)
+                    },
+                    selectedAvatarId = "3",
+                )
+                avatarsFlow.emit(emailAvatarsCopy)
+                assertEquals(
+                    avatarPickerUiState.copy(
+                        emailAvatars = emailAvatarsCopy,
                         uploadingAvatar = null,
                         scrollToIndex = null,
                         avatarUpdates = 1,

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -220,9 +220,7 @@ class AvatarPickerViewModelTest {
             )
             assertEquals(
                 avatarPickerUiState.copy(
-                    emailAvatars = emailAvatarsCopy.copy(selectedAvatarId = avatars.last().imageId),
                     selectingAvatarId = null,
-                    scrollToIndex = 0,
                     avatarUpdates = 1,
                 ),
                 awaitItem(),

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -9,7 +9,6 @@ import com.gravatar.quickeditor.data.FileUtils
 import com.gravatar.quickeditor.data.ImageDownloader
 import com.gravatar.quickeditor.data.models.QuickEditorError
 import com.gravatar.quickeditor.data.repository.AvatarRepository
-import com.gravatar.quickeditor.data.repository.EmailAvatars
 import com.gravatar.quickeditor.ui.CoroutineTestRule
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.restapi.models.Avatar
@@ -46,7 +45,7 @@ class AvatarPickerViewModelTest {
     private val avatarRepository = mockk<AvatarRepository>()
     private val fileUtils = mockk<FileUtils>()
     private val imageDownloader = mockk<ImageDownloader>()
-    private val avatarsFlow = MutableSharedFlow<EmailAvatars>(replay = 1)
+    private val avatarsFlow = MutableSharedFlow<List<Avatar>>(replay = 1)
 
     private lateinit var viewModel: AvatarPickerViewModel
 
@@ -54,7 +53,7 @@ class AvatarPickerViewModelTest {
     private val avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal
     private val profile = defaultProfile(hash = "hash", displayName = "Display name")
     private val avatars = listOf(createAvatar("1"), createAvatar("2"))
-    private val emailAvatars = EmailAvatars(emptyList(), null)
+    private val emptyEmailAvatars = emptyList<Avatar>().toEmailAvatars()
     private val errorMessage = "errorMessage"
     private val invalidRequest = QuickEditorError.Request(
         ErrorType.InvalidRequest(
@@ -68,14 +67,14 @@ class AvatarPickerViewModelTest {
     @Before
     fun setup() {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Failure(ErrorType.Unknown())
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatars)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emptyList())
         coEvery { avatarRepository.getAvatarsFlow(email) } returns avatarsFlow
     }
 
     @Test
     fun `given view model initialization when avatars request succeed then uiState is updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = listOf(createAvatar(id = "1", isSelected = true), createAvatar("2"))
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -90,7 +89,7 @@ class AvatarPickerViewModelTest {
             assertEquals(
                 avatarPickerUiState.copy(
                     email = email,
-                    emailAvatars = emailAvatarsCopy,
+                    emailAvatars = avatars.toEmailAvatars(),
                     error = null,
                     profile = null,
                     scrollToIndex = 0,
@@ -137,7 +136,7 @@ class AvatarPickerViewModelTest {
             assertEquals(
                 avatarPickerUiState.copy(
                     email = email,
-                    emailAvatars = emailAvatars,
+                    emailAvatars = emptyEmailAvatars,
                     error = null,
                     profile = ComponentState.Loading,
                     nonSelectedAvatarAlertVisible = false,
@@ -147,7 +146,7 @@ class AvatarPickerViewModelTest {
             assertEquals(
                 avatarPickerUiState.copy(
                     email = email,
-                    emailAvatars = emailAvatars,
+                    emailAvatars = emptyEmailAvatars,
                     error = null,
                     profile = ComponentState.Loaded(profile),
                     nonSelectedAvatarAlertVisible = false,
@@ -169,7 +168,7 @@ class AvatarPickerViewModelTest {
             assertEquals(
                 avatarPickerUiState.copy(
                     email = email,
-                    emailAvatars = emailAvatars,
+                    emailAvatars = emptyEmailAvatars,
                     error = null,
                     profile = ComponentState.Loading,
                     nonSelectedAvatarAlertVisible = false,
@@ -179,7 +178,7 @@ class AvatarPickerViewModelTest {
             assertEquals(
                 avatarPickerUiState.copy(
                     email = email,
-                    emailAvatars = emailAvatars,
+                    emailAvatars = emptyEmailAvatars,
                     error = null,
                     profile = null,
                     nonSelectedAvatarAlertVisible = false,
@@ -192,8 +191,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given avatar when selected successful then uiState is updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId("1")
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
 
@@ -206,7 +205,7 @@ class AvatarPickerViewModelTest {
             viewModel.onEvent(AvatarPickerEvent.AvatarSelected(avatars.last()))
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy,
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = avatars.last().imageId,
@@ -234,8 +233,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given avatar when selected failure then uiState is updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId("1")
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
@@ -248,7 +247,7 @@ class AvatarPickerViewModelTest {
             viewModel.onEvent(AvatarPickerEvent.AvatarSelected(avatars.last()))
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy,
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = avatars.last().imageId,
@@ -309,12 +308,12 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given cropped image when upload successful then uiState is updated`() = runTest {
         val uri = mockk<Uri>()
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
+        val avatars = avatars.selectAvatarId("1")
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val uploadedAvatar = createAvatar("3")
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -326,7 +325,7 @@ class AvatarPickerViewModelTest {
 
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy,
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = null,
@@ -353,12 +352,12 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given cropped image when upload failure then uiState is updated`() = runTest {
         val uri = mockk<Uri>()
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
+        val avatars = avatars.selectAvatarId("1")
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -370,7 +369,7 @@ class AvatarPickerViewModelTest {
 
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy,
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = null,
@@ -398,13 +397,13 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given cropped image when upload successful then scrollToIndex updated`() = runTest {
         val uri = mockk<Uri>()
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "2")
+        val avatars = avatars.selectAvatarId("2")
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Success(createAvatar("3"))
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -432,13 +431,13 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given cropped image when upload failed then scrollToIndex updated`() = runTest {
         val uri = mockk<Uri>()
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "2")
+        val avatars = avatars.selectAvatarId("2")
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
 
@@ -467,10 +466,10 @@ class AvatarPickerViewModelTest {
     fun `given multiple failed uploads when upload successful then uiState is updated`() = runTest {
         val uriOne = mockk<Uri>()
         val uriTwo = mockk<Uri>()
-        val emailAvatarsCopy = emailAvatars.copy(avatars = listOf(createAvatar("3")), selectedAvatarId = "3")
+        val avatars = listOf(createAvatar("3", isSelected = true))
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
 
         viewModel = initViewModel()
@@ -489,7 +488,7 @@ class AvatarPickerViewModelTest {
             viewModel.onEvent(AvatarPickerEvent.ImageCropped(uriTwo))
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy,
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = null,
@@ -529,10 +528,10 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given failed avatar upload when FailedAvatarTapped then UiState updated`() = runTest {
         val uri = mockk<Uri>()
-        val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
+        val avatars = avatars.selectAvatarId("1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -551,12 +550,12 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given failed avatar upload dialog shown when FailedAvatarDismissed then UiState updated`() = runTest {
         val uri = mockk<Uri>()
-        val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
+        val avatars = avatars.selectAvatarId("1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -578,10 +577,10 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given failed avatar upload dialog shown when FailedAvatarDialogDismissed then UiState updated`() = runTest {
         val uri = mockk<Uri>()
-        val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
+        val avatars = avatars.selectAvatarId("1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Failure(invalidRequest)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -603,12 +602,12 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given failed avatar upload dialog shown when ImageCropped then UiState updated`() = runTest {
         val uri = mockk<Uri>()
-        val identityAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
+        val avatars = avatars.selectAvatarId("1")
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.uploadAvatar(any(), any())
         } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Server))
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(identityAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
 
         viewModel = initViewModel()
         viewModel.onEvent(AvatarPickerEvent.ImageCropped(uri))
@@ -647,13 +646,10 @@ class AvatarPickerViewModelTest {
     @Test
     fun `given no avatar selected when avatar upload success then avatar is selected - uiState is updated`() = runTest {
         val uriOne = mockk<Uri>()
-        val emailAvatarsCopy = emailAvatars.copy(
-            avatars = listOf(createAvatar("3", isSelected = false)),
-            selectedAvatarId = null,
-        )
+        val avatars = listOf(createAvatar("3", isSelected = false))
         every { fileUtils.deleteFile(any()) } returns Unit
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
+        coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
         val uploadedAvatar = createAvatar(id = "1", isSelected = true)
         coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
 
@@ -669,7 +665,7 @@ class AvatarPickerViewModelTest {
             // State before upload starts
             var avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy,
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = null,
@@ -687,7 +683,7 @@ class AvatarPickerViewModelTest {
             // Note that emailAvatars will be updated though the observer when the repository emits the new value
             avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy,
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 selectingAvatarId = null,
@@ -710,8 +706,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given selected avatar when delete successful then uiState is updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId(avatars.first().imageId)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns GravatarResult.Success(Unit)
 
@@ -725,7 +721,7 @@ class AvatarPickerViewModelTest {
             viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
             var avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy.copy(avatars = avatars.minus(avatarToDelete), selectedAvatarId = null),
+                emailAvatars = avatars.minus(avatarToDelete).toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 avatarPickerContentLayout = avatarPickerContentLayout,
@@ -761,8 +757,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given non selected avatar when delete successful then uiState is updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId(avatars.first().imageId)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns GravatarResult.Success(Unit)
 
@@ -776,10 +772,7 @@ class AvatarPickerViewModelTest {
             viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy.copy(
-                    avatars = avatars.minus(avatarToDelete),
-                    selectedAvatarId = avatars.first().imageId,
-                ),
+                emailAvatars = avatars.minus(avatarToDelete).toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 avatarPickerContentLayout = avatarPickerContentLayout,
@@ -800,8 +793,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given selected avatar when delete fails then uiState is updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId(avatars.first().imageId)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
@@ -811,14 +804,14 @@ class AvatarPickerViewModelTest {
 
         viewModel.uiState.test {
             expectMostRecentItem()
-            val avatarToDelete = avatars.first()
+            val avatarToDelete = this@AvatarPickerViewModelTest.avatars.first()
             viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
 
             awaitItem()
 
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy.copy(avatars = avatars, selectedAvatarId = avatars.first().imageId),
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 avatarPickerContentLayout = avatarPickerContentLayout,
@@ -839,8 +832,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given non selected avatar when delete fails then uiState is updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId(avatars.first().imageId)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
@@ -850,14 +843,14 @@ class AvatarPickerViewModelTest {
 
         viewModel.uiState.test {
             expectMostRecentItem()
-            val avatarToDelete = avatars.last() // Non selected avatar
+            val avatarToDelete = this@AvatarPickerViewModelTest.avatars.last() // Non selected avatar
             viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
 
             awaitItem()
 
             val avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy.copy(avatars = avatars, selectedAvatarId = avatars.first().imageId),
+                emailAvatars = avatars.toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 avatarPickerContentLayout = avatarPickerContentLayout,
@@ -881,10 +874,9 @@ class AvatarPickerViewModelTest {
     fun `given alert banner dismissed when avatar upload successful then nonSelectedAvatarAlertVisible is hidden`() =
         runTest {
             val uri = mockk<Uri>()
-            var emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = null)
             every { fileUtils.deleteFile(any()) } returns Unit
             coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
-            coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(emailAvatarsCopy)
+            coEvery { avatarRepository.getAvatars(any()) } returns GravatarResult.Success(avatars)
             val uploadedAvatar = createAvatar("3", isSelected = true)
             coEvery { avatarRepository.uploadAvatar(any(), any()) } returns GravatarResult.Success(uploadedAvatar)
 
@@ -899,7 +891,7 @@ class AvatarPickerViewModelTest {
 
                 val avatarPickerUiState = AvatarPickerUiState(
                     email = email,
-                    emailAvatars = emailAvatarsCopy,
+                    emailAvatars = avatars.toEmailAvatars(),
                     error = null,
                     profile = ComponentState.Loaded(profile),
                     selectingAvatarId = null,
@@ -921,17 +913,14 @@ class AvatarPickerViewModelTest {
                     awaitItem(),
                 )
                 // Avatars are updated by the avatars flow in the repository
-                emailAvatarsCopy = emailAvatarsCopy.copy(
-                    avatars = buildList {
-                        add(uploadedAvatar)
-                        addAll(emailAvatarsCopy.avatars)
-                    },
-                    selectedAvatarId = "3",
-                )
-                avatarsFlow.emit(emailAvatarsCopy)
+                val updatedAvatars = buildList {
+                    add(uploadedAvatar)
+                    addAll(avatars)
+                }
+                avatarsFlow.emit(updatedAvatars)
                 assertEquals(
                     avatarPickerUiState.copy(
-                        emailAvatars = emailAvatarsCopy,
+                        emailAvatars = updatedAvatars.toEmailAvatars(),
                         uploadingAvatar = null,
                         scrollToIndex = null,
                         avatarUpdates = 1,
@@ -948,8 +937,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given avatar already deleted when delete returns 404 then uiState is updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = avatars.first().imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId(avatars.first().imageId)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.deleteAvatar(any(), any()) } returns
             GravatarResult.Failure(QuickEditorError.Request(ErrorType.NotFound))
@@ -964,7 +953,7 @@ class AvatarPickerViewModelTest {
             viewModel.onEvent(AvatarPickerEvent.AvatarDeleteSelected(avatarToDelete.imageId))
             var avatarPickerUiState = AvatarPickerUiState(
                 email = email,
-                emailAvatars = emailAvatarsCopy.copy(avatars = avatars.minus(avatarToDelete), selectedAvatarId = null),
+                emailAvatars = avatars.minus(avatarToDelete).toEmailAvatars(),
                 error = null,
                 profile = ComponentState.Loaded(profile),
                 avatarPickerContentLayout = avatarPickerContentLayout,
@@ -990,8 +979,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given avatar when download queued then AvatarDownloadStarted sent`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId("1")
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
         coEvery { imageDownloader.downloadImage(any()) } returns GravatarResult.Success(Unit)
@@ -1000,7 +989,7 @@ class AvatarPickerViewModelTest {
 
         advanceUntilIdle()
 
-        viewModel.onEvent(AvatarPickerEvent.DownloadAvatarTapped(avatars.first()))
+        viewModel.onEvent(AvatarPickerEvent.DownloadAvatarTapped(this@AvatarPickerViewModelTest.avatars.first()))
 
         viewModel.actions.test {
             assertEquals(AvatarPickerAction.AvatarDownloadStarted, awaitItem())
@@ -1010,7 +999,7 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given avatar when download manager disabled then uiState updated`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
+        val emailAvatarsCopy = avatars.selectAvatarId("1")
         coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
@@ -1032,8 +1021,8 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given avatar when download manager not available then DownloadManagerNotAvailable sent`() = runTest {
-        val emailAvatarsCopy = emailAvatars.copy(avatars = avatars, selectedAvatarId = "1")
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = avatars.selectAvatarId("1")
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery { avatarRepository.selectAvatar(any(), any()) } returns GravatarResult.Success(Unit)
         coEvery {
@@ -1056,9 +1045,9 @@ class AvatarPickerViewModelTest {
     fun `given avatarId when updateAvatar succeeds then uiState is updated`() = runTest {
         val avatarId = "avatarId"
         val rating = Avatar.Rating.PG
-        val oldAvatar = createAvatar(avatarId)
-        val emailAvatarsCopy = emailAvatars.copy(avatars = listOf(oldAvatar), selectedAvatarId = avatarId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val oldAvatar = createAvatar(avatarId, isSelected = true)
+        val avatars = listOf(oldAvatar)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         val updatedAvatar = oldAvatar.copy(rating)
         coEvery {
@@ -1072,11 +1061,10 @@ class AvatarPickerViewModelTest {
         viewModel.uiState.test {
             expectMostRecentItem()
             viewModel.onEvent(AvatarPickerEvent.AvatarRatingSelected(avatarId, rating))
-            val updatedEmailAvatars = emailAvatarsCopy.copy(avatars = listOf(updatedAvatar))
             assertEquals(
                 AvatarPickerUiState(
                     email = email,
-                    emailAvatars = updatedEmailAvatars,
+                    emailAvatars = listOf(updatedAvatar).toEmailAvatars(),
                     profile = ComponentState.Loaded(profile),
                     avatarPickerContentLayout = avatarPickerContentLayout,
                     scrollToIndex = 0,
@@ -1095,8 +1083,8 @@ class AvatarPickerViewModelTest {
         val avatarId = "avatarId"
         val rating = Avatar.Rating.PG
         val oldAvatar = createAvatar(avatarId, isSelected = true)
-        val emailAvatarsCopy = emailAvatars.copy(avatars = listOf(oldAvatar), selectedAvatarId = avatarId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = listOf(oldAvatar)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.updateAvatar(email, avatarId, rating)
@@ -1110,11 +1098,10 @@ class AvatarPickerViewModelTest {
             expectMostRecentItem()
             viewModel.onEvent(AvatarPickerEvent.AvatarRatingSelected(avatarId, rating))
             val updatedAvatar = oldAvatar.copy(rating)
-            val updatedEmailAvatars = emailAvatarsCopy.copy(avatars = listOf(updatedAvatar))
             assertEquals(
                 AvatarPickerUiState(
                     email = email,
-                    emailAvatars = updatedEmailAvatars,
+                    emailAvatars = listOf(updatedAvatar).toEmailAvatars(),
                     profile = ComponentState.Loaded(profile),
                     avatarPickerContentLayout = avatarPickerContentLayout,
                     scrollToIndex = 0,
@@ -1124,7 +1111,7 @@ class AvatarPickerViewModelTest {
             assertEquals(
                 AvatarPickerUiState(
                     email = email,
-                    emailAvatars = emailAvatarsCopy,
+                    emailAvatars = avatars.toEmailAvatars(),
                     profile = ComponentState.Loaded(profile),
                     avatarPickerContentLayout = avatarPickerContentLayout,
                     scrollToIndex = 0,
@@ -1144,8 +1131,8 @@ class AvatarPickerViewModelTest {
         val rating = Avatar.Rating.PG
         val altText = "New Alt"
         val oldAvatar = createAvatar(avatarId, isSelected = true, rating = rating, altText = altText)
-        val emailAvatarsCopy = emailAvatars.copy(avatars = listOf(oldAvatar), selectedAvatarId = avatarId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatars = listOf(oldAvatar)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
         coEvery {
             avatarRepository.updateAvatar(email, avatarId, rating)
@@ -1182,9 +1169,9 @@ class AvatarPickerViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given AvatarAltTextTapped event when received then LaunchAvatarAltText action is launched`() = runTest {
-        val avatar = createAvatar("1")
-        val emailAvatarsCopy = emailAvatars.copy(avatars = listOf(avatar), selectedAvatarId = avatar.imageId)
-        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatarsCopy)
+        val avatar = createAvatar("1", isSelected = true)
+        val avatars = listOf(avatar)
+        coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(avatars)
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
 
         viewModel = initViewModel()
@@ -1200,7 +1187,7 @@ class AvatarPickerViewModelTest {
             assertEquals(
                 AvatarPickerUiState(
                     email = email,
-                    emailAvatars = emailAvatarsCopy,
+                    emailAvatars = avatars.toEmailAvatars(),
                     profile = ComponentState.Loaded(profile),
                     avatarPickerContentLayout = avatarPickerContentLayout,
                     scrollToIndex = 0,
@@ -1208,6 +1195,10 @@ class AvatarPickerViewModelTest {
                 awaitItem(),
             )
         }
+    }
+
+    private fun List<Avatar>.selectAvatarId(avatarId: String) = map {
+        it.copy(selected = it.imageId == avatarId)
     }
 
     private fun initViewModel(handleExpiredSession: Boolean = true) = AvatarPickerViewModel(

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -25,6 +25,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -45,6 +46,7 @@ class AvatarPickerViewModelTest {
     private val avatarRepository = mockk<AvatarRepository>()
     private val fileUtils = mockk<FileUtils>()
     private val imageDownloader = mockk<ImageDownloader>()
+    private val avatarsFlow = MutableSharedFlow<EmailAvatars>(replay = 1)
 
     private lateinit var viewModel: AvatarPickerViewModel
 
@@ -67,6 +69,7 @@ class AvatarPickerViewModelTest {
     fun setup() {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Failure(ErrorType.Unknown())
         coEvery { avatarRepository.getAvatars(email) } returns GravatarResult.Success(emailAvatars)
+        coEvery { avatarRepository.getAvatarsFlow(email) } returns avatarsFlow
     }
 
     @Test

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -3,6 +3,7 @@ package com.gravatar.quickeditor.ui.avatarpicker
 import android.net.Uri
 import app.cash.turbine.test
 import com.gravatar.extensions.defaultProfile
+import com.gravatar.quickeditor.createAvatar
 import com.gravatar.quickeditor.data.DownloadManagerError
 import com.gravatar.quickeditor.data.FileUtils
 import com.gravatar.quickeditor.data.ImageDownloader
@@ -33,7 +34,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
-import java.net.URI
 
 @Suppress("LargeClass")
 class AvatarPickerViewModelTest {
@@ -1219,18 +1219,4 @@ class AvatarPickerViewModelTest {
         fileUtils = fileUtils,
         imageDownloader = imageDownloader,
     )
-
-    private fun createAvatar(
-        id: String,
-        isSelected: Boolean? = null,
-        rating: Avatar.Rating = Avatar.Rating.G,
-        altText: String = "alt",
-    ) = Avatar {
-        imageUrl = URI.create("https://gravatar.com/avatar/test")
-        imageId = id
-        this.rating = rating
-        this.altText = altText
-        updatedDate = ""
-        selected = isSelected
-    }
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -68,7 +68,7 @@ class AvatarPickerViewModelTest {
     fun setup() {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Failure(ErrorType.Unknown())
         coEvery { avatarRepository.refreshAvatars(email) } returns GravatarResult.Success(emptyList())
-        coEvery { avatarRepository.getAvatarsFlow(email) } returns avatarsFlow
+        coEvery { avatarRepository.getAvatars(email) } returns avatarsFlow
     }
 
     @Test


### PR DESCRIPTION
Closes #516 

### Description

With the new `AltTextPage`, we need to save the avatar's data in a shared place as we need to access that info from both screens. We already have the `AvatarsRepository`, so that's the best place to keep the avatars list locally. We need to create a flow for each email and update that flow in every repository operation.

We were doing a similar thing in the `AvatarPickerViewModel`. We had a variable where we kept the avatars list and updated it in the different operations (avatar upload, deletion, selection...). This PR moves that logic to the repository while sharing the avatar flow for each email. 

### Testing Steps

Everything should work as before except the AltText, where this PR should solve the issue of reopening the AltText page after changing it. In that situation, the new AltText should be visible, not as it was before when the old AltText was visible.

- Smoke test all the operations in the QE (avatar upload, deletion, selection, rating)
- Test that after changing the `AltText` and reopening the AltTextPage for the same image, the new AltText is visible instead of the old one.

https://github.com/user-attachments/assets/9257df1d-8c47-410a-8717-df6c2cf61b52