### PR TITLE
QuickEditor: Load Avatar object from `AvatarsRepository` in `AltTextViewModel`

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/data/repository/AvatarRepository.kt
@@ -21,6 +21,9 @@ internal class AvatarRepository(
 ) {
     fun getAvatars(email: Email) = avatarStorage.avatarsFlow(email).asSharedFlow()
 
+    fun getAvatar(email: Email, avatarId: String): Avatar? =
+        getAvatars(email).replayCache.firstOrNull()?.firstOrNull { it.imageId == avatarId }
+
     suspend fun refreshAvatars(email: Email): GravatarResult<List<Avatar>, QuickEditorError> = withContext(dispatcher) {
         val token = tokenStorage.getToken(email.hash().toString())
         token?.let {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextAction.kt
@@ -4,4 +4,6 @@ internal sealed class AltTextAction {
     data object AltTextUpdated : AltTextAction()
 
     data object AltTextUpdateFailed : AltTextAction()
+
+    data object AvatarCantBeLoaded : AltTextAction()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextPage.kt
@@ -49,6 +49,7 @@ import com.gravatar.ui.GravatarTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.net.URI
 import java.net.URL
 
 /** Gravatar Alt Text help URL */
@@ -59,12 +60,10 @@ private const val GRAVATAR_ALT_TEXT_HELP_URL: String =
 internal fun AltTextPage(
     email: String,
     avatarId: String,
-    altText: String,
-    avatarUrl: String,
     onBackPressed: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: AltTextViewModel = viewModel(
-        factory = AltTextViewModelFactory(email, avatarId, altText, avatarUrl),
+        factory = AltTextViewModelFactory(email, avatarId),
     ),
 ) {
     BackHandler {
@@ -82,7 +81,9 @@ internal fun AltTextPage(
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.actions.collect { action ->
                     when (action) {
-                        is AltTextAction.AltTextUpdated -> {
+                        is AltTextAction.AvatarCantBeLoaded,
+                        is AltTextAction.AltTextUpdated,
+                        -> {
                             onBackPressed()
                         }
 
@@ -203,9 +204,9 @@ internal fun AltTextPage(
     }
 }
 
-private fun AltTextUiState.imageUrlWithSize(sizePx: Int) = URL(avatarUrl).let { url ->
+private fun AltTextUiState.imageUrlWithSize(sizePx: Int) = avatarUrl?.toURL()?.let { url ->
     URL(url.protocol, url.host, url.path.plus("?size=$sizePx"))
-}.toString()
+}?.toString().orEmpty()
 
 @Composable
 @Preview(showBackground = true)
@@ -213,7 +214,7 @@ private fun AltTextPagePreview() {
     GravatarTheme {
         AltTextPage(
             altTextState = AltTextUiState(
-                avatarUrl = "https://gravatar.com/avatar/test",
+                avatarUrl = URI.create("https://gravatar.com/avatar/test"),
                 isUpdating = false,
                 altText = "alt",
                 isSaveButtonEnabled = true,
@@ -229,7 +230,7 @@ private fun AltTextPageEmptyAltTextPreview() {
     GravatarTheme {
         AltTextPage(
             altTextState = AltTextUiState(
-                avatarUrl = "https://gravatar.com/avatar/test",
+                avatarUrl = URI.create("https://gravatar.com/avatar/test"),
                 isUpdating = false,
                 altText = "",
                 isSaveButtonEnabled = true,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextUiState.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextUiState.kt
@@ -1,8 +1,10 @@
 package com.gravatar.quickeditor.ui.alttext
 
+import java.net.URI
+
 internal data class AltTextUiState(
-    val avatarUrl: String,
+    val avatarUrl: URI? = null,
     val isSaveButtonEnabled: Boolean,
     val isUpdating: Boolean,
-    val altText: String,
+    val altText: String = "",
 )

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModel.kt
@@ -37,9 +37,7 @@ internal class AltTextViewModel(
 
     private fun getAvatarData() {
         viewModelScope.launch {
-            val avatar = avatarRepository.getAvatars(
-                Email(email),
-            ).replayCache.firstOrNull()?.firstOrNull { it.imageId == avatarId }
+            val avatar = avatarRepository.getAvatar(Email(email), avatarId)
             if (avatar != null) {
                 originalAltText = avatar.altText
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModel.kt
@@ -19,17 +19,41 @@ import kotlinx.coroutines.launch
 internal class AltTextViewModel(
     private val email: String,
     private val avatarId: String,
-    private val altText: String,
-    avatarUrl: String,
     private val avatarRepository: AvatarRepository,
 ) : ViewModel() {
     private val _uiState =
         MutableStateFlow(
-            AltTextUiState(avatarUrl = avatarUrl, isSaveButtonEnabled = false, isUpdating = false, altText = altText),
+            AltTextUiState(isSaveButtonEnabled = false, isUpdating = false),
         )
     val uiState: StateFlow<AltTextUiState> = _uiState.asStateFlow()
     private val _actions = Channel<AltTextAction>(Channel.BUFFERED)
     val actions = _actions.receiveAsFlow()
+
+    private lateinit var originalAltText: String
+
+    init {
+        getAvatarData()
+    }
+
+    private fun getAvatarData() {
+        viewModelScope.launch {
+            val avatar = avatarRepository.getAvatars(
+                Email(email),
+            ).replayCache.firstOrNull()?.firstOrNull { it.imageId == avatarId }
+            if (avatar != null) {
+                originalAltText = avatar.altText
+
+                _uiState.update {
+                    it.copy(
+                        avatarUrl = avatar.imageUrl,
+                        altText = avatar.altText,
+                    )
+                }
+            } else {
+                _actions.send(AltTextAction.AvatarCantBeLoaded)
+            }
+        }
+    }
 
     fun onEvent(event: AltTextEvent) {
         when (event) {
@@ -75,7 +99,7 @@ internal class AltTextViewModel(
             _uiState.update { currentState ->
                 currentState.copy(
                     altText = newAltText,
-                    isSaveButtonEnabled = newAltText != altText,
+                    isSaveButtonEnabled = newAltText != originalAltText,
                 )
             }
         }
@@ -85,16 +109,12 @@ internal class AltTextViewModel(
 internal class AltTextViewModelFactory(
     private val email: String,
     private val avatarId: String,
-    private val altText: String,
-    private val avatarUrl: String,
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
         return AltTextViewModel(
             email = email,
             avatarId = avatarId,
-            altText = altText,
-            avatarUrl = avatarUrl,
             avatarRepository = QuickEditorContainer.getInstance().avatarRepository,
         ) as T
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/avatarpicker/AvatarPicker.kt
@@ -89,7 +89,7 @@ internal fun AvatarPicker(
     handleExpiredSession: Boolean,
     onAvatarSelected: () -> Unit,
     onSessionExpired: () -> Unit,
-    onAltTextTapped: (email: String, avatarId: String, altText: String, avatarUrl: String) -> Unit,
+    onAltTextTapped: (email: String, avatarId: String) -> Unit,
     viewModel: AvatarPickerViewModel = viewModel(
         factory = AvatarPickerViewModelFactory(gravatarQuickEditorParams, handleExpiredSession),
     ),
@@ -334,7 +334,7 @@ private fun AvatarPickerAction.handle(
     cropperLauncher: CropperLauncher,
     onAvatarSelected: () -> Unit,
     onSessionExpired: () -> Unit,
-    onAltTextTapped: (email: String, avatarId: String, altText: String, avatarUrl: String) -> Unit,
+    onAltTextTapped: (email: String, avatarId: String) -> Unit,
     snackState: SnackbarHostState,
     context: Context,
     uCropLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>,
@@ -425,8 +425,6 @@ private fun AvatarPickerAction.handle(
         is AvatarPickerAction.LaunchAvatarAltText -> onAltTextTapped(
             email.toString(),
             avatar.imageId,
-            avatar.altText,
-            avatar.imageUrl.toString(),
         )
     }
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -20,8 +20,6 @@ import com.gravatar.quickeditor.ui.navigation.QuickEditorPage
 import com.gravatar.quickeditor.ui.oauth.OAuthPage
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
 import com.gravatar.quickeditor.ui.splash.SplashPage
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 /**
  * Raw composable component for the Quick Editor.
@@ -149,32 +147,25 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
                 handleExpiredSession = handleExpiredSession,
                 onAvatarSelected = onAvatarSelected,
                 onSessionExpired = onSessionExpired,
-                onAltTextTapped = { email, avatarId, altText, avatarUrl ->
-                    val encodedUrl = URLEncoder.encode(avatarUrl, StandardCharsets.UTF_8.toString())
+                onAltTextTapped = { email, avatarId ->
                     navController.navigate(
-                        route = "${EditorNavDestinations.ALT_TEXT.name}/$email/$avatarId/$altText/$encodedUrl",
+                        route = "${EditorNavDestinations.ALT_TEXT.name}/$email/$avatarId",
                     )
                 },
             )
         }
         composable(
-            route = "${EditorNavDestinations.ALT_TEXT.name}/{email}/{avatarId}/{altText}/{avatarUrl}",
+            route = "${EditorNavDestinations.ALT_TEXT.name}/{email}/{avatarId}",
             arguments = listOf(
                 navArgument("email") { type = NavType.StringType },
                 navArgument("avatarId") { type = NavType.StringType },
-                navArgument("altText") { type = NavType.StringType },
-                navArgument("avatarUrl") { type = NavType.StringType },
             ),
         ) {
             val email = requireNotNull(it.arguments?.getString("email"))
             val avatarId = requireNotNull(it.arguments?.getString("avatarId"))
-            val altText = requireNotNull(it.arguments?.getString("altText"))
-            val avatarUrl = requireNotNull(it.arguments?.getString("avatarUrl"))
             AltTextPage(
                 email = email,
                 avatarId = avatarId,
-                altText = altText,
-                avatarUrl = avatarUrl,
                 onBackPressed = { navController.popBackStack() },
             )
         }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/AvatarTestUtils.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/AvatarTestUtils.kt
@@ -8,8 +8,9 @@ internal fun createAvatar(
     isSelected: Boolean? = null,
     rating: Avatar.Rating = Avatar.Rating.G,
     altText: String = "alt",
+    url: URI = URI.create("https://gravatar.com/avatar/test"),
 ) = Avatar {
-    imageUrl = URI.create("https://gravatar.com/avatar/test")
+    imageUrl = url
     imageId = id
     this.rating = rating
     this.altText = altText

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/repository/AvatarRepositoryTest.kt
@@ -97,6 +97,30 @@ class AvatarRepositoryTest {
     }
 
     @Test
+    fun `given email and avatarId when avatar is in avatarStore then avatar is returned`() = runTest {
+        val avatarId = "avatarId"
+        val avatar = createAvatar(avatarId)
+        coEvery { avatarStorage.avatarsFlow(email) } returns mockk {
+            every { replayCache } returns listOf(listOf(avatar))
+        }
+
+        val result = avatarRepository.getAvatar(email, avatarId)
+
+        assertEquals(avatar, result)
+    }
+
+    @Test
+    fun `given email and avatarId when avatar is not in avatarStore then null is returned`() = runTest {
+        coEvery { avatarStorage.avatarsFlow(email) } returns mockk {
+            every { replayCache } returns listOf(emptyList())
+        }
+
+        val result = avatarRepository.getAvatar(email, "nonExistentAvatarId")
+
+        assertEquals(null, result)
+    }
+
+    @Test
     fun `given email stored when token not found then TokenNotFound result`() = runTest {
         coEvery { tokenStorage.getToken(any()) } returns null
 

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/alttext/AltTextPageTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/alttext/AltTextPageTest.kt
@@ -5,6 +5,7 @@ import com.gravatar.ui.GravatarTheme
 import com.gravatar.uitestutils.RoborazziTest
 import org.junit.Test
 import org.robolectric.annotation.Config
+import java.net.URI
 
 class AltTextPageTest : RoborazziTest() {
     @Test
@@ -12,7 +13,7 @@ class AltTextPageTest : RoborazziTest() {
         GravatarTheme {
             AltTextPage(
                 altTextState = AltTextUiState(
-                    avatarUrl = "https://gravatar.com/avatar/test",
+                    avatarUrl = URI("https://gravatar.com/avatar/test"),
                     isUpdating = false,
                     altText = "alt",
                     isSaveButtonEnabled = false,
@@ -28,7 +29,7 @@ class AltTextPageTest : RoborazziTest() {
         GravatarTheme {
             AltTextPage(
                 altTextState = AltTextUiState(
-                    avatarUrl = "https://gravatar.com/avatar/test",
+                    avatarUrl = URI("https://gravatar.com/avatar/test"),
                     isUpdating = false,
                     altText = "alt",
                     isSaveButtonEnabled = false,
@@ -43,7 +44,7 @@ class AltTextPageTest : RoborazziTest() {
         GravatarTheme {
             AltTextPage(
                 altTextState = AltTextUiState(
-                    avatarUrl = "https://gravatar.com/avatar/test",
+                    avatarUrl = URI("https://gravatar.com/avatar/test"),
                     isUpdating = false,
                     altText = "New alt text",
                     isSaveButtonEnabled = true,
@@ -59,7 +60,7 @@ class AltTextPageTest : RoborazziTest() {
         GravatarTheme {
             AltTextPage(
                 altTextState = AltTextUiState(
-                    avatarUrl = "https://gravatar.com/avatar/test",
+                    avatarUrl = URI("https://gravatar.com/avatar/test"),
                     isUpdating = false,
                     altText = "New alt text",
                     isSaveButtonEnabled = true,

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModelTest.kt
@@ -10,7 +10,6 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -31,13 +30,11 @@ class AltTextViewModelTest {
     private val altText = "Alternative Text"
     private val avatarUrl = URI("https://gravatar.com/avatar/test")
     private val avatarRepository = mockk<AvatarRepository>()
-    private val avatarsSharedFlow = mockk<SharedFlow<List<Avatar>>>()
 
     @Test
     fun `given an avatar that can't be loaded when view model is initialized then  AvatarCantBeLoaded is sent`() =
         runTest {
-            coEvery { avatarRepository.getAvatars(any()) } returns avatarsSharedFlow
-            coEvery { avatarsSharedFlow.replayCache } returns listOf(emptyList())
+            coEvery { avatarRepository.getAvatar(any(), any()) } returns null
 
             viewModel = AltTextViewModel(email, avatarId, avatarRepository)
 
@@ -174,12 +171,7 @@ class AltTextViewModelTest {
     }
 
     private fun initWithAvatarStorage(avatar: Avatar) {
-        initWithAvatarStorage(listOf(avatar))
-    }
-
-    private fun initWithAvatarStorage(avatars: List<Avatar>) {
-        coEvery { avatarRepository.getAvatars(any()) } returns avatarsSharedFlow
-        coEvery { avatarsSharedFlow.replayCache } returns listOf(avatars)
+        coEvery { avatarRepository.getAvatar(any(), any()) } returns avatar
 
         viewModel = AltTextViewModel(email, avatarId, avatarRepository)
     }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModelTest.kt
@@ -9,8 +9,10 @@ import com.gravatar.services.GravatarResult
 import io.mockk.coEvery
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -44,13 +46,14 @@ class AltTextViewModelTest {
             }
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given some initial values when view model is initialized then uiState is correct`() = runTest {
         initWithAvatarStorage(createAvatar(id = avatarId, url = avatarUrl, altText = altText))
 
-        viewModel.uiState.test {
-            skipItems(1) // Skipping the initial value
+        advanceUntilIdle()
 
+        viewModel.uiState.test {
             val altTextUiState = AltTextUiState(
                 avatarUrl = avatarUrl,
                 isSaveButtonEnabled = false,
@@ -58,19 +61,23 @@ class AltTextViewModelTest {
                 altText = altText,
             )
 
-            assertEquals(altTextUiState, awaitItem())
+            assertEquals(altTextUiState, expectMostRecentItem())
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given an alt text change event when onEvent is called then uiState is updated with new alt text`() = runTest {
         initWithAvatarStorage(createAvatar(id = avatarId, url = avatarUrl, altText = altText))
 
         val newAltText = "New Alternative Text"
-        viewModel.onEvent(AltTextEvent.AvatarAltTextChange(newAltText))
+
+        advanceUntilIdle()
 
         viewModel.uiState.test {
-            skipItems(2) // Skipping the initial value and the value set in the init block
+            expectMostRecentItem()
+
+            viewModel.onEvent(AltTextEvent.AvatarAltTextChange(newAltText))
 
             val altTextUiState = AltTextUiState(
                 avatarUrl = avatarUrl,
@@ -83,6 +90,7 @@ class AltTextViewModelTest {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given an alt text save tapped event when alt text is successfully updated then uiState is updated`() =
         runTest {
@@ -95,10 +103,12 @@ class AltTextViewModelTest {
 
             viewModel.onEvent(AltTextEvent.AvatarAltTextChange(newAltText))
 
-            viewModel.onEvent(AltTextEvent.AvatarAltTextSaveTapped)
+            advanceUntilIdle()
 
             viewModel.uiState.test {
-                skipItems(3) // Skipping the following values: initial, init block and alt text change event
+                expectMostRecentItem()
+
+                viewModel.onEvent(AltTextEvent.AvatarAltTextSaveTapped)
 
                 var altTextUiState = AltTextUiState(
                     avatarUrl = avatarUrl,
@@ -122,6 +132,7 @@ class AltTextViewModelTest {
             }
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `given an alt text save tapped event when alt text update fails then uiState is updated`() = runTest {
         initWithAvatarStorage(createAvatar(id = avatarId, url = avatarUrl, altText = altText))
@@ -133,10 +144,12 @@ class AltTextViewModelTest {
 
         viewModel.onEvent(AltTextEvent.AvatarAltTextChange(newAltText))
 
-        viewModel.onEvent(AltTextEvent.AvatarAltTextSaveTapped)
+        advanceUntilIdle()
 
         viewModel.uiState.test {
-            skipItems(3) // Skipping the following values: initial, init block and alt text change event
+            expectMostRecentItem()
+
+            viewModel.onEvent(AltTextEvent.AvatarAltTextSaveTapped)
 
             var altTextUiState = AltTextUiState(
                 avatarUrl = avatarUrl,

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/alttext/AltTextViewModelTest.kt
@@ -1,17 +1,20 @@
 package com.gravatar.quickeditor.ui.alttext
 
 import app.cash.turbine.test
+import com.gravatar.quickeditor.createAvatar
 import com.gravatar.quickeditor.data.repository.AvatarRepository
 import com.gravatar.quickeditor.ui.CoroutineTestRule
+import com.gravatar.restapi.models.Avatar
 import com.gravatar.services.GravatarResult
 import io.mockk.coEvery
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.net.URI
 
 class AltTextViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
@@ -24,23 +27,30 @@ class AltTextViewModelTest {
     private val email = "testEmail"
     private val avatarId = "testAvatarId"
     private val altText = "Alternative Text"
-    private val avatarUrl = "https://gravatar.com/avatar/test"
+    private val avatarUrl = URI("https://gravatar.com/avatar/test")
     private val avatarRepository = mockk<AvatarRepository>()
+    private val avatarsSharedFlow = mockk<SharedFlow<List<Avatar>>>()
 
-    @Before
-    fun setUp() {
-        viewModel = AltTextViewModel(
-            email = email,
-            avatarId = avatarId,
-            altText = altText,
-            avatarUrl = avatarUrl,
-            avatarRepository = avatarRepository,
-        )
-    }
+    @Test
+    fun `given an avatar that can't be loaded when view model is initialized then  AvatarCantBeLoaded is sent`() =
+        runTest {
+            coEvery { avatarRepository.getAvatars(any()) } returns avatarsSharedFlow
+            coEvery { avatarsSharedFlow.replayCache } returns listOf(emptyList())
+
+            viewModel = AltTextViewModel(email, avatarId, avatarRepository)
+
+            viewModel.actions.test {
+                assertEquals(AltTextAction.AvatarCantBeLoaded, awaitItem())
+            }
+        }
 
     @Test
     fun `given some initial values when view model is initialized then uiState is correct`() = runTest {
+        initWithAvatarStorage(createAvatar(id = avatarId, url = avatarUrl, altText = altText))
+
         viewModel.uiState.test {
+            skipItems(1) // Skipping the initial value
+
             val altTextUiState = AltTextUiState(
                 avatarUrl = avatarUrl,
                 isSaveButtonEnabled = false,
@@ -54,11 +64,13 @@ class AltTextViewModelTest {
 
     @Test
     fun `given an alt text change event when onEvent is called then uiState is updated with new alt text`() = runTest {
+        initWithAvatarStorage(createAvatar(id = avatarId, url = avatarUrl, altText = altText))
+
         val newAltText = "New Alternative Text"
         viewModel.onEvent(AltTextEvent.AvatarAltTextChange(newAltText))
 
         viewModel.uiState.test {
-            expectMostRecentItem()
+            skipItems(2) // Skipping the initial value and the value set in the init block
 
             val altTextUiState = AltTextUiState(
                 avatarUrl = avatarUrl,
@@ -74,6 +86,8 @@ class AltTextViewModelTest {
     @Test
     fun `given an alt text save tapped event when alt text is successfully updated then uiState is updated`() =
         runTest {
+            initWithAvatarStorage(createAvatar(id = avatarId, url = avatarUrl, altText = altText))
+
             val newAltText = "New Alternative Text"
             coEvery {
                 avatarRepository.updateAvatar(email = any(), avatarId = avatarId, rating = null, altText = newAltText)
@@ -84,7 +98,7 @@ class AltTextViewModelTest {
             viewModel.onEvent(AltTextEvent.AvatarAltTextSaveTapped)
 
             viewModel.uiState.test {
-                skipItems(2)
+                skipItems(3) // Skipping the following values: initial, init block and alt text change event
 
                 var altTextUiState = AltTextUiState(
                     avatarUrl = avatarUrl,
@@ -110,6 +124,8 @@ class AltTextViewModelTest {
 
     @Test
     fun `given an alt text save tapped event when alt text update fails then uiState is updated`() = runTest {
+        initWithAvatarStorage(createAvatar(id = avatarId, url = avatarUrl, altText = altText))
+
         val newAltText = "New Alternative Text"
         coEvery {
             avatarRepository.updateAvatar(email = any(), avatarId = avatarId, rating = null, altText = newAltText)
@@ -120,7 +136,7 @@ class AltTextViewModelTest {
         viewModel.onEvent(AltTextEvent.AvatarAltTextSaveTapped)
 
         viewModel.uiState.test {
-            skipItems(2)
+            skipItems(3) // Skipping the following values: initial, init block and alt text change event
 
             var altTextUiState = AltTextUiState(
                 avatarUrl = avatarUrl,
@@ -142,5 +158,16 @@ class AltTextViewModelTest {
         viewModel.actions.test {
             assertEquals(AltTextAction.AltTextUpdateFailed, awaitItem())
         }
+    }
+
+    private fun initWithAvatarStorage(avatar: Avatar) {
+        initWithAvatarStorage(listOf(avatar))
+    }
+
+    private fun initWithAvatarStorage(avatars: List<Avatar>) {
+        coEvery { avatarRepository.getAvatars(any()) } returns avatarsSharedFlow
+        coEvery { avatarsSharedFlow.replayCache } returns listOf(avatars)
+
+        viewModel = AltTextViewModel(email, avatarId, avatarRepository)
     }
 }


### PR DESCRIPTION
Closes #523 

### Description

With the recent implementation of the `AvatarStorage` we are ready to remove the extra params we needed to open the AltTextPage (url and alt_text). 

We can load the avatar data from the repository just by using the `avatarId` so we can simplify the navigation as we only need the email and the avatarId to open the AltTextPage.

### Testing Steps

- Smoke test the AltText feature (everything should work as before)
