### PR TITLE
Remove Retrofit dependency from the :quickeditor module

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The OpenAPI definitions are located in the `openapi` directory. In the same dire
 the custom templates used by the OpenAPI Generator to generate the code that the Gravatar library needs. You can obtain the default templates by running the following command:
 
 ```sh
-openapi-generator author template -g kotlin --library jvm-retrofit2
+openapi-generator author template -g kotlin --library jvm-okhttp4
 ```
 
 The [OpenAPI Generator documentation](https://openapi-generator.tech/docs/templating) provides more information about the templates.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,6 @@ moshi = "1.15.1"
 navigationCompose = "2.8.3"
 okhttp = "4.12.0"
 openapi = "7.4.0"
-retrofit = "2.11.0"
 robolectric = "4.12.2"
 roborazzi = "1.26.0"
 startup = "1.1.1"
@@ -73,8 +72,6 @@ mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", versio
 moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
-retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-retrofit-moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }
 roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }

--- a/gravatar-quickeditor/build.gradle.kts
+++ b/gravatar-quickeditor/build.gradle.kts
@@ -36,8 +36,6 @@ dependencies {
     implementation(libs.androidx.startup)
 
     implementation(libs.coil.compose)
-    implementation(libs.retrofit)
-    implementation(libs.retrofit.moshi.converter)
     implementation(libs.ucrop)
 
     // Jetpack Compose

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptorTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/data/AcceptedLanguageInterceptorTest.kt
@@ -6,73 +6,72 @@ import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockkStatic
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import retrofit2.Call
-import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
-import retrofit2.http.GET
 import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 class AcceptedLanguageInterceptorTest {
     private val mockWebServer = MockWebServer()
 
-    private lateinit var api: TestApi
+    private lateinit var client: OkHttpClient
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
-    private val testResponse = "\"name\""
-
     @Before
     fun setUp() {
-        val client = OkHttpClient.Builder()
+        client = OkHttpClient.Builder()
             .addInterceptor(AcceptedLanguageInterceptor(context))
             .build()
+    }
 
-        api = Retrofit.Builder()
-            .baseUrl(mockWebServer.url("/"))
-            .addConverterFactory(MoshiConverterFactory.create())
-            .client(client)
-            .build()
-            .create(TestApi::class.java)
+    @After
+    fun after() {
+        mockWebServer.shutdown()
     }
 
     @Test
     fun `given one languages when intercepting then Accept-Language header set`() {
         mockkStatic(Context::languagesList)
         every { context.languagesList } returns LocaleListCompat.create(Locale.ENGLISH)
-        val successResponse = MockResponse().setBody(testResponse)
-        mockWebServer.enqueue(successResponse)
 
-        api.test().execute()
+        val mockResponse = MockResponse().setResponseCode(200)
+        mockWebServer.enqueue(mockResponse)
+        mockWebServer.start()
 
-        val request = mockWebServer.takeRequest()
-        val header = request.getHeader("Accept-Language")
-        assertEquals("en", header)
+        val request = Request.Builder()
+            .url(mockWebServer.url("/test"))
+            .build()
+
+        client.newCall(request).execute()
+
+        val recordedRequest = mockWebServer.takeRequest()
+        assertEquals("en", recordedRequest.getHeader("Accept-Language"))
     }
 
     @Test
     fun `given many languages when intercepting then Accept-Language header set`() {
         mockkStatic(Context::languagesList)
         every { context.languagesList } returns LocaleListCompat.create(Locale.ENGLISH, Locale.FRENCH, Locale.GERMANY)
-        val successResponse = MockResponse().setBody(testResponse)
-        mockWebServer.enqueue(successResponse)
 
-        api.test().execute()
+        val mockResponse = MockResponse().setResponseCode(200)
+        mockWebServer.enqueue(mockResponse)
+        mockWebServer.start()
 
-        val request = mockWebServer.takeRequest()
-        val header = request.getHeader("Accept-Language")
-        assertEquals("en,fr;q=0.9,de;q=0.8", header)
+        val request = Request.Builder()
+            .url(mockWebServer.url("/test"))
+            .build()
+
+        client.newCall(request).execute()
+
+        val recordedRequest = mockWebServer.takeRequest()
+        assertEquals("en,fr;q=0.9,de;q=0.8", recordedRequest.getHeader("Accept-Language"))
     }
-}
-
-private interface TestApi {
-    @GET("/test")
-    fun test(): Call<String>
 }


### PR DESCRIPTION
Closes #603

### Description

It was only used in tests at this point. Originally, it was used for OAuth REST API calls but we changed the method so it was pretty much a leftover. 

### Testing Steps

Green CI should be good.
