### PR TITLE
Document permissions used by the QuickEditor

### DIFF
--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -500,3 +500,14 @@ public fun Avatar(
 ```
 
 By setting `forceRefresh` to true, you ensure that the avatar is always fetched with the latest changes.
+
+### Android Permission
+
+The Quick Editor module requires certain permissions to function correctly. Below is a table listing the permissions and the reasons why they are needed:
+
+| Permission                  | Reason                                                                                           |
+|-----------------------------|--------------------------------------------------------------------------------------------------|
+| `INTERNET`                  | Required to make network requests to the Gravatar API.                                           |
+| `WRITE_EXTERNAL_STORAGE`    | Allows the app to save images to the device storage on Android 9 and lower via Download Manager. |
+
+If you use the same permission with different configurations, you might end up with conflicts.


### PR DESCRIPTION
Closes #505

### Description

I believe it's good to be transparent about the permission we define in the QuickEditor's manifest file. This PR adds a section showing what permissions we use and why. 

<img width="1125" alt="Screenshot 2025-01-15 at 15 16 38" src="https://github.com/user-attachments/assets/f7d01e0b-53ef-4a7c-9bad-552042d0aa83" />

1. Is there anything else we should add? 
2. Do you think there's a better place for it?

### Testing Steps

Read the docs. 