### PR TITLE
Bump uCrop to 2.2.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ roborazzi = "1.26.0"
 startup = "1.1.1"
 testCoreKtx = "1.6.1"
 turbine = "1.1.0"
-ucrop = "2.2.10"
+ucrop = "2.2.11"
 
 [libraries]
 android-material = { group = "com.google.android.material", name = "material", version.ref = "material" }


### PR DESCRIPTION

### Description

Edge-to-edge on Android 15 was fixed in the 2.2.11 so bumping it in the SDK. See the changes for reference here - https://github.com/Automattic/uCrop/pull/12. 

### Testing Steps

Changes were tested in uCrop but you can also test it here by trying to upload a new avatar. Make sure to launch the demo app on Android 15.
