### PR TITLE
Update release-toolkit to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 
 gem 'danger-dangermattic', '~> 1.1'
 gem 'fastlane', '~> 2.222'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 13.0'
 gem 'rubocop', '~> 1.65'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,8 +5,9 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.2.1)
+    activesupport (8.0.2)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
@@ -16,6 +17,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
@@ -39,8 +41,9 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
-    bigdecimal (3.1.8)
-    buildkit (1.6.0)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
+    buildkit (1.6.1)
       sawyer (>= 0.6)
     chroma (0.2.0)
     claide (1.1.0)
@@ -52,8 +55,8 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
     cork (0.3.0)
       colored2 (~> 3.1)
     danger (9.5.0)
@@ -79,7 +82,7 @@ GEM
       danger
       rubocop (~> 1.0)
     declarative (0.0.20)
-    diffy (3.4.2)
+    diffy (3.4.3)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
@@ -159,7 +162,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-wpmreleasetoolkit (11.1.0)
+    fastlane-plugin-wpmreleasetoolkit (13.1.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
@@ -168,7 +171,7 @@ GEM
       git (~> 1.3)
       google-cloud-storage (~> 1.31)
       java-properties (~> 0.3.0)
-      nokogiri (~> 1.11, < 1.17)
+      nokogiri (~> 1.11)
       octokit (~> 6.1)
       parallel (~> 1.14)
       plist (~> 3.1)
@@ -220,7 +223,7 @@ GEM
     http-cookie (1.0.7)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     java-properties (0.3.0)
     jmespath (1.6.2)
@@ -232,19 +235,19 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
-    logger (1.6.1)
+    logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    minitest (5.25.1)
+    minitest (5.25.5)
     multi_json (1.15.0)
     multipart-post (2.4.1)
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
     nkf (0.2.0)
-    nokogiri (1.16.7-arm64-darwin)
+    nokogiri (1.18.7-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.18.7-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (6.1.1)
       faraday (>= 1, < 3)
@@ -265,7 +268,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
-    rake-compiler (1.2.7)
+    rake-compiler (1.2.9)
       rake
     rchardet (1.8.0)
     regexp_parser (2.9.2)
@@ -294,7 +297,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    securerandom (0.3.1)
+    securerandom (0.4.1)
     security (0.1.5)
     signet (0.19.0)
       addressable (~> 2.8)
@@ -316,6 +319,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.6.0)
+    uri (1.0.3)
     word_wrap (1.0.0)
     xcodeproj (1.25.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -330,13 +334,12 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
-  arm64-darwin-23
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   danger-dangermattic (~> 1.1)
   fastlane (~> 2.222)
-  fastlane-plugin-wpmreleasetoolkit (~> 11.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 13.0)
   rubocop (~> 1.65)
 
 BUNDLED WITH


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-Android/security/dependabot/54

### Description

This is mostly to address the security issue with the `nokogiri` dependency.

### Testing Steps

CI is green