### PR TITLE
Update the Release Process documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,9 @@ If you wish to check the changes first set it to `true` and commit the changes y
 We're following [Semantic Versioning](https://semver.org/) for the releases. Here is the process to create a new release:
 
 1. Make sure the latest translations are commited the repository. See [Translations](#Translations)
-2. Generate a new release branch: `git checkout -b release/x.x.x`.
-3. Open a PR, wait for a review, merge the PR on approval.
-4. Pull the `trunk` branch and tag the git commit with the version number: `git tag -a x.x.x -m "Release x.x.x"`
-5. Push the new tag: `git push --tags`.
-6. Go to the [GitHub releases page](https://github.com/Automattic/Gravatar-SDK-Android/releases) and create a new release with the tag name and the release notes.
+2. Pull the `trunk` branch and tag the git commit with the version number: `git tag -a x.x.x -m "Release x.x.x"`
+3. Push the new tag: `git push --tags`.
+4. Go to the [GitHub releases page](https://github.com/Automattic/Gravatar-SDK-Android/releases) and create a new release with the tag name and the release notes.
 
 ## Contributing
 


### PR DESCRIPTION


### Description

The steps are outdated. We no longer need to create the release branch. Generating the docs with Dokka was required before, but now this is automated with GitHub Actions.

### Testing Steps

I will test it soon later today.
