### PR TITLE
Fix no avatar selected banner shown when avatar list empty

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModel.kt
@@ -423,21 +423,13 @@ internal class AvatarPickerViewModel(
     private fun nonAvatarSelectedAlertObserver() {
         _uiState
             .filter { it.emailAvatars != null }
-            .map { it.emailAvatars?.selectedAvatarId != null }
+            .map { it.emailAvatars?.selectedAvatarId == null && it.emailAvatars?.avatars?.isNotEmpty() == true }
             .distinctUntilChanged()
-            .onEach { isAvatarSelected ->
-                if (isAvatarSelected) {
-                    _uiState.update { currentState ->
-                        currentState.copy(
-                            nonSelectedAvatarAlertVisible = false,
-                        )
-                    }
-                } else {
-                    _uiState.update { currentState ->
-                        currentState.copy(
-                            nonSelectedAvatarAlertVisible = true,
-                        )
-                    }
+            .onEach { shouldShowAlert ->
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        nonSelectedAvatarAlertVisible = shouldShowAlert,
+                    )
                 }
             }
             .launchIn(viewModelScope)

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPickerViewModelTest.kt
@@ -151,17 +151,6 @@ class AvatarPickerViewModelTest {
                 ),
                 awaitItem(),
             )
-            // Checking that the nonSelectedAvatarAlertVisible is set to true after emails are loaded
-            assertEquals(
-                avatarPickerUiState.copy(
-                    email = email,
-                    emailAvatars = emailAvatars,
-                    error = null,
-                    profile = ComponentState.Loaded(profile),
-                    nonSelectedAvatarAlertVisible = true,
-                ),
-                awaitItem(),
-            )
         }
     }
 
@@ -194,7 +183,6 @@ class AvatarPickerViewModelTest {
                 ),
                 awaitItem(),
             )
-            skipItems(1) // skipping the nonAvatarSelectedAlertVisible state
         }
     }
 
@@ -1243,6 +1231,20 @@ class AvatarPickerViewModelTest {
         }
         viewModel.actions.test {
             expectNoEvents()
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `given empty avatar list when loaded then avatar not selected banner invisible`() = runTest {
+        coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(profile)
+
+        viewModel = initViewModel()
+
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            assertEquals(false, awaitItem().nonSelectedAvatarAlertVisible)
         }
     }
 


### PR DESCRIPTION
Closes #519

### Description

This PR fixes a bug where the alert banner about no selected avatar is visible when no avatars are uploaded.

| Before | After |
|---|---|
| <img width="563" alt="Screenshot 2025-01-07 at 11 35 03" src="https://github.com/user-attachments/assets/4e1d0bf5-506d-4af2-9792-dc0ff1902f7a" /> | <img width="346" alt="Screenshot 2025-01-08 at 11 36 24" src="https://github.com/user-attachments/assets/b7ceeebc-4081-4750-acc4-4e7292d19547" /> |


### Testing Steps

1. Make sure you have no avatars uploaded
2. Launch the QE
3. The banner shouldn't be visible
4. You can upload two avatars (make sure the banner is not visible when uploading the first one), select one, and remove: 
5. Selected one first
6. Then select the other
7. Make sure the banner visibility is correct with each step
