### PR TITLE
Show all avatars in the Profile card regardless of the rating

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/ProfileCard.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/ProfileCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.AvatarQueryOptions
+import com.gravatar.ImageRating
 import com.gravatar.extensions.avatarUrl
 import com.gravatar.extensions.defaultProfile
 import com.gravatar.restapi.models.Profile
@@ -50,6 +51,7 @@ internal fun ProfileCard(
                             avatarUrl(
                                 AvatarQueryOptions {
                                     preferredSize = sizePx
+                                    rating = ImageRating.X
                                 },
                             ).url(avatarCacheBuster).toString()
                         },


### PR DESCRIPTION
Closes #549

### Description

The profile card in the QE wouldn't show avatars that are not G-rated. This fixes the problem by updating the request URL param.

| Before | After |
|---|---|
| ![avatar_rating_before](https://github.com/user-attachments/assets/50781698-6652-4b4e-811c-ab8397e861e5) | ![avatar_rating_after](https://github.com/user-attachments/assets/e17a750e-79e9-49bc-8bab-ce309dedfe4d) |

### Testing Steps

1. Launch the QE 
2. Set one Avatar's rating to X
3. Select that avatar
4. Confirm you can see it displayed in the Profile card
