### PR TITLE
Make sure the save button can always be reached

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/alttext/AltTextPage.kt
@@ -15,8 +15,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -141,6 +143,7 @@ internal fun AltTextPage(
         Box(
             modifier = Modifier
                 .animateContentSize()
+                .verticalScroll(rememberScrollState())
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -197,6 +200,7 @@ internal fun AltTextPage(
                         onValueChange = { newAltText ->
                             onEvent(AltTextEvent.AvatarAltTextChange(newAltText))
                         },
+                        maxLines = 5,
                         textStyle = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurface),
                         modifier = Modifier
                             .fillMaxSize(),


### PR DESCRIPTION
Closes #533

### Description

The Save button could be pushed away from the screen. It was not possible to reach it. There were two reasons for that:
1. The Input field could grow its height without any limits
2. The whole page was not scrollable, making it impossible to scroll to it

I applied changes to limit the input field height (5 lines) and make the whole page scrollable. 

Here's the video with both font and display scaled up a lot.

https://github.com/user-attachments/assets/25f48ea4-e245-4172-8232-5e47beae2c15

### Testing Steps

1. Open the Alt text page
2. Type enter a few times to increase the number of lines
3. Confirm you can always reach the Save button
4. Feel free to play with the font&display scaling 