### PR TITLE
Enable explicitApi() in the convention plugin

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
@@ -5,7 +5,9 @@ import MIN_SDK
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, *, *, *, *, *>) {
@@ -33,5 +35,8 @@ internal fun Project.configureKotlin() {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
+    }
+    extensions.configure<KotlinProjectExtension> {
+        explicitApi()
     }
 }


### PR DESCRIPTION
### Description

This was removed by accident while converting to convetion plugins.

### Testing Steps

Remove any of the internal/public/private visibility modifier and confirm that AS shows an error.