### PR TITLE
Properly init in-memory usage when restoring the state

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -77,7 +77,7 @@ import kotlinx.coroutines.withContext
 fun AvatarUpdateTab(modifier: Modifier = Modifier) {
     var userEmail by remember { mutableStateOf(BuildConfig.DEMO_EMAIL) }
     var userToken by remember { mutableStateOf(BuildConfig.DEMO_BEARER_TOKEN) }
-    var useToken by remember { mutableStateOf(false) }
+    var useToken by rememberSaveable { mutableStateOf(false) }
     var tokenVisible by remember { mutableStateOf(false) }
     val context = LocalContext.current
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -16,7 +15,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.gravatar.quickeditor.QuickEditorContainer
 import com.gravatar.quickeditor.ui.alttext.AltTextPage
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarPicker
 import com.gravatar.quickeditor.ui.navigation.EditorNavDestinations
@@ -110,14 +108,6 @@ internal fun GravatarQuickEditorPage(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
 ) {
     val navController = rememberNavController()
-
-    DisposableEffect(authToken) {
-        QuickEditorContainer.getInstance().useInMemoryTokenStorage()
-
-        onDispose {
-            QuickEditorContainer.getInstance().resetUseInMemoryTokenStorage()
-        }
-    }
 
     NavHost(
         navController,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -42,6 +43,7 @@ import com.composables.core.SheetDetent
 import com.composables.core.SheetDetent.Companion.FullyExpanded
 import com.composables.core.SheetDetent.Companion.Hidden
 import com.composables.core.rememberModalBottomSheetState
+import com.gravatar.quickeditor.QuickEditorContainer
 import com.gravatar.quickeditor.ui.components.QEDragHandle
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
@@ -97,6 +99,16 @@ internal fun GravatarQuickEditorBottomSheet(
     val onDoneClicked: () -> Unit = {
         coroutineScope.launch {
             modalBottomSheetState.currentDetent = Hidden
+        }
+    }
+
+    DisposableEffect(Unit) {
+        if (authenticationMethod is AuthenticationMethod.Bearer) {
+            QuickEditorContainer.getInstance().useInMemoryTokenStorage()
+        }
+
+        onDispose {
+            QuickEditorContainer.getInstance().resetUseInMemoryTokenStorage()
         }
     }
 


### PR DESCRIPTION
Closes #609

### Description

When the "Don't keep activities" is ON, the Quick Editor state won't properly display the data inside. It's caused by a timing issue. The `QuickEditorContainer.getInstance().useInMemoryTokenStorage()` that is called in the `DisposableEffect` is invoked after the `NavController` starts the restored destination, so the ViewModel and its dependencies don't use the in-memory storage as they should. 

Moving the `DisposableEffect` to a Composable higher up in the hierarchy fixes this timing issue. 

| Before | After |
|---|---|
| ![state_before](https://github.com/user-attachments/assets/9aad3879-28ec-4dc3-8a17-ea47cccf4525) | ![state_after](https://github.com/user-attachments/assets/c3e57eee-8e80-4904-9a96-6bd909b6dd6c) |

### Testing Steps

1. [Enable Developer Options](https://developer.android.com/studio/debug/dev-options) on your device
2. Launch the demo app
3. Move to the Avatar update tab
4. Paste in your WP token and select the checkbox next to it. You can also add it to `secrets.properties` file with name `demo-app.bearer.token`.
5. Tap the avatar to launch the QE
6. Tap on the `View Profile`
7. Go back with a system button or a gesture
8. Confirm the QE is restored and no errors are visible
