### PR TITLE
Remove unnecessary dependencies from the :ui module

### DIFF
--- a/gravatar-ui/build.gradle.kts
+++ b/gravatar-ui/build.gradle.kts
@@ -20,15 +20,9 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.android.material)
     implementation(libs.coil.compose)
     implementation(libs.coil.svg)
     implementation(project(":gravatar"))
-
-    testImplementation(libs.junit)
-    testImplementation(project(":uitestutils"))
 
     // Jetpack Compose
     implementation(platform(libs.compose.bom))
@@ -36,4 +30,7 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
     debugImplementation(libs.androidx.compose.ui.tooling)
+
+    testImplementation(libs.junit)
+    testImplementation(project(":uitestutils"))
 }


### PR DESCRIPTION
### Description

This PR removes those dependencies:
```
implementation(libs.androidx.core.ktx)
implementation(libs.androidx.appcompat)
implementation(libs.android.material) 
```

from the `:ui` module as they were not used.

### Testing Steps

Green CI is good.
