### PR TITLE
Handle the back navigation manually in the QuickEditor

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -12,7 +12,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import androidx.navigation.navOptions
 import com.gravatar.quickeditor.QuickEditorContainer
 import com.gravatar.quickeditor.ui.alttext.AltTextPage
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarPicker
@@ -74,7 +73,9 @@ internal fun GravatarQuickEditorPage(
             handleExpiredSession = true,
             navController = navController,
             onAvatarSelected = onAvatarSelected,
-            onSessionExpired = { navController.navigate(QuickEditorPage.OAUTH.name) },
+            onSessionExpired = {
+                navController.navigateAndClean(QuickEditorPage.OAUTH.name)
+            },
         )
     }
 }
@@ -152,9 +153,6 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
                     val encodedUrl = URLEncoder.encode(avatarUrl, StandardCharsets.UTF_8.toString())
                     navController.navigate(
                         route = "${EditorNavDestinations.ALT_TEXT.name}/$email/$avatarId/$altText/$encodedUrl",
-                        navOptions = navOptions {
-                            popUpTo(EditorNavDestinations.AVATAR_SELECTION.name) { saveState = true }
-                        },
                     )
                 },
             )

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -53,9 +53,9 @@ internal fun GravatarQuickEditorPage(
         composable(route = QuickEditorPage.SPLASH.name) {
             SplashPage(email = gravatarQuickEditorParams.email) { isAuthorized ->
                 if (isAuthorized) {
-                    navController.navigate(QuickEditorPage.EDITOR.name)
+                    navController.navigateAndClean(QuickEditorPage.EDITOR.name)
                 } else {
-                    navController.navigate(QuickEditorPage.OAUTH.name)
+                    navController.navigateAndClean(QuickEditorPage.OAUTH.name)
                 }
             }
         }
@@ -64,7 +64,9 @@ internal fun GravatarQuickEditorPage(
                 oAuthParams = oAuthParams,
                 email = gravatarQuickEditorParams.email,
                 onAuthError = { onDismiss(GravatarQuickEditorDismissReason.OauthFailed) },
-                onAuthSuccess = { navController.navigate(QuickEditorPage.EDITOR.name) },
+                onAuthSuccess = {
+                    navController.navigateAndClean(QuickEditorPage.EDITOR.name)
+                },
             )
         }
         addAvatarPickerGraph(
@@ -116,7 +118,7 @@ internal fun GravatarQuickEditorPage(
                 email = gravatarQuickEditorParams.email,
                 token = authToken,
             ) {
-                navController.navigate(QuickEditorPage.EDITOR.name)
+                navController.navigateAndClean(QuickEditorPage.EDITOR.name)
             }
         }
         addAvatarPickerGraph(
@@ -179,4 +181,11 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
             )
         }
     }
+}
+
+private fun NavHostController.navigateAndClean(route: String) {
+    navigate(route = route) {
+        popUpTo(graph.startDestinationId) { inclusive = true }
+    }
+    graph.setStartDestination(route)
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -2,6 +2,7 @@ package com.gravatar.quickeditor.ui.editor.bottomsheet
 
 import android.content.res.Configuration
 import android.graphics.Color
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -35,6 +36,7 @@ import androidx.window.core.layout.WindowHeightSizeClass
 import com.composables.core.LocalModalWindow
 import com.composables.core.ModalBottomSheet
 import com.composables.core.ModalBottomSheetState
+import com.composables.core.ModalSheetProperties
 import com.composables.core.Scrim
 import com.composables.core.Sheet
 import com.composables.core.SheetDetent
@@ -151,7 +153,13 @@ private fun GravatarModalBottomSheet(
         GravatarTheme {
             ModalBottomSheet(
                 state = modalBottomSheetState,
+                properties = ModalSheetProperties(dismissOnBackPress = false),
             ) {
+                BackHandler {
+                    coroutineScope.launch {
+                        modalBottomSheetState.animateTo(Hidden)
+                    }
+                }
                 // Modal content must be taking the uiMode from Activity and doesn't respect
                 // the above set CompositionLocalProvider
                 CompositionLocalProvider(


### PR DESCRIPTION
Closes #513

### Description

The system back button wouldn't work properly after showing the keyboard. For some reason, the `AltTextPage`'s back handler would lose the priority and the Bottom Sheet would take over and dismiss itself. 

I could figure out why, but rather than trying to fix this, I went ahead and implemented the back behavior manually, by properly clearing the navigation stack and hiding the bottom sheet when nothing is left. I think this is the way to go now, given we have an actual pages in the stack that should be kept. 

### Testing Steps

1. Test the back button behavior within the Quick Editor. Test OAuth flow, Alt text modifications, etc.
