### PR TITLE
Fix the QE recomposition when selecting an avatar

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -54,9 +54,9 @@ internal fun GravatarQuickEditorPage(
         composable(route = QuickEditorPage.SPLASH.name) {
             SplashPage(email = gravatarQuickEditorParams.email) { isAuthorized ->
                 if (isAuthorized) {
-                    navController.navigateAndClean(QuickEditorPage.EDITOR.name)
+                    navController.navigateAndPopupTo(QuickEditorPage.EDITOR.name, QuickEditorPage.SPLASH.name)
                 } else {
-                    navController.navigateAndClean(QuickEditorPage.OAUTH.name)
+                    navController.navigateAndPopupTo(QuickEditorPage.OAUTH.name, QuickEditorPage.SPLASH.name)
                 }
             }
         }
@@ -66,7 +66,7 @@ internal fun GravatarQuickEditorPage(
                 email = gravatarQuickEditorParams.email,
                 onAuthError = { onDismiss(GravatarQuickEditorDismissReason.OauthFailed) },
                 onAuthSuccess = {
-                    navController.navigateAndClean(QuickEditorPage.EDITOR.name)
+                    navController.navigateAndPopupTo(QuickEditorPage.EDITOR.name, QuickEditorPage.OAUTH.name)
                 },
             )
         }
@@ -76,7 +76,7 @@ internal fun GravatarQuickEditorPage(
             navController = navController,
             onAvatarSelected = onAvatarSelected,
             onSessionExpired = {
-                navController.navigateAndClean(QuickEditorPage.OAUTH.name)
+                navController.navigateAndPopupTo(QuickEditorPage.OAUTH.name, QuickEditorPage.EDITOR.name)
             },
         )
     }
@@ -121,7 +121,7 @@ internal fun GravatarQuickEditorPage(
                 email = gravatarQuickEditorParams.email,
                 token = authToken,
             ) {
-                navController.navigateAndClean(QuickEditorPage.EDITOR.name)
+                navController.navigateAndPopupTo(QuickEditorPage.EDITOR.name, QuickEditorPage.SPLASH.name)
             }
         }
         addAvatarPickerGraph(
@@ -185,9 +185,8 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
     }
 }
 
-private fun NavHostController.navigateAndClean(route: String) {
+private fun NavHostController.navigateAndPopupTo(route: String, popUpTo: String) {
     navigate(route = route) {
-        popUpTo(graph.startDestinationId) { inclusive = true }
+        popUpTo(popUpTo) { inclusive = true }
     }
-    graph.setStartDestination(route)
 }


### PR DESCRIPTION

### Description

There's a bug that's causing the QE to reload on Avatar change. The problem is this [line](https://github.com/Automattic/Gravatar-SDK-Android/blob/trunk/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt#L188). When an avatar is selected the `onAvatarSelected` lambda is invoked and this triggered the recomposition caused by the changed `startDestination`. 

Changing the start destination was convenient but not necessary, so I reworked the code to not require it. 

### Testing Steps

1. Launch the QE
2. Select an avatar
3. Confirm the QE did not recompose
4.  Test for regression in the back button navigation - Go through the OAuth flow, Alt text page, etc.