### PR TITLE
QuickEditor: Fix `AvatarStorage.updateAvatar` to not override the `selected` value 

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/AvatarStorage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/storage/AvatarStorage.kt
@@ -73,7 +73,9 @@ internal class AvatarStorage {
             val avatars = avatarsFlow.replayCache.lastOrNull()?.let {
                 it.map { avatar ->
                     if (avatar.imageId == avatarToUpdate.imageId) {
-                        avatarToUpdate
+                        // If the avatarToUpdate has a selected value, use it.
+                        // Otherwise, use the stored avatar selected value.
+                        avatarToUpdate.copy(selected = avatarToUpdate.selected ?: avatar.selected)
                     } else {
                         avatar
                     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/storage/AvatarStorageTest.kt
@@ -2,6 +2,7 @@ package com.gravatar.quickeditor.data.storage
 
 import app.cash.turbine.test
 import com.gravatar.quickeditor.createAvatar
+import com.gravatar.quickeditor.ui.avatarpicker.copy
 import com.gravatar.types.Email
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
@@ -106,18 +107,45 @@ class AvatarStorageTest {
     }
 
     @Test
-    fun `given avatar when updateAvatar then avatarsFlow emits avatars with updated avatar`() = runTest {
+    fun `given avatar without selected info when updateAvatar then emits avatars with updated avatar`() = runTest {
         val email = Email("email")
 
         // Given
-        val avatars = listOf(createAvatar("otherAvatar"), createAvatar("imageId", altText = "altText"))
+        val avatars = listOf(
+            createAvatar("otherAvatar"),
+            createAvatar("imageId", altText = "altText", isSelected = true),
+        )
         avatarStorage.storeAvatars(avatars, email)
 
-        // When
+        // When - Updated avatar without selected info
         val updatedAvatar = createAvatar("imageId", altText = "newAltText")
         avatarStorage.updateAvatar(email, updatedAvatar)
 
-        // Then
+        // Then - Updated avatar should keep the selected value from the previous stored avatar
+        avatarStorage.avatarsFlow(email).test {
+            assertEquals(
+                listOf(createAvatar("otherAvatar"), updatedAvatar.copy(selected = true)),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `given avatar with selected info when updateAvatar then emits avatars with updated avatar`() = runTest {
+        val email = Email("email")
+
+        // Given
+        val avatars = listOf(
+            createAvatar("otherAvatar"),
+            createAvatar("imageId", altText = "altText", isSelected = false),
+        )
+        avatarStorage.storeAvatars(avatars, email)
+
+        // When - Updated avatar with selected info
+        val updatedAvatar = createAvatar("imageId", altText = "newAltText", isSelected = true)
+        avatarStorage.updateAvatar(email, updatedAvatar)
+
+        // Then - Updated avatar should keep the selected value from the updated avatar
         avatarStorage.avatarsFlow(email).test {
             assertEquals(
                 listOf(createAvatar("otherAvatar"), updatedAvatar),


### PR DESCRIPTION
Closes #526 

### Description

The `PATCH` to update avatars doesn't receive the email, so, in the backend, we can't decide if that's the avatar selected for the email we are working with.

In the `AvatarStorage.updateAvatar` method, we should only use the value from the `updatedAvatar` if it's not `null`. Otherwise, we should keep the stored avatar's selected value.

<details>
<summary> Before </summary>

https://github.com/user-attachments/assets/3b2fe41b-13a7-41c8-b585-4d33588540f8
</details>

<details>
<summary> After </summary>

https://github.com/user-attachments/assets/f30f84e1-ff05-4b5c-853d-1fb5803c0a7e
</details>

### Testing Steps

1. Open the QE
2. Select an avatar (if you don't have one selected already)
3. Modify the rating of the selected avatar
4. Verify that you still see the avatar as selected when the rating is modified
5. Open the AltTextPage and modify the AltText for the selected avatar
6. Verify that you still see the avatar as selected when the AltText is modified