### PR TITLE
Move more common logic from build.gradle.kts to convention plugins

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
   - label: "Static code analysis"
     command: |
       echo "--- 🧹 Linting"
-      ./gradlew ktlintcheck detekt
+      ./gradlew :build-logic:convention:ktlintcheck :build-logic:convention:detekt ktlintcheck detekt
     notify:
       - github_commit_status:
           context: "Static code analysis"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -20,8 +20,9 @@ tasks.withType<KotlinCompile>().configureEach {
 dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
-    compileOnly(libs.vanniktech.maven.publish.plugin)
+    compileOnly(libs.vanniktech.maven.publishPlugin)
     compileOnly(libs.detekt.gradlePlugin)
+    compileOnly(libs.openapi.generator.gradlePlugin)
 }
 
 tasks {
@@ -44,6 +45,10 @@ gradlePlugin {
         register("gravatarAndroidCompose") {
             id = libs.plugins.gravatar.android.compose.get().pluginId
             implementationClass = "GravatarComposeConventionPlugin"
+        }
+        register("gravatarOpenApiGenerator") {
+            id = libs.plugins.gravatar.openapi.generator.get().pluginId
+            implementationClass = "GravatarOpenApiGeneratorConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.vanniktech.maven.publish.plugin)
+    compileOnly(libs.detekt.gradlePlugin)
 }
 
 tasks {
@@ -35,6 +36,14 @@ gradlePlugin {
         register("mavenCentralPublish") {
             id = libs.plugins.gravatar.maven.publish.get().pluginId
             implementationClass = "MavenPublishConventionPlugin"
+        }
+        register("gravatarAndroidLibrary") {
+            id = libs.plugins.gravatar.android.library.get().pluginId
+            implementationClass = "GravatarAndroidLibraryConventionPlugin"
+        }
+        register("gravatarAndroidCompose") {
+            id = libs.plugins.gravatar.android.compose.get().pluginId
+            implementationClass = "GravatarComposeConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -3,6 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     `kotlin-dsl`
     kotlin("jvm") version "2.0.21"
+    alias(libs.plugins.ktlint)
+    alias(libs.plugins.detekt)
 }
 
 group = "com.gravatar.buildlogic"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     compileOnly(libs.vanniktech.maven.publishPlugin)
     compileOnly(libs.detekt.gradlePlugin)
     compileOnly(libs.openapi.generator.gradlePlugin)
+    compileOnly(libs.ktlint.gradlePlugin)
+    compileOnly(libs.roborazzi.gradlePlugin)
 }
 
 tasks {

--- a/build-logic/convention/src/main/kotlin/GravatarAndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarAndroidLibraryConventionPlugin.kt
@@ -1,18 +1,22 @@
 import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.LibraryPlugin
 import com.gravatar.configureDetekt
 import com.gravatar.configureKotlinAndroid
+import io.gitlab.arturbosch.detekt.DetektPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
+import org.jlleitschuh.gradle.ktlint.KtlintPlugin
 
 class GravatarAndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            apply(plugin = "com.android.library")
-            apply(plugin = "org.jetbrains.kotlin.android")
-            apply(plugin = "org.jlleitschuh.gradle.ktlint")
-            apply(plugin = "io.gitlab.arturbosch.detekt")
+            apply<LibraryPlugin>()
+            apply<KotlinAndroidPluginWrapper>()
+            apply<KtlintPlugin>()
+            apply<DetektPlugin>()
 
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)

--- a/build-logic/convention/src/main/kotlin/GravatarAndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarAndroidLibraryConventionPlugin.kt
@@ -1,0 +1,40 @@
+import com.android.build.gradle.LibraryExtension
+import com.gravatar.configureDetekt
+import com.gravatar.configureKotlinAndroid
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+
+class GravatarAndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = "com.android.library")
+            apply(plugin = "org.jetbrains.kotlin.android")
+            apply(plugin = "org.jlleitschuh.gradle.ktlint")
+            apply(plugin = "io.gitlab.arturbosch.detekt")
+
+            extensions.configure<LibraryExtension> {
+                configureKotlinAndroid(this)
+                defaultConfig.apply {
+                    targetSdk = 34
+                    consumerProguardFiles("consumer-rules.pro")
+                }
+                configureBuildTypes()
+            }
+            configureDetekt()
+        }
+    }
+
+    private fun LibraryExtension.configureBuildTypes() {
+        buildTypes {
+            getByName("release") {
+                isMinifyEnabled = false
+                proguardFiles(
+                    getDefaultProguardFile("proguard-android-optimize.txt"),
+                    "proguard-rules.pro",
+                )
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/GravatarAndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarAndroidLibraryConventionPlugin.kt
@@ -10,6 +10,10 @@ import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
 import org.jlleitschuh.gradle.ktlint.KtlintPlugin
 
+private const val TARGET_SDK = 34
+internal const val COMPILE_SDK = 34
+internal const val MIN_SDK = 21
+
 class GravatarAndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
@@ -21,7 +25,7 @@ class GravatarAndroidLibraryConventionPlugin : Plugin<Project> {
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
                 defaultConfig.apply {
-                    targetSdk = 34
+                    targetSdk = TARGET_SDK
                     consumerProguardFiles("consumer-rules.pro")
                 }
                 configureBuildTypes()

--- a/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
@@ -1,0 +1,61 @@
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+class GravatarComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = "io.github.takahirom.roborazzi")
+
+            extensions.configure<LibraryExtension> {
+                buildFeatures {
+                    compose = true
+                }
+                composeOptions {
+                    kotlinCompilerExtensionVersion = "1.5.15"
+                }
+                testOptions {
+                    unitTests {
+                        // For Roborazzi
+                        isIncludeAndroidResources = true
+                        all {
+                            // -Pscreenshot to filter screenshot tests
+                            it.useJUnit {
+                                if (project.hasProperty("screenshot")) {
+                                    includeCategories("com.gravatar.uitestutils.ScreenshotTests")
+                                } else {
+                                    excludeCategories("com.gravatar.uitestutils.ScreenshotTests")
+                                }
+                            }
+                            it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
+                        }
+                    }
+                }
+                tasks.withType<KotlinCompile>().configureEach {
+                    kotlinOptions {
+                        val composeReportsDir = "reports/compose"
+                        freeCompilerArgs += listOf(
+                            "-P",
+                            "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
+                                    "${project.rootDir}/compose_compiler_config.conf",
+                        )
+                        freeCompilerArgs += listOf(
+                            "-P",
+                            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                                    project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
+                        )
+                        freeCompilerArgs += listOf(
+                            "-P",
+                            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                                    project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
@@ -1,5 +1,6 @@
 import com.android.build.gradle.LibraryExtension
 import com.gravatar.libs
+import io.github.takahirom.roborazzi.RoborazziPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
@@ -10,7 +11,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 class GravatarComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            apply(plugin = "io.github.takahirom.roborazzi")
+            apply<RoborazziPlugin>()
 
             extensions.configure<LibraryExtension> {
                 buildFeatures {

--- a/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
@@ -38,20 +38,17 @@ class GravatarComposeConventionPlugin : Plugin<Project> {
                 tasks.withType<KotlinCompile>().configureEach {
                     kotlinOptions {
                         val composeReportsDir = "reports/compose"
+                        val prefix="plugin:androidx.compose.compiler.plugins.kotlin"
+
                         freeCompilerArgs += listOf(
                             "-P",
-                            "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
-                                    "${project.rootDir}/compose_compiler_config.conf",
-                        )
-                        freeCompilerArgs += listOf(
+                            "$prefix:stabilityConfigurationPath=${project.rootDir}/compose_compiler_config.conf",
                             "-P",
-                            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
-                                    project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
-                        )
-                        freeCompilerArgs += listOf(
+                            "$prefix:metricsDestination=${project.layout.buildDirectory.get().dir(composeReportsDir)
+                                .asFile.absolutePath}",
                             "-P",
-                            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
-                                    project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
+                            "$prefix:reportsDestination=${project.layout.buildDirectory.get().dir(composeReportsDir)
+                                .asFile.absolutePath}"
                         )
                     }
                 }

--- a/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
@@ -1,4 +1,5 @@
 import com.android.build.gradle.LibraryExtension
+import com.gravatar.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
@@ -16,7 +17,8 @@ class GravatarComposeConventionPlugin : Plugin<Project> {
                     compose = true
                 }
                 composeOptions {
-                    kotlinCompilerExtensionVersion = "1.5.15"
+                    kotlinCompilerExtensionVersion =
+                        libs.findVersion("kotlinCompilerExtension").get().toString()
                 }
                 testOptions {
                     unitTests {

--- a/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
@@ -41,7 +41,7 @@ class GravatarComposeConventionPlugin : Plugin<Project> {
                 tasks.withType<KotlinCompile>().configureEach {
                     kotlinOptions {
                         val composeReportsDir = "reports/compose"
-                        val prefix="plugin:androidx.compose.compiler.plugins.kotlin"
+                        val prefix = "plugin:androidx.compose.compiler.plugins.kotlin"
 
                         freeCompilerArgs += listOf(
                             "-P",
@@ -51,7 +51,7 @@ class GravatarComposeConventionPlugin : Plugin<Project> {
                                 .asFile.absolutePath}",
                             "-P",
                             "$prefix:reportsDestination=${project.layout.buildDirectory.get().dir(composeReportsDir)
-                                .asFile.absolutePath}"
+                                .asFile.absolutePath}",
                         )
                     }
                 }

--- a/build-logic/convention/src/main/kotlin/GravatarOpenApiGeneratorConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarOpenApiGeneratorConventionPlugin.kt
@@ -1,0 +1,77 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorGenerateExtension
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+
+class GravatarOpenApiGeneratorConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = "org.openapi.generator")
+
+            extensions.configure<OpenApiGeneratorGenerateExtension> {
+                generatorName.set("kotlin")
+                inputSpec.set("${projectDir.path}/openapi/api-gravatar.json")
+                outputDir.set("${layout.buildDirectory.asFile.get().absolutePath}/openapi")
+
+                // Use the custom templates if they are present. If not, the generator will use the default ones
+                templateDir.set("${projectDir.path}/openapi/templates")
+
+                // Set the generation configuration options
+                configOptions.set(
+                    mapOf(
+                        "library" to "jvm-retrofit2",
+                        "serializationLibrary" to "moshi",
+                        "groupId" to "com.gravatar",
+                        "packageName" to "com.gravatar.restapi",
+                        "useCoroutines" to "true",
+                        "moshiCodeGen" to "true",
+                    ),
+                )
+                importMappings.set(
+                    mapOf(
+                        "DateTime" to "String",
+                    ),
+                )
+
+                typeMappings.set(
+                    mapOf(
+                        "DateTime" to "String",
+                    ),
+                )
+
+                // We only want the apis and models, not the "infrastructure" folder
+                // See: https://github.com/OpenAPITools/openapi-generator/issues/6455
+                globalProperties.set(
+                    mapOf(
+                        "apis" to "",
+                        "models" to "",
+                    ),
+                )
+            }
+
+            tasks.withType<GenerateTask>().configureEach {
+                // Workaround for avoid the build error
+                notCompatibleWithConfigurationCache("Incomplete support for configuration cache in OpenAPI Generator plugin.")
+
+                val buildPath = layout.buildDirectory.asFile.get().absolutePath
+
+                // Move the generated code to the correct package and remove the generated folder
+                doLast {
+                    file("${projectDir.path}/src/main/java/com/gravatar/restapi").deleteRecursively()
+                    file("$buildPath/openapi/src/main/kotlin/com/gravatar/restapi")
+                        .renameTo(file("${projectDir.path}/src/main/java/com/gravatar/restapi"))
+                    file("$buildPath/openapi").deleteRecursively()
+                }
+
+                // Format the generated code
+                this.finalizedBy(project.tasks.named("ktlintFormat"))
+
+                // Always run the task forcing the up-to-date check to return false
+                outputs.upToDateWhen { false }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/GravatarOpenApiGeneratorConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarOpenApiGeneratorConventionPlugin.kt
@@ -3,13 +3,14 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
+import org.openapitools.generator.gradle.plugin.OpenApiGeneratorPlugin
 import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorGenerateExtension
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 class GravatarOpenApiGeneratorConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            apply(plugin = "org.openapi.generator")
+            apply<OpenApiGeneratorPlugin>()
 
             extensions.configure<OpenApiGeneratorGenerateExtension> {
                 generatorName.set("kotlin")

--- a/build-logic/convention/src/main/kotlin/GravatarOpenApiGeneratorConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarOpenApiGeneratorConventionPlugin.kt
@@ -55,7 +55,9 @@ class GravatarOpenApiGeneratorConventionPlugin : Plugin<Project> {
 
             tasks.withType<GenerateTask>().configureEach {
                 // Workaround for avoid the build error
-                notCompatibleWithConfigurationCache("Incomplete support for configuration cache in OpenAPI Generator plugin.")
+                notCompatibleWithConfigurationCache(
+                    "Incomplete support for configuration cache in OpenAPI Generator plugin.",
+                )
 
                 val buildPath = layout.buildDirectory.asFile.get().absolutePath
 

--- a/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.MavenPublishPlugin
 import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -10,7 +11,7 @@ import org.gradle.kotlin.dsl.provideDelegate
 class MavenPublishConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            apply(plugin = "com.vanniktech.maven.publish")
+            apply<MavenPublishPlugin>()
 
             extensions.configure<MavenPublishBaseExtension> {
                 publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)

--- a/build-logic/convention/src/main/kotlin/com/gravatar/Detekt.kt
+++ b/build-logic/convention/src/main/kotlin/com/gravatar/Detekt.kt
@@ -1,0 +1,15 @@
+package com.gravatar
+
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+internal fun Project.configureDetekt() {
+    configure<DetektExtension> {
+        config.setFrom("${project.rootDir}/config/detekt/detekt.yml")
+        source.setFrom("src")
+        autoCorrect = false
+        buildUponDefaultConfig = true
+        parallel = true
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
@@ -1,0 +1,37 @@
+package com.gravatar
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+internal fun Project.configureKotlinAndroid(
+    commonExtension: CommonExtension<*, *, *, *, *, *>,
+) {
+    commonExtension.apply {
+        compileSdk = 34
+
+        defaultConfig {
+            minSdk = 21
+            testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        }
+
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
+    }
+    configureKotlin()
+}
+
+/**
+ * Configure base Kotlin options for JVM (non-Android)
+ */
+internal fun Project.configureKotlin() {
+    tasks.withType<KotlinCompile>().configureEach {
+        kotlinOptions {
+            jvmTarget = JavaVersion.VERSION_1_8.toString()
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
@@ -1,19 +1,19 @@
 package com.gravatar
 
+import COMPILE_SDK
+import MIN_SDK
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-internal fun Project.configureKotlinAndroid(
-    commonExtension: CommonExtension<*, *, *, *, *, *>,
-) {
+internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, *, *, *, *, *>) {
     commonExtension.apply {
-        compileSdk = 34
+        compileSdk = COMPILE_SDK
 
         defaultConfig {
-            minSdk = 21
+            minSdk = MIN_SDK
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         }
 

--- a/build-logic/convention/src/main/kotlin/com/gravatar/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/gravatar/ProjectExtensions.kt
@@ -1,0 +1,9 @@
+package com.gravatar
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+val Project.libs
+    get(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -2,6 +2,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
     versionCatalogs {
         create("libs") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,14 +8,11 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
-    // Ktlint
     alias(libs.plugins.ktlint) apply false
-    // Detekt
     alias(libs.plugins.detekt) apply false
-    // Dokka
     alias(libs.plugins.dokka)
-    // Roborazzi
     alias(libs.plugins.roborazzi) apply false
+    alias(libs.plugins.openapi.generator) apply false
     alias(libs.plugins.binary.compatibility.validator)
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.vanniktech.maven.publish) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ testCoreKtx = "1.6.1"
 turbine = "1.1.0"
 ucrop = "2.2.11"
 mavenPublish = "0.31.0"
+kotlinCompilerExtension = "1.5.15"
 
 [libraries]
 android-material = { group = "com.google.android.material", name = "material", version.ref = "material" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,8 +84,9 @@ ucrop = { group = "com.automattic", name = "ucrop", version.ref = "ucrop" }
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
-vanniktech-maven-publish-plugin = { group = "com.vanniktech.maven.publish", name = "com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublish" }
+vanniktech-maven-publishPlugin = { group = "com.vanniktech.maven.publish", name = "com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublish" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "io.gitlab.arturbosch.detekt.gradle.plugin", version.ref = "detekt" }
+openapi-generator-gradlePlugin = { group = "org.openapitools", name = "openapi-generator-gradle-plugin", version.ref = "openapi" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
@@ -105,3 +106,4 @@ vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = 
 gravatar-maven-publish = { id = "gravatar.maven.publish" }
 gravatar-android-library = { id = "gravatar.android.library" }
 gravatar-android-compose = { id = "gravatar.android.compose" }
+gravatar-openapi-generator = { id = "gravatar.openapi.generator" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ ucrop = { group = "com.automattic", name = "ucrop", version.ref = "ucrop" }
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 vanniktech-maven-publish-plugin = { group = "com.vanniktech.maven.publish", name = "com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublish" }
+detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "io.gitlab.arturbosch.detekt.gradle.plugin", version.ref = "detekt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
@@ -102,3 +103,5 @@ vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = 
 
 # Plugins defined by this project
 gravatar-maven-publish = { id = "gravatar.maven.publish" }
+gravatar-android-library = { id = "gravatar.android.library" }
+gravatar-android-compose = { id = "gravatar.android.compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,8 @@ kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-pl
 vanniktech-maven-publishPlugin = { group = "com.vanniktech.maven.publish", name = "com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublish" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "io.gitlab.arturbosch.detekt.gradle.plugin", version.ref = "detekt" }
 openapi-generator-gradlePlugin = { group = "org.openapitools", name = "openapi-generator-gradle-plugin", version.ref = "openapi" }
+ktlint-gradlePlugin = { group = "org.jlleitschuh.gradle.ktlint", name = "org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlint" }
+roborazzi-gradlePlugin = { group = "io.github.takahirom.roborazzi", name = "io.github.takahirom.roborazzi.gradle.plugin", version.ref = "roborazzi" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -1,96 +1,24 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    alias(libs.plugins.android.library)
+    alias(libs.plugins.gravatar.android.library)
+    alias(libs.plugins.gravatar.android.compose)
     alias(libs.plugins.parcelize)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ktlint)
-    alias(libs.plugins.detekt)
-    alias(libs.plugins.roborazzi)
     alias(libs.plugins.dokka)
     alias(libs.plugins.gravatar.maven.publish)
 }
 
 android {
     namespace = "com.gravatar.quickeditor"
-    compileSdk = 34
 
     defaultConfig {
         minSdk = 23
-        // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdk = 34
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
     }
 
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-        val composeReportsDir = "reports/compose"
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
-                "${project.rootDir}/compose_compiler_config.conf",
-        )
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
-                project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
-        )
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
-                project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
-        )
-    }
-    detekt {
-        config.setFrom("${project.rootDir}/config/detekt/detekt.yml")
-        source.setFrom("src")
-        autoCorrect = false
-        buildUponDefaultConfig = true
-        parallel = false
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
-    }
     tasks.withType<DokkaTaskPartial>().configureEach {
         dokkaSourceSets {
             configureEach {
                 includes.from("QuickEditor.md")
-            }
-        }
-    }
-
-    // Explicit API mode
-    kotlin {
-        explicitApi()
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-            all {
-                // -Pscreenshot to filter screenshot tests
-                it.useJUnit {
-                    if (project.hasProperty("screenshot")) {
-                        includeCategories("com.gravatar.uitestutils.ScreenshotTests")
-                    } else {
-                        excludeCategories("com.gravatar.uitestutils.ScreenshotTests")
-                    }
-                }
-                it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
             }
         }
     }

--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -1,95 +1,19 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ktlint)
-    alias(libs.plugins.detekt)
-    alias(libs.plugins.roborazzi)
+    alias(libs.plugins.gravatar.android.library)
+    alias(libs.plugins.gravatar.android.compose)
     alias(libs.plugins.dokka)
     alias(libs.plugins.gravatar.maven.publish)
 }
 
 android {
     namespace = "com.gravatar.ui"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 21
-        // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdk = 34
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-        val composeReportsDir = "reports/compose"
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
-                "${project.rootDir}/compose_compiler_config.conf",
-        )
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
-                project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
-        )
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
-                project.layout.buildDirectory.get().dir(composeReportsDir).asFile.absolutePath,
-        )
-    }
-    detekt {
-        config.setFrom("${project.rootDir}/config/detekt/detekt.yml")
-        source.setFrom("src")
-        autoCorrect = false
-        buildUponDefaultConfig = true
-        parallel = false
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
-    }
 
     tasks.withType<DokkaTaskPartial>().configureEach {
         dokkaSourceSets {
             configureEach {
                 includes.from("GravatarUi.md")
-            }
-        }
-    }
-
-    // Explicit API mode
-    kotlin {
-        explicitApi()
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-            all {
-                // -Pscreenshot to filter screenshot tests
-                it.useJUnit {
-                    if (project.hasProperty("screenshot")) {
-                        includeCategories("com.gravatar.uitestutils.ScreenshotTests")
-                    } else {
-                        excludeCategories("com.gravatar.uitestutils.ScreenshotTests")
-                    }
-                }
             }
         }
     }

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -1,11 +1,8 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.gravatar.android.library)
     alias(libs.plugins.parcelize)
-    alias(libs.plugins.ktlint)
-    alias(libs.plugins.detekt)
     alias(libs.plugins.openapi.generator)
     alias(libs.plugins.dokka)
     alias(libs.plugins.ksp)
@@ -16,38 +13,10 @@ val sdkVersion: String by rootProject.extra
 
 android {
     namespace = "com.gravatar"
-    compileSdk = 34
     buildFeatures.buildConfig = true
 
     defaultConfig {
-        minSdk = 21
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
         buildConfigField("String", "SDK_VERSION", "\"$sdkVersion\"")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    detekt {
-        config.setFrom("${project.rootDir}/config/detekt/detekt.yml")
-        source.setFrom("src")
-        autoCorrect = false
-        buildUponDefaultConfig = true
-        parallel = true
     }
 
     testOptions {
@@ -62,11 +31,6 @@ android {
                 includes.from("GravatarCore.md")
             }
         }
-    }
-
-    // Explicit API mode
-    kotlin {
-        explicitApi()
     }
 }
 

--- a/gravatar/build.gradle.kts
+++ b/gravatar/build.gradle.kts
@@ -2,8 +2,8 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
     alias(libs.plugins.gravatar.android.library)
+    alias(libs.plugins.gravatar.openapi.generator)
     alias(libs.plugins.parcelize)
-    alias(libs.plugins.openapi.generator)
     alias(libs.plugins.dokka)
     alias(libs.plugins.ksp)
     alias(libs.plugins.gravatar.maven.publish)
@@ -46,66 +46,4 @@ dependencies {
     testImplementation(libs.mockk.agent)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(kotlin("test"))
-}
-
-openApiGenerate {
-    generatorName = "kotlin"
-    inputSpec = "${projectDir.path}/openapi/api-gravatar.json"
-    outputDir = "${layout.buildDirectory.asFile.get().absolutePath}/openapi"
-
-    // Use the custom templates if they are present. If not, the generator will use the default ones
-    templateDir.set("${projectDir.path}/openapi/templates")
-
-    // Set the generation configuration options
-    configOptions.set(
-        mapOf(
-            "library" to "jvm-retrofit2",
-            "serializationLibrary" to "moshi",
-            "groupId" to "com.gravatar",
-            "packageName" to "com.gravatar.restapi",
-            "useCoroutines" to "true",
-            "moshiCodeGen" to "true",
-        ),
-    )
-    importMappings.set(
-        mapOf(
-            "DateTime" to "String",
-        ),
-    )
-
-    typeMappings.set(
-        mapOf(
-            "DateTime" to "String",
-        ),
-    )
-
-    // We only want the apis and models, not the "infrastructure" folder
-    // See: https://github.com/OpenAPITools/openapi-generator/issues/6455
-    globalProperties.set(
-        mapOf(
-            "apis" to "",
-            "models" to "",
-        ),
-    )
-}
-
-tasks.openApiGenerate {
-    // Workaround for avoid the build error
-    notCompatibleWithConfigurationCache("Incomplete support for configuration cache in OpenAPI Generator plugin.")
-
-    val buildPath = layout.buildDirectory.asFile.get().absolutePath
-
-    // Move the generated code to the correct package and remove the generated folder
-    doLast {
-        file("${projectDir.path}/src/main/java/com/gravatar/restapi").deleteRecursively()
-        file("$buildPath/openapi/src/main/kotlin/com/gravatar/restapi")
-            .renameTo(file("${projectDir.path}/src/main/java/com/gravatar/restapi"))
-        file("$buildPath/openapi").deleteRecursively()
-    }
-
-    // Format the generated code
-    this.finalizedBy(tasks.ktlintFormat.get().path)
-
-    // Always run the task forcing the up-to-date check to return false
-    outputs.upToDateWhen { false }
 }


### PR DESCRIPTION
Closes #591

### Description

This PR moves more logic from submodules' `build.gradle.kts`. I have introduced three convention plugins: `GravatarAndroidLibraryConventionPlugin`, `GravatarComposeConventionPlugin`, and `GravatarOpenApiGeneratorConventionPlugin`.

I've kept dependencies and some custom logic in each `build.gradle.kts`.

FYI: I haven't touched the `build.gradle.kts` of the DemoApp in this PR.

### Testing Steps

Code review, building the project should be enough. 

You can also run `./gradlew :gravatar:openApiGenerate` to make sure the generation the same way (no changes expected after running this command).

You can also check the `build/reports/compose` folder for the generated metric files. 
