### PR TITLE
QuickEditor: Add enter/exit transitions to AltText and AvatarSelection composables

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -3,8 +3,8 @@ package com.gravatar.quickeditor.ui.editor
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -148,6 +148,7 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
         composable(
             route = EditorNavDestinations.AVATAR_SELECTION.name,
             enterTransition = { fadeIn() },
+            popEnterTransition = { fadeIn() + expandVertically() },
             exitTransition = {
                 slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Start) + shrinkVertically()
             },
@@ -170,8 +171,8 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
                 navArgument("email") { type = NavType.StringType },
                 navArgument("avatarId") { type = NavType.StringType },
             ),
-            exitTransition = { fadeOut() },
-            enterTransition = { fadeIn() },
+            exitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.End) },
+            enterTransition = { slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Start) },
         ) {
             val email = requireNotNull(it.arguments?.getString("email"))
             val avatarId = requireNotNull(it.arguments?.getString("avatarId"))

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -1,7 +1,11 @@
 package com.gravatar.quickeditor.ui.editor
 
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.navigation.NavGraphBuilder
@@ -141,7 +145,13 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
         route = QuickEditorPage.EDITOR.name,
         startDestination = EditorNavDestinations.AVATAR_SELECTION.name,
     ) {
-        composable(route = EditorNavDestinations.AVATAR_SELECTION.name) {
+        composable(
+            route = EditorNavDestinations.AVATAR_SELECTION.name,
+            enterTransition = { fadeIn() },
+            exitTransition = {
+                slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Start) + shrinkVertically()
+            },
+        ) {
             AvatarPicker(
                 gravatarQuickEditorParams = gravatarQuickEditorParams,
                 handleExpiredSession = handleExpiredSession,
@@ -160,6 +170,8 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
                 navArgument("email") { type = NavType.StringType },
                 navArgument("avatarId") { type = NavType.StringType },
             ),
+            exitTransition = { fadeOut() },
+            enterTransition = { fadeIn() },
         ) {
             val email = requireNotNull(it.arguments?.getString("email"))
             val avatarId = requireNotNull(it.arguments?.getString("avatarId"))


### PR DESCRIPTION
Closes #498 

### Description

This PR improves the transitions between the AvatarSelection and the AltText page by using simple predefined transitions. 

<details>
<summary> Before </summary>

https://github.com/user-attachments/assets/a3268110-420d-4600-888f-c4be4222c998
</details>

<details>
<summary> After </summary>

https://github.com/user-attachments/assets/99c1d68d-172c-4369-ab48-d152bb691d31
</details>

### Testing Steps

- On the QE, verify the transitions between the AvatarSelection <-> AltText
- Also verify the transition between the OAuth screen and the AvatarSelectionPage as the enterTransition applies each time the AvatarSelection is shown.
