### PR TITLE
[Buildkite] Test Android Staging on `ami-0ed66347bb94c070a` -> `ami-03794d38ac4991af7`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@
 # Variables used in this pipeline are defined in `shared-pipeline-vars`, which is `source`'d before calling `buidkite-agent pipeline upload`
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: "Gradle Wrapper Validation"


### PR DESCRIPTION
Related: [buildkite-ci#610](https://github.com/Automattic/buildkite-ci/pull/610)

AMI Name: `android-build-image-6.12.0v1.7-rc-1` -> `android-build-image-6.12.0v1.8-rc-1`

-----

### Description

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0ed66347bb94c070a` works as expected.

-----

### Testing Steps

Check CI and verify everything is working as expected with the `android-staging` agent.