### PR TITLE
QuickEditor: Make sure the QE works well when the app get's killed during the OAuth flow

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-<!--    <uses-permission android:name="android.permission.CAMERA" />-->
+    <!--    <uses-permission android:name="android.permission.CAMERA" />-->
 
     <application
         android:allowBackup="true"
@@ -19,14 +19,53 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTask"
-            android:windowSoftInputMode="adjustResize"
-            android:theme="@style/Theme.Gravatar">
+            android:theme="@style/Theme.Gravatar"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".ui.activity.QuickEditorTestActivity"
+            android:exported="true"
+            android:label="Old good Activity"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.Gravatar">
+            <!--            <intent-filter>-->
+            <!--                <action android:name="android.intent.action.VIEW" />-->
+
+            <!--                <category android:name="android.intent.category.DEFAULT" />-->
+            <!--                <category android:name="android.intent.category.BROWSABLE" />-->
+
+            <!--                <data-->
+            <!--                    android:host="${DEMO_OAUTH_REDIRECT_URI_HOST}"-->
+            <!--                    android:scheme="${DEMO_OAUTH_REDIRECT_URI_SCHEME}" />-->
+            <!--            </intent-filter>-->
+        </activity>
+
+        <!-- Gravatar QE Activity -->
+        <!--        <activity-->
+        <!--            android:name="com.gravatar.quickeditor.ui.GravatarQuickEditorActivity"-->
+        <!--            tools:node="merge">-->
+
+        <!--            <intent-filter>-->
+        <!--                <action android:name="android.intent.action.VIEW" />-->
+
+        <!--                <category android:name="android.intent.category.DEFAULT" />-->
+        <!--                <category android:name="android.intent.category.BROWSABLE" />-->
+
+        <!--                <data-->
+        <!--                    android:host="${DEMO_OAUTH_REDIRECT_URI_HOST}"-->
+        <!--                    android:scheme="${DEMO_OAUTH_REDIRECT_URI_SCHEME}" />-->
+        <!--            </intent-filter>-->
+        <!--        </activity>-->
+
+        <activity
+            android:name="com.gravatar.quickeditor.ui.oauth.GravatarOAuthActivity"
+            tools:node="merge">
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -38,40 +77,6 @@
                     android:scheme="${DEMO_OAUTH_REDIRECT_URI_SCHEME}" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".ui.activity.QuickEditorTestActivity"
-            android:launchMode="singleTask"
-            android:label="Old good Activity"
-            android:theme="@style/Theme.Gravatar"
-            android:exported="true">
-<!--            <intent-filter>-->
-<!--                <action android:name="android.intent.action.VIEW" />-->
-
-<!--                <category android:name="android.intent.category.DEFAULT" />-->
-<!--                <category android:name="android.intent.category.BROWSABLE" />-->
-
-<!--                <data-->
-<!--                    android:host="${DEMO_OAUTH_REDIRECT_URI_HOST}"-->
-<!--                    android:scheme="${DEMO_OAUTH_REDIRECT_URI_SCHEME}" />-->
-<!--            </intent-filter>-->
-        </activity>
-
-        <!-- Gravatar QE Activity -->
-<!--        <activity-->
-<!--            android:name="com.gravatar.quickeditor.ui.GravatarQuickEditorActivity"-->
-<!--            tools:node="merge">-->
-
-<!--            <intent-filter>-->
-<!--                <action android:name="android.intent.action.VIEW" />-->
-
-<!--                <category android:name="android.intent.category.DEFAULT" />-->
-<!--                <category android:name="android.intent.category.BROWSABLE" />-->
-
-<!--                <data-->
-<!--                    android:host="${DEMO_OAUTH_REDIRECT_URI_HOST}"-->
-<!--                    android:scheme="${DEMO_OAUTH_REDIRECT_URI_SCHEME}" />-->
-<!--            </intent-filter>-->
-<!--        </activity>-->
 
 
         <!-- Lib activities -->
@@ -82,8 +87,8 @@
         <provider
             android:name=".DemoFileProvider"
             android:authorities="${applicationId}.fileprovider"
-            android:grantUriPermissions="true"
-            android:exported="false">
+            android:exported="false"
+            android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/filepaths" />

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -451,6 +451,11 @@ public final class com/gravatar/quickeditor/ui/oauth/ComposableSingletons$OAuthP
 	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity : androidx/appcompat/app/AppCompatActivity {
+	public static final field $stable I
+	public fun <init> ()V
+}
+
 public final class com/gravatar/quickeditor/ui/oauth/OAuthParams : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/gravatar-quickeditor/src/main/AndroidManifest.xml
+++ b/gravatar-quickeditor/src/main/AndroidManifest.xml
@@ -15,6 +15,12 @@
             android:launchMode="singleTask"
             android:theme="@style/GravatarQETheme.Transparent" />
 
+        <activity
+            android:name=".ui.oauth.GravatarOAuthActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/GravatarQETheme.Transparent" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
@@ -1,0 +1,173 @@
+package com.gravatar.quickeditor.ui.oauth
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabsIntent
+import com.gravatar.quickeditor.ui.GravatarQuickEditorActivity
+import com.gravatar.types.Email
+import java.net.URLDecoder
+
+/**
+ * Activity to handle OAuth authentication with Gravatar.
+ *
+ * This activity launches a custom tab for the user to authenticate with Gravatar.
+ * Once the authentication is complete, it retrieves the access token from the redirect URI
+ * and returns it as a result.
+ *
+ * It's used internally, but it's exposed as a public as it needs to be declared in your AndroidManifest.xml file
+ * with the proper deep linking setup.
+ */
+public class GravatarOAuthActivity : AppCompatActivity() {
+    private var oAuthStarted = false
+    private lateinit var clientId: String
+    private lateinit var redirectUri: String
+    private lateinit var email: String
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        clientId = intent.getStringExtra(CLIENT_ID_KEY)!!
+        redirectUri = intent.getStringExtra(REDIRECT_URI_KEY)!!
+        email = intent.getStringExtra(EMAIL_KEY)!!
+
+        oAuthStarted = savedInstanceState?.getBoolean(OAUTH_STARTED_KEY) ?: false
+
+        addOnNewIntentListener { newIntent ->
+            val token = newIntent.data
+                ?.encodedFragment
+                ?.split("&")
+                ?.associate {
+                    val split = it.split("=")
+                    split.first() to split.last()
+                }
+                ?.get("access_token")
+                ?.let { URLDecoder.decode(it, "UTF-8") }
+
+            if (token != null) {
+                val resultIntent = Intent().apply {
+                    putExtra(ACTIVITY_RESULT, RESULT_TOKEN_RETRIEVED)
+                    putExtra(TOKEN_KEY, token)
+                }
+
+                setResult(RESULT_OK, resultIntent)
+            } else {
+                setResult(
+                    RESULT_OK,
+                    Intent().apply {
+                        putExtra(ACTIVITY_RESULT, RESULT_TOKEN_ERROR)
+                    },
+                )
+            }
+            finish()
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        outState.putBoolean(OAUTH_STARTED_KEY, oAuthStarted)
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        if (!oAuthStarted) {
+            launchCustomTab(
+                this,
+                clientId = clientId,
+                redirectUri = redirectUri,
+                email = Email(email),
+            )
+            oAuthStarted = true
+        } else {
+            setResult(
+                RESULT_OK,
+                Intent().apply {
+                    putExtra(ACTIVITY_RESULT, RESULT_CANCELED)
+                },
+            )
+            finish()
+        }
+    }
+
+    private fun launchCustomTab(context: Context, clientId: String, redirectUri: String, email: Email) {
+        val customTabIntent: CustomTabsIntent = CustomTabsIntent.Builder()
+            .build()
+        customTabIntent.launchUrl(
+            context,
+            Uri.parse(WordPressOauth.buildUrl(clientId, redirectUri, email)),
+        )
+    }
+
+    internal companion object {
+        private const val CLIENT_ID_KEY = "client_id"
+        private const val REDIRECT_URI_KEY = "redirect_uri"
+        private const val EMAIL_KEY = "email"
+        private const val OAUTH_STARTED_KEY = "oauth_started"
+        internal const val TOKEN_KEY = "auth_token"
+
+        const val ACTIVITY_RESULT: String = "oAuthActivityResult"
+        const val RESULT_CANCELED: Int = 1000
+        const val RESULT_TOKEN_RETRIEVED: Int = 1001
+        const val RESULT_TOKEN_ERROR: Int = 1002
+
+        internal fun createIntent(context: Context, oAuthParams: OAuthParams, email: String): Intent {
+            return Intent(context, GravatarOAuthActivity::class.java).apply {
+                putExtra(CLIENT_ID_KEY, oAuthParams.clientId)
+                putExtra(REDIRECT_URI_KEY, oAuthParams.redirectUri)
+                putExtra(EMAIL_KEY, email)
+            }
+        }
+    }
+}
+
+/**
+ * Activity result contract to get the result from the [GravatarOAuthActivity].
+ *
+ * @see GravatarOAuthActivityParams
+ * @see GravatarOAuthResult
+ */
+internal class GravatarOAuthResultContract :
+    ActivityResultContract<GravatarOAuthActivityParams, GravatarOAuthResult>() {
+    override fun createIntent(context: Context, input: GravatarOAuthActivityParams): Intent {
+        return GravatarOAuthActivity.createIntent(
+            context = context,
+            oAuthParams = input.oAuthParams,
+            email = input.email,
+        )
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): GravatarOAuthResult {
+        return when (intent?.getIntExtra(GravatarOAuthActivity.ACTIVITY_RESULT, -1)) {
+            GravatarOAuthActivity.RESULT_TOKEN_RETRIEVED -> GravatarOAuthResult.TOKEN(
+                intent.getStringExtra(GravatarOAuthActivity.TOKEN_KEY)!!,
+            )
+
+            GravatarOAuthActivity.RESULT_TOKEN_ERROR -> GravatarOAuthResult.ERROR
+            else -> GravatarOAuthResult.DISMISSED
+        }
+    }
+}
+
+/**
+ * Parameters for the [GravatarOAuthActivity].
+ */
+internal class GravatarOAuthActivityParams(
+    val oAuthParams: OAuthParams,
+    val email: String,
+)
+
+/**
+ * Result enum for the [GravatarQuickEditorActivity].
+ */
+internal sealed class GravatarOAuthResult {
+    data class TOKEN(val token: String) : GravatarOAuthResult()
+
+    data object DISMISSED : GravatarOAuthResult()
+
+    data object ERROR : GravatarOAuthResult()
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
@@ -3,6 +3,8 @@ package com.gravatar.quickeditor.ui.oauth
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
@@ -29,6 +31,12 @@ public class GravatarOAuthActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
+        } else {
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+        }
 
         oAuthStarted = savedInstanceState?.getBoolean(OAUTH_STARTED_KEY) ?: false
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
@@ -110,10 +110,10 @@ public class GravatarOAuthActivity : AppCompatActivity() {
         private const val OAUTH_STARTED_KEY = "oauth_started"
         internal const val TOKEN_KEY = "auth_token"
 
-        const val ACTIVITY_RESULT: String = "oAuthActivityResult"
-        const val RESULT_CANCELED: Int = 1000
-        const val RESULT_TOKEN_RETRIEVED: Int = 1001
-        const val RESULT_TOKEN_ERROR: Int = 1002
+        internal const val ACTIVITY_RESULT: String = "oAuthActivityResult"
+        internal const val RESULT_CANCELED: Int = 1000
+        internal const val RESULT_TOKEN_RETRIEVED: Int = 1001
+        internal const val RESULT_TOKEN_ERROR: Int = 1002
 
         internal fun createIntent(context: Context, oAuthParams: OAuthParams, email: String): Intent {
             return Intent(context, GravatarOAuthActivity::class.java).apply {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
@@ -23,18 +23,29 @@ import java.net.URLDecoder
  */
 public class GravatarOAuthActivity : AppCompatActivity() {
     private var oAuthStarted = false
-    private lateinit var clientId: String
-    private lateinit var redirectUri: String
-    private lateinit var email: String
+    private var clientId: String? = null
+    private var redirectUri: String? = null
+    private var email: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        clientId = intent.getStringExtra(CLIENT_ID_KEY)!!
-        redirectUri = intent.getStringExtra(REDIRECT_URI_KEY)!!
-        email = intent.getStringExtra(EMAIL_KEY)!!
-
         oAuthStarted = savedInstanceState?.getBoolean(OAUTH_STARTED_KEY) ?: false
+
+        clientId = intent.getStringExtra(CLIENT_ID_KEY)
+        redirectUri = intent.getStringExtra(REDIRECT_URI_KEY)
+        email = intent.getStringExtra(EMAIL_KEY)
+
+        if (clientId == null || redirectUri == null || email == null) {
+            setResult(
+                RESULT_OK,
+                Intent().apply {
+                    putExtra(ACTIVITY_RESULT, RESULT_CANCELED)
+                },
+            )
+            finish()
+            return
+        }
 
         addOnNewIntentListener { newIntent ->
             val token = newIntent.data
@@ -78,9 +89,9 @@ public class GravatarOAuthActivity : AppCompatActivity() {
         if (!oAuthStarted) {
             launchCustomTab(
                 this,
-                clientId = clientId,
-                redirectUri = redirectUri,
-                email = Email(email),
+                clientId = clientId!!,
+                redirectUri = redirectUri!!,
+                email = Email(email!!),
             )
             oAuthStarted = true
         } else {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
@@ -78,7 +78,9 @@ internal fun OAuthPage(
             val listener = Consumer<Intent> { newIntent ->
                 Log.w(
                     "QuickEditor",
-                    "GRAVATAR SDK WARNING: You're using a deprecated version of the Gravatar QuickEditor OAuth flow. Set up GravatarOAuthActivity in your AndroidManifest.xml to handle the OAuth flow and to remove this warning message. ",
+                    "GRAVATAR SDK WARNING: You're using a deprecated version of the Gravatar QuickEditor OAuth " +
+                        "flow. Set up GravatarOAuthActivity in your AndroidManifest.xml to handle the OAuth flow and " +
+                        "to remove this warning message.",
                 )
                 val token = newIntent.data
                     ?.encodedFragment

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
@@ -2,10 +2,8 @@ package com.gravatar.quickeditor.ui.oauth
 
 import android.content.Context
 import android.content.ContextWrapper
-import android.content.Intent
-import android.net.Uri
 import androidx.activity.ComponentActivity
-import androidx.browser.customtabs.CustomTabsIntent
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -31,7 +28,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.util.Consumer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
@@ -46,7 +42,6 @@ import com.gravatar.types.Email
 import com.gravatar.ui.GravatarTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.net.URLDecoder
 
 @Composable
 internal fun OAuthPage(
@@ -58,10 +53,16 @@ internal fun OAuthPage(
     modifier: Modifier = Modifier,
     viewModel: OAuthViewModel = viewModel(factory = OAuthViewModelFactory(email)),
 ) {
-    val context = LocalContext.current
-    val activity = context.findComponentActivity()
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val uiState by viewModel.uiState.collectAsState()
+
+    val oAuthLauncher = rememberLauncherForActivityResult(GravatarOAuthResultContract()) { result ->
+        when (result) {
+            GravatarOAuthResult.DISMISSED -> Unit
+            is GravatarOAuthResult.TOKEN -> viewModel.tokenReceived(email, result.token)
+            GravatarOAuthResult.ERROR -> onAuthError()
+        }
+    }
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.Main.immediate) {
@@ -70,35 +71,16 @@ internal fun OAuthPage(
                     when (action) {
                         OAuthAction.AuthorizationSuccess -> onAuthSuccess()
                         OAuthAction.AuthorizationFailure -> onAuthError()
-                        OAuthAction.StartOAuth -> launchCustomTab(context, oAuthParams, email)
+                        OAuthAction.StartOAuth -> {
+                            oAuthLauncher.launch(
+                                GravatarOAuthActivityParams(
+                                    oAuthParams = oAuthParams,
+                                    email = email.toString(),
+                                ),
+                            )
+                        }
                     }
                 }
-            }
-        }
-    }
-
-    if (activity != null) {
-        DisposableEffect(Unit) {
-            val listener = Consumer<Intent> { newIntent ->
-                val token = newIntent.data
-                    ?.encodedFragment
-                    ?.split("&")
-                    ?.associate {
-                        val split = it.split("=")
-                        split.first() to split.last()
-                    }
-                    ?.get("access_token")
-                    ?.let { URLDecoder.decode(it, "UTF-8") }
-
-                if (token != null) {
-                    viewModel.tokenReceived(email, token)
-                } else {
-                    onAuthError()
-                }
-            }
-            activity.addOnNewIntentListener(listener)
-            onDispose {
-                activity.removeOnNewIntentListener(listener)
             }
         }
     }
@@ -207,15 +189,6 @@ internal fun OauthPage(
             },
         )
     }
-}
-
-private fun launchCustomTab(context: Context, oauthParams: OAuthParams, email: Email) {
-    val customTabIntent: CustomTabsIntent = CustomTabsIntent.Builder()
-        .build()
-    customTabIntent.launchUrl(
-        context,
-        Uri.parse(WordPressOauth.buildUrl(oauthParams.clientId, oauthParams.redirectUri, email)),
-    )
 }
 
 internal fun Context.findComponentActivity(): ComponentActivity? = when (this) {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
@@ -2,6 +2,8 @@ package com.gravatar.quickeditor.ui.oauth
 
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.Intent
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.border
@@ -16,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -28,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.util.Consumer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
@@ -42,6 +46,7 @@ import com.gravatar.types.Email
 import com.gravatar.ui.GravatarTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.net.URLDecoder
 
 @Composable
 internal fun OAuthPage(
@@ -53,6 +58,8 @@ internal fun OAuthPage(
     modifier: Modifier = Modifier,
     viewModel: OAuthViewModel = viewModel(factory = OAuthViewModelFactory(email)),
 ) {
+    val context = LocalContext.current
+    val activity = context.findComponentActivity()
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val uiState by viewModel.uiState.collectAsState()
 
@@ -61,6 +68,38 @@ internal fun OAuthPage(
             GravatarOAuthResult.DISMISSED -> Unit
             is GravatarOAuthResult.TOKEN -> viewModel.tokenReceived(email, result.token)
             GravatarOAuthResult.ERROR -> onAuthError()
+        }
+    }
+
+    // Kept for backwards-compatibility.
+    // This will be removed in the future and the GravatarOAuthActivity should be used instead.
+    if (activity != null) {
+        DisposableEffect(Unit) {
+            val listener = Consumer<Intent> { newIntent ->
+                Log.w(
+                    "QuickEditor",
+                    "Setup GravatarOAuthActivity in your AndroidManifest.xml to handle the OAuth flow.",
+                )
+                val token = newIntent.data
+                    ?.encodedFragment
+                    ?.split("&")
+                    ?.associate {
+                        val split = it.split("=")
+                        split.first() to split.last()
+                    }
+                    ?.get("access_token")
+                    ?.let { URLDecoder.decode(it, "UTF-8") }
+
+                if (token != null) {
+                    viewModel.tokenReceived(email, token)
+                } else {
+                    onAuthError()
+                }
+            }
+            activity.addOnNewIntentListener(listener)
+            onDispose {
+                activity.removeOnNewIntentListener(listener)
+            }
         }
     }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt
@@ -78,7 +78,7 @@ internal fun OAuthPage(
             val listener = Consumer<Intent> { newIntent ->
                 Log.w(
                     "QuickEditor",
-                    "Setup GravatarOAuthActivity in your AndroidManifest.xml to handle the OAuth flow.",
+                    "GRAVATAR SDK WARNING: You're using a deprecated version of the Gravatar QuickEditor OAuth flow. Set up GravatarOAuthActivity in your AndroidManifest.xml to handle the OAuth flow and to remove this warning message. ",
                 )
                 val token = newIntent.data
                     ?.encodedFragment

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModel.kt
@@ -1,7 +1,9 @@
 package com.gravatar.quickeditor.ui.oauth
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.gravatar.quickeditor.QuickEditorContainer
@@ -21,6 +23,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 internal class OAuthViewModel(
+    private val savedStateHandle: SavedStateHandle,
     private val email: Email,
     private val tokenStorage: TokenStorage,
     private val profileStorage: ProfileStorage,
@@ -36,8 +39,10 @@ internal class OAuthViewModel(
         fetchProfile()
         viewModelScope.launch {
             val loginIntroShown = profileStorage.getLoginIntroShown(email.hash().toString())
-            if (loginIntroShown) {
+            val oauthStarted = savedStateHandle.get<Boolean>(OAUTH_STARTED_KEY) ?: false
+            if (loginIntroShown && !oauthStarted) {
                 _actions.send(OAuthAction.StartOAuth)
+                savedStateHandle[OAUTH_STARTED_KEY] = true
             }
         }
     }
@@ -105,6 +110,10 @@ internal class OAuthViewModel(
             }
         }
     }
+
+    companion object {
+        private const val OAUTH_STARTED_KEY = "oauth_started"
+    }
 }
 
 internal class OAuthViewModelFactory(
@@ -113,6 +122,7 @@ internal class OAuthViewModelFactory(
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
         return OAuthViewModel(
+            savedStateHandle = extras.createSavedStateHandle(),
             email = email,
             tokenStorage = QuickEditorContainer.getInstance().tokenStorage,
             profileStorage = QuickEditorContainer.getInstance().profileStorage,

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/oauth/OAuthViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.gravatar.quickeditor.ui.oauth
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.gravatar.quickeditor.data.storage.ProfileStorage
 import com.gravatar.quickeditor.data.storage.TokenStorage
@@ -28,6 +29,7 @@ class OAuthViewModelTest {
     private val tokenStorage = mockk<TokenStorage>()
     private val profileService = mockk<ProfileService>()
     private val profileStorage = mockk<ProfileStorage>()
+    private val savedStateHandle = SavedStateHandle()
 
     private lateinit var viewModel: OAuthViewModel
 
@@ -40,7 +42,7 @@ class OAuthViewModelTest {
         coEvery { profileService.retrieveCatching(email) } returns GravatarResult.Success(mockk())
         coEvery { profileStorage.getLoginIntroShown(any()) } returns false
         coEvery { profileStorage.setLoginIntroShown(any()) } returns Unit
-        viewModel = OAuthViewModel(email, tokenStorage, profileStorage, profileService)
+        viewModel = createViewModel()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -191,6 +193,22 @@ class OAuthViewModelTest {
         viewModel.actions.test {
             assertEquals(OAuthAction.StartOAuth, awaitItem())
         }
+        assertEquals(true, savedStateHandle.get<Boolean>("oauth_started"))
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when init and oAuthStarted before then StartOAuth action is not sent`() = runTest {
+        coEvery { profileStorage.getLoginIntroShown(email.hash().toString()) } returns true
+        savedStateHandle["oauth_started"] = true
+
+        viewModel = createViewModel()
+
+        advanceUntilIdle()
+
+        viewModel.actions.test {
+            expectNoEvents()
+        }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -221,6 +239,6 @@ class OAuthViewModelTest {
     }
 
     private fun createViewModel(): OAuthViewModel {
-        return OAuthViewModel(email, tokenStorage, profileStorage, profileService)
+        return OAuthViewModel(savedStateHandle, email, tokenStorage, profileStorage, profileService)
     }
 }


### PR DESCRIPTION
Closes #525

### Description

The current code has a problem with the OAuth flow when the app get's killed by the system (or when the "Don't keep activities" setting is ON). Here's how Hector [described it](https://github.com/Automattic/Gravatar-SDK-Android/issues/525#issuecomment-2595700254): 

> ...
>
>The culprit of the problem is that we add the [OnNewIntentListener in the OAuthPage](https://github.com/Automattic/Gravatar-SDK-Android/blob/ca5b79ac430c5e278962f1d88f966f3b090d0062/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/OAuthPage.kt#L81) so while that composable and the activity where it's contained is alive there is no problem.
>
>However, when the activity is destroyed after opening the CustomTab, it will be recreated after the OAuthFlow has finished. In the MainActivity example, when the OAuthFlow finishes, the steps are:
>
>MainActivity.onCreate()
MainActivity.onNewIntent()
The onCreate method recreates the activity as it was, keeping the QE with the OAuthScreen opened, but the onNewIntent is called before the composables are inflated and the listener in the OAuthPage composable registered, so we are missing it.
>
>We can, somehow, try to resolve this in an activity under our control (GravatarQuickEditorActivity), but I think it is more complicated in a third-party app as (MainActivity).

So far, the main QE's flow would make the third-party activity handle the deep linking for the OAuth flow, so there was very little we could do to fix this. Hector explored a suggestion that maybe we could achieve this by using Deep Linking via Jetpack Compose Navigation but our NavGraph lives only in the Bottom Sheet, not the activity so making it work seems equally tricky. 

This PR proposes a different approach that not only fixes this issue #525 but also **removes the requirement from third-party apps to use `singleTask` launch mode on the activity that launches the QuickEditor.**

The solution:

Instead of relying on third-party activity to handle the OAuth deep links, the QuickEditor opens a fully transparent activity `GravatarOAuthActivity` before launching the Custom Tab to start the OAuth. From now on this is the only Activity that requires the `launchMode=singleTask`. This activity also handles the `onNewIntent` and we no longer need to handle that within the Composable so the whole timing issue described by Hector is no longer a problem.

I had to set a local flag to make sure the `GravatarOAuthActivity` is finished when the Custom tab is dismissed (without it the QE would appear as focused but wouldn't actually work because it would be under the activity).

Additionally, I had to add `SavedStateHandle` to the `OAuthViewModel` so as not to send the `StartOauth` action in the init block. When the activity is recreated, so is the ViewModel, so we need to make sure that action hasn't been emitted before. 

Here's the result:

https://github.com/user-attachments/assets/9deb049f-c992-4c02-850d-dbbe54ea737b

Once this is merged we can deprecate the `GravatarQuickEditorActivity` as its only purpose was so that third parties don't have to set `singleTask` on their Activity. We will have to adjust the docs as well. 

### Testing Steps

1. Go to the Developer settings and enable the "Don't keep activities" - you can also play by killing the app via ADB
2. Fresh install the Demo app
3. Launch the QE
4. Dismitt the custom tab via `x` in the Toolbar
5. Confirm you see the QE with the intro page
6. Tap `Continue`
7. Tap `Deny`
8. Confirm the QE was closed and error toast was shown
9. Launch the QE
10. Tap `Approve`
11. Confirm you were logged in and you can see your Avatars
12. Disable the "Don't keep activities" setting
13. Repeat the above steps, and make sure all works as expected

