### PR TITLE
Change screenshot threshold to 0.005

### DIFF
--- a/uitestutils/src/main/java/com/gravatar/uitestutils/RoborazziTest.kt
+++ b/uitestutils/src/main/java/com/gravatar/uitestutils/RoborazziTest.kt
@@ -43,7 +43,7 @@ abstract class RoborazziTest {
             roborazziOptions = RoborazziOptions(
                 compareOptions = RoborazziOptions.CompareOptions(
                     imageComparator = SimpleImageComparator(maxDistance = 0.007F, hShift = 1),
-                    changeThreshold = 0.01f,
+                    changeThreshold = 0.005f,
                 ),
             ),
         ),


### PR DESCRIPTION


### Description

This [PR](https://github.com/Automattic/Gravatar-SDK-Android/pull/528) should fail but didn't so I found out the the 0,01 threshold was to big. 

It's a bit weird because the change from that PR seems to be quite significant, but 0.005 made it fail so...

### Testing Steps

The only way is to apply this change to the mentioned PR and verify the screenshot tests.
