### PR TITLE
Deprecate GravatarQuickEditorActivity

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/GravatarQuickEditorActivity.kt
@@ -23,6 +23,10 @@ import kotlinx.parcelize.Parcelize
  *
  * @see GravatarEditorActivityArguments
  */
+@Deprecated(
+    message = "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("GravatarQuickEditor.show()"),
+)
 public class GravatarQuickEditorActivity : AppCompatActivity() {
     private var avatarHasChanged: Boolean = false
 
@@ -109,6 +113,10 @@ public class GravatarQuickEditorActivity : AppCompatActivity() {
  * @see GravatarQuickEditorResult
  * @see GravatarEditorActivityArguments
  */
+@Deprecated(
+    message = "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("GravatarQuickEditor.show()"),
+)
 public class GetQuickEditorResult :
     ActivityResultContract<GravatarEditorActivityArguments, GravatarQuickEditorResult?>() {
     override fun createIntent(context: Context, input: GravatarEditorActivityArguments): Intent {
@@ -129,6 +137,10 @@ public class GetQuickEditorResult :
 /**
  * Result enum for the [GravatarQuickEditorActivity].
  */
+@Deprecated(
+    message = "This class is deprecated and will be removed in a future release.",
+    replaceWith = ReplaceWith("GravatarQuickEditor.show()"),
+)
 public enum class GravatarQuickEditorResult {
     AVATAR_SELECTED,
     DISMISSED,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/oauth/GravatarOAuthActivity.kt
@@ -9,7 +9,6 @@ import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
-import com.gravatar.quickeditor.ui.GravatarQuickEditorActivity
 import com.gravatar.types.Email
 import java.net.URLDecoder
 
@@ -181,7 +180,7 @@ internal class GravatarOAuthActivityParams(
 )
 
 /**
- * Result enum for the [GravatarQuickEditorActivity].
+ * Result enum for the [GravatarOAuthActivity].
  */
 internal sealed class GravatarOAuthResult {
     data class TOKEN(val token: String) : GravatarOAuthResult()


### PR DESCRIPTION
Closes #542

### Description

Now that [this PR](https://github.com/Automattic/Gravatar-SDK-Android/pull/541) was merged we can deprecate the `GravatarQuickEditorActivity`. Its only purpose was not to force third-party apps to set one of their activities to singleTask. Now that we will use `GravatarOAuthActivity` for the OAuth flow, the singleTask needs to be set only on this activity so the `GravatarQuickEditorActivity` serves no purpose.

I will update docs in a separate PRs. 

### Testing Steps

None, really. 
