### PR TITLE
Alert dialog when closing without saving changes

### DIFF
--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -82,6 +82,19 @@ public final class com/gravatar/quickeditor/ui/abouteditor/components/Composable
 	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/gravatar/quickeditor/ui/abouteditor/components/ComposableSingletons$DiscardChangesAlertDialogKt {
+	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/abouteditor/components/ComposableSingletons$DiscardChangesAlertDialogKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$gravatar_quickeditor_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/gravatar/quickeditor/ui/alttext/ComposableSingletons$AltTextPageKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/alttext/ComposableSingletons$AltTextPageKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gravatar.quickeditor.R
 import com.gravatar.quickeditor.ui.abouteditor.components.AboutSection
+import com.gravatar.quickeditor.ui.abouteditor.components.DiscardChangesAlertDialog
 import com.gravatar.quickeditor.ui.components.QEButton
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.extensions.QESnackbarHost
@@ -47,6 +48,7 @@ import kotlinx.coroutines.withContext
 internal fun AboutEditor(
     quickEditorParams: GravatarQuickEditorParams,
     onProfileUpdated: (Profile) -> Unit,
+    onClose: () -> Unit,
     viewModel: AboutEditorViewModel = viewModel(
         factory = AboutEditorViewModelFactory(quickEditorParams),
     ),
@@ -85,6 +87,10 @@ internal fun AboutEditor(
                                 )
                             }
                         }
+
+                        AboutEditorAction.CloseEditor -> {
+                            onClose()
+                        }
                     }
                 }
             }
@@ -104,6 +110,16 @@ internal fun AboutEditor(
                 modifier = Modifier
                     .align(Alignment.BottomStart),
                 hostState = snackState,
+            )
+            DiscardChangesAlertDialog(
+                visible = uiState.discardChangesDialogVisible,
+                onKeepEditing = {
+                    viewModel.onEvent(AboutEditorEvent.OnDiscardDialogDismissed)
+                },
+                onDiscardClicked = {
+                    viewModel.onEvent(AboutEditorEvent.OnDiscardDialogDismissed)
+                    onClose()
+                },
             )
         }
     }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
@@ -117,7 +117,7 @@ internal fun AboutEditor(
                     viewModel.onEvent(AboutEditorEvent.OnDiscardDialogDismissed)
                 },
                 onDiscardClicked = {
-                    viewModel.onEvent(AboutEditorEvent.OnDiscardDialogDismissed)
+                    viewModel.onEvent(AboutEditorEvent.OnDiscardConfirmed)
                     onClose()
                 },
             )

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorAction.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorAction.kt
@@ -6,4 +6,6 @@ internal sealed class AboutEditorAction {
     data class ProfileUpdated(val profile: Profile) : AboutEditorAction()
 
     data object ProfileUpdateFailed : AboutEditorAction()
+
+    data object CloseEditor : AboutEditorAction()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorEvent.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorEvent.kt
@@ -10,4 +10,6 @@ internal sealed class AboutEditorEvent {
     data object OnDoneClicked : AboutEditorEvent()
 
     data object OnDiscardDialogDismissed : AboutEditorEvent()
+
+    data object OnDiscardConfirmed : AboutEditorEvent()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorEvent.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorEvent.kt
@@ -6,4 +6,8 @@ internal sealed class AboutEditorEvent {
     ) : AboutEditorEvent()
 
     data object OnSaveClicked : AboutEditorEvent()
+
+    data object OnDoneClicked : AboutEditorEvent()
+
+    data object OnDiscardDialogDismissed : AboutEditorEvent()
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorUiState.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorUiState.kt
@@ -4,6 +4,7 @@ internal data class AboutEditorUiState(
     val aboutFields: AboutFields = AboutFields.EMPTY,
     val isLoading: Boolean = false,
     val savingProfile: Boolean = false,
+    val discardChangesDialogVisible: Boolean = false,
 ) {
     val formEnabled: Boolean = !savingProfile
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModel.kt
@@ -29,6 +29,8 @@ internal class AboutEditorViewModel(
     private val _actions = Channel<AboutEditorAction>(Channel.BUFFERED)
     val actions = _actions.receiveAsFlow()
 
+    private var savedProfile: Profile? = null
+
     init {
         fetchProfile()
     }
@@ -37,6 +39,30 @@ internal class AboutEditorViewModel(
         when (aboutEditorEvent) {
             is AboutEditorEvent.OnAboutFieldUpdated -> updateAboutField(aboutEditorEvent.aboutField)
             AboutEditorEvent.OnSaveClicked -> saveProfile()
+            AboutEditorEvent.OnDoneClicked -> checkForUnsavedChanges()
+            AboutEditorEvent.OnDiscardDialogDismissed -> dismissDiscardChangesDialog()
+        }
+    }
+
+    private fun dismissDiscardChangesDialog() {
+        _uiState.update { currentState ->
+            currentState.copy(discardChangesDialogVisible = false)
+        }
+    }
+
+    private fun checkForUnsavedChanges() {
+        val currentProfile = uiState.value.aboutFields
+        val savedProfile = savedProfile?.aboutFields
+        viewModelScope.launch {
+            if (currentProfile != savedProfile) {
+                _uiState.update { currentProfile ->
+                    currentProfile.copy(
+                        discardChangesDialogVisible = true,
+                    )
+                }
+            } else {
+                _actions.send(AboutEditorAction.CloseEditor)
+            }
         }
     }
 
@@ -48,14 +74,16 @@ internal class AboutEditorViewModel(
             val updateProfileRequest = uiState.value.aboutFields.updateProfileRequest
             when (val result = profileRepository.updateProfile(email, updateProfileRequest)) {
                 is GravatarResult.Success -> {
+                    val profile = result.value
+                    savedProfile = profile
                     _uiState.update { currentState ->
                         currentState.copy(
                             savingProfile = false,
-                            aboutFields = result.value.aboutFields,
+                            aboutFields = profile.aboutFields,
                         )
                     }
                     _actions.send(
-                        AboutEditorAction.ProfileUpdated(result.value),
+                        AboutEditorAction.ProfileUpdated(profile),
                     )
                 }
 
@@ -91,9 +119,11 @@ internal class AboutEditorViewModel(
             when (val result = profileRepository.getProfile(email)) {
                 is GravatarResult.Success -> {
                     _uiState.update {
+                        val profile = result.value
+                        savedProfile = profile
                         it.copy(
                             isLoading = false,
-                            aboutFields = result.value.aboutFields,
+                            aboutFields = profile.aboutFields,
                         )
                     }
                 }
@@ -110,7 +140,7 @@ internal class AboutEditorViewModel(
     }
 }
 
-private val Profile.aboutFields: AboutFields
+internal val Profile.aboutFields: AboutFields
     get() {
         return AboutFields(
             personal = PersonalFields(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModel.kt
@@ -40,7 +40,9 @@ internal class AboutEditorViewModel(
             is AboutEditorEvent.OnAboutFieldUpdated -> updateAboutField(aboutEditorEvent.aboutField)
             AboutEditorEvent.OnSaveClicked -> saveProfile()
             AboutEditorEvent.OnDoneClicked -> checkForUnsavedChanges()
-            AboutEditorEvent.OnDiscardDialogDismissed -> dismissDiscardChangesDialog()
+            AboutEditorEvent.OnDiscardDialogDismissed,
+            AboutEditorEvent.OnDiscardConfirmed,
+            -> dismissDiscardChangesDialog()
         }
     }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/components/DiscardChangesAlertDialog.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/components/DiscardChangesAlertDialog.kt
@@ -1,0 +1,47 @@
+package com.gravatar.quickeditor.ui.abouteditor.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.gravatar.quickeditor.R
+import com.gravatar.ui.GravatarTheme
+
+@Composable
+internal fun DiscardChangesAlertDialog(visible: Boolean, onDiscardClicked: () -> Unit, onKeepEditing: () -> Unit) {
+    if (visible) {
+        GravatarTheme {
+            AlertDialog(
+                onDismissRequest = onKeepEditing,
+                title = {
+                    Text(text = stringResource(id = R.string.gravatar_qe_about_discard_changes_dialog_title))
+                },
+                text = {
+                    Text(text = stringResource(R.string.gravatar_qe_about_discard_changes_dialog_message))
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = onDiscardClicked,
+                    ) { Text(stringResource(R.string.gravatar_qe_about_discard_changes_dialog_confirm)) }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = onKeepEditing,
+                    ) { Text(stringResource(R.string.gravatar_qe_about_discard_changes_dialog_dismiss)) }
+                },
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun FailedAvatarUploadAlertDialogPreview() {
+    DiscardChangesAlertDialog(
+        visible = true,
+        onDiscardClicked = {},
+        onKeepEditing = {},
+    )
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditor.kt
@@ -11,6 +11,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gravatar.quickeditor.ui.abouteditor.AboutEditor
+import com.gravatar.quickeditor.ui.abouteditor.AboutEditorEvent
+import com.gravatar.quickeditor.ui.abouteditor.AboutEditorViewModel
+import com.gravatar.quickeditor.ui.abouteditor.AboutEditorViewModelFactory
 import com.gravatar.quickeditor.ui.avatarpicker.AvatarPicker
 import com.gravatar.quickeditor.ui.components.EmailLabel
 import com.gravatar.quickeditor.ui.components.ProfileCard
@@ -30,10 +33,19 @@ internal fun QuickEditor(
     ),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val aboutEditorViewModel: AboutEditorViewModel = viewModel(
+        factory = AboutEditorViewModelFactory(gravatarQuickEditorParams),
+    )
 
     QuickEditor(
         uiState = uiState,
-        onDoneClicked = onDoneClicked,
+        onDoneClicked = {
+            when (gravatarQuickEditorParams.scope) {
+                QuickEditorScope.AVATAR -> onDoneClicked()
+                QuickEditorScope.ABOUT ->
+                    aboutEditorViewModel.onEvent(AboutEditorEvent.OnDoneClicked)
+            }
+        },
     ) {
         when (gravatarQuickEditorParams.scope) {
             QuickEditorScope.AVATAR -> {
@@ -58,6 +70,8 @@ internal fun QuickEditor(
                     onProfileUpdated = {
                         viewModel.onEvent(QuickEditorEvent.OnProfileUpdated(it))
                     },
+                    onClose = onDoneClicked,
+                    viewModel = aboutEditorViewModel,
                 )
             }
         }

--- a/gravatar-quickeditor/src/main/res/values/strings.xml
+++ b/gravatar-quickeditor/src/main/res/values/strings.xml
@@ -88,4 +88,8 @@
     <string name="gravatar_qe_about_field_section_label_professional">Professional</string>
     <string name="gravatar_qe_about_save_profile_error_message">Error saving the changes.</string>
     <string name="gravatar_qe_about_save_profile_success_message">Profile updated successfully</string>
+    <string name="gravatar_qe_about_discard_changes_dialog_title">Unsaved changes!</string>
+    <string name="gravatar_qe_about_discard_changes_dialog_message">You\'ll lose your work if you exit now.</string>
+    <string name="gravatar_qe_about_discard_changes_dialog_confirm">Exit</string>
+    <string name="gravatar_qe_about_discard_changes_dialog_dismiss">Keep editing</string>
 </resources>

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModelTest.kt
@@ -1,0 +1,192 @@
+package com.gravatar.quickeditor.ui.abouteditor
+
+import app.cash.turbine.test
+import com.gravatar.extensions.defaultProfile
+import com.gravatar.quickeditor.data.models.QuickEditorError
+import com.gravatar.quickeditor.data.repository.ProfileRepository
+import com.gravatar.quickeditor.ui.CoroutineTestRule
+import com.gravatar.restapi.models.UpdateProfileRequest
+import com.gravatar.services.GravatarResult
+import com.gravatar.types.Email
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AboutEditorViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    var coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private val profileRepository = mockk<ProfileRepository>()
+    private lateinit var viewModel: AboutEditorViewModel
+
+    private val email = Email("testEmail")
+    private val profile = defaultProfile(hash = "hash")
+    private val updatedProfile = defaultProfile(hash = "hash", displayName = "Updated Name")
+    private val updateProfileRequest = UpdateProfileRequest {
+        displayName = "Updated Name"
+        jobTitle = ""
+        company = ""
+        description = ""
+        location = ""
+        pronunciation = ""
+        pronouns = ""
+    }
+
+    @Before
+    fun setup() {
+        coEvery { profileRepository.getProfile(email) } returns GravatarResult.Success(profile)
+    }
+
+    @Test
+    fun `given view model initialization when profile fetch succeeds then uiState is updated`() = runTest {
+        viewModel = initViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(AboutEditorUiState(isLoading = false), awaitItem())
+            assertEquals(AboutEditorUiState(isLoading = true), awaitItem())
+            assertEquals(
+                AboutEditorUiState(
+                    isLoading = false,
+                    aboutFields = profile.aboutFields,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `given view model initialization when profile fetch fails then uiState is updated`() = runTest {
+        coEvery { profileRepository.getProfile(email) } returns GravatarResult.Failure(QuickEditorError.Unknown)
+
+        viewModel = initViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(AboutEditorUiState(isLoading = false), awaitItem())
+            assertEquals(AboutEditorUiState(isLoading = true), awaitItem())
+            assertEquals(AboutEditorUiState(isLoading = false), awaitItem())
+        }
+    }
+
+    @Test
+    fun `given updated about field when save clicked and update succeeds then uiState is updated`() = runTest {
+        coEvery {
+            profileRepository.updateProfile(email, updateProfileRequest)
+        } returns GravatarResult.Success(updatedProfile)
+
+        viewModel = initViewModel()
+        viewModel.onEvent(AboutEditorEvent.OnAboutFieldUpdated(AboutInputField.Personal.DisplayName("Updated Name")))
+
+        advanceUntilIdle()
+
+        viewModel.onEvent(AboutEditorEvent.OnSaveClicked)
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals(
+                AboutEditorUiState(savingProfile = true, aboutFields = updatedProfile.aboutFields),
+                awaitItem(),
+            )
+            assertEquals(
+                AboutEditorUiState(
+                    savingProfile = false,
+                    aboutFields = updatedProfile.aboutFields,
+                ),
+                awaitItem(),
+            )
+        }
+        viewModel.actions.test {
+            assertEquals(AboutEditorAction.ProfileUpdated(updatedProfile), awaitItem())
+        }
+    }
+
+    @Test
+    fun `given updated about field when save clicked and update fails then uiState is updated`() = runTest {
+        coEvery {
+            profileRepository.updateProfile(email, updateProfileRequest)
+        } returns GravatarResult.Failure(QuickEditorError.Unknown)
+
+        viewModel = initViewModel()
+        viewModel.onEvent(AboutEditorEvent.OnAboutFieldUpdated(AboutInputField.Personal.DisplayName("Updated Name")))
+
+        advanceUntilIdle()
+
+        viewModel.onEvent(AboutEditorEvent.OnSaveClicked)
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals(
+                AboutEditorUiState(savingProfile = true, aboutFields = updatedProfile.aboutFields),
+                awaitItem(),
+            )
+            assertEquals(
+                AboutEditorUiState(
+                    savingProfile = false,
+                    aboutFields = updatedProfile.aboutFields,
+                ),
+                awaitItem(),
+            )
+        }
+        viewModel.actions.test {
+            assertEquals(AboutEditorAction.ProfileUpdateFailed, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given no changes when done clicked then editor is closed`() = runTest {
+        viewModel = initViewModel()
+
+        advanceUntilIdle()
+
+        viewModel.onEvent(AboutEditorEvent.OnDoneClicked)
+
+        viewModel.actions.test {
+            assertEquals(AboutEditorAction.CloseEditor, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given changes when done clicked then discard changes dialog is shown`() = runTest {
+        viewModel = initViewModel()
+
+        viewModel.onEvent(AboutEditorEvent.OnAboutFieldUpdated(AboutInputField.Personal.DisplayName("Updated Name")))
+        viewModel.onEvent(AboutEditorEvent.OnDoneClicked)
+
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            assertEquals(true, awaitItem().discardChangesDialogVisible)
+        }
+    }
+
+    @Test
+    fun `given discard changes dialog shown when dismissed then hidden`() = runTest {
+        viewModel = initViewModel()
+
+        viewModel.onEvent(AboutEditorEvent.OnAboutFieldUpdated(AboutInputField.Personal.DisplayName("Updated Name")))
+        viewModel.onEvent(AboutEditorEvent.OnDoneClicked)
+
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            assertEquals(true, awaitItem().discardChangesDialogVisible)
+
+            viewModel.onEvent(AboutEditorEvent.OnDiscardDialogDismissed)
+            assertEquals(false, awaitItem().discardChangesDialogVisible)
+        }
+    }
+
+    private fun initViewModel() = AboutEditorViewModel(
+        email = email,
+        profileRepository = profileRepository,
+    )
+}

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModelTest.kt
@@ -66,7 +66,9 @@ class AboutEditorViewModelTest {
 
     @Test
     fun `given view model initialization when profile fetch fails then uiState is updated`() = runTest {
-        coEvery { profileRepository.getProfile(email) } returns GravatarResult.Failure(QuickEditorError.Unknown)
+        coEvery { profileRepository.getProfile(email) } returns GravatarResult.Failure(
+            QuickEditorError.Unknown,
+        )
 
         viewModel = initViewModel()
 
@@ -84,7 +86,13 @@ class AboutEditorViewModelTest {
         } returns GravatarResult.Success(updatedProfile)
 
         viewModel = initViewModel()
-        viewModel.onEvent(AboutEditorEvent.OnAboutFieldUpdated(AboutInputField.Personal.DisplayName("Updated Name")))
+        viewModel.onEvent(
+            AboutEditorEvent.OnAboutFieldUpdated(
+                AboutInputField.Personal.DisplayName(
+                    "Updated Name",
+                ),
+            ),
+        )
 
         advanceUntilIdle()
 
@@ -93,7 +101,10 @@ class AboutEditorViewModelTest {
         viewModel.uiState.test {
             expectMostRecentItem()
             assertEquals(
-                AboutEditorUiState(savingProfile = true, aboutFields = updatedProfile.aboutFields),
+                AboutEditorUiState(
+                    savingProfile = true,
+                    aboutFields = updatedProfile.aboutFields,
+                ),
                 awaitItem(),
             )
             assertEquals(
@@ -116,7 +127,13 @@ class AboutEditorViewModelTest {
         } returns GravatarResult.Failure(QuickEditorError.Unknown)
 
         viewModel = initViewModel()
-        viewModel.onEvent(AboutEditorEvent.OnAboutFieldUpdated(AboutInputField.Personal.DisplayName("Updated Name")))
+        viewModel.onEvent(
+            AboutEditorEvent.OnAboutFieldUpdated(
+                AboutInputField.Personal.DisplayName(
+                    "Updated Name",
+                ),
+            ),
+        )
 
         advanceUntilIdle()
 
@@ -125,7 +142,10 @@ class AboutEditorViewModelTest {
         viewModel.uiState.test {
             expectMostRecentItem()
             assertEquals(
-                AboutEditorUiState(savingProfile = true, aboutFields = updatedProfile.aboutFields),
+                AboutEditorUiState(
+                    savingProfile = true,
+                    aboutFields = updatedProfile.aboutFields,
+                ),
                 awaitItem(),
             )
             assertEquals(
@@ -158,7 +178,13 @@ class AboutEditorViewModelTest {
     fun `given changes when done clicked then discard changes dialog is shown`() = runTest {
         viewModel = initViewModel()
 
-        viewModel.onEvent(AboutEditorEvent.OnAboutFieldUpdated(AboutInputField.Personal.DisplayName("Updated Name")))
+        viewModel.onEvent(
+            AboutEditorEvent.OnAboutFieldUpdated(
+                AboutInputField.Personal.DisplayName(
+                    "Updated Name",
+                ),
+            ),
+        )
         viewModel.onEvent(AboutEditorEvent.OnDoneClicked)
 
         advanceUntilIdle()
@@ -172,7 +198,13 @@ class AboutEditorViewModelTest {
     fun `given discard changes dialog shown when dismissed then hidden`() = runTest {
         viewModel = initViewModel()
 
-        viewModel.onEvent(AboutEditorEvent.OnAboutFieldUpdated(AboutInputField.Personal.DisplayName("Updated Name")))
+        viewModel.onEvent(
+            AboutEditorEvent.OnAboutFieldUpdated(
+                AboutInputField.Personal.DisplayName(
+                    "Updated Name",
+                ),
+            ),
+        )
         viewModel.onEvent(AboutEditorEvent.OnDoneClicked)
 
         advanceUntilIdle()
@@ -181,6 +213,29 @@ class AboutEditorViewModelTest {
             assertEquals(true, awaitItem().discardChangesDialogVisible)
 
             viewModel.onEvent(AboutEditorEvent.OnDiscardDialogDismissed)
+            assertEquals(false, awaitItem().discardChangesDialogVisible)
+        }
+    }
+
+    @Test
+    fun `given discard changes dialog shown when discard confirmed then hidden`() = runTest {
+        viewModel = initViewModel()
+
+        viewModel.onEvent(
+            AboutEditorEvent.OnAboutFieldUpdated(
+                AboutInputField.Personal.DisplayName(
+                    "Updated Name",
+                ),
+            ),
+        )
+        viewModel.onEvent(AboutEditorEvent.OnDoneClicked)
+
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            assertEquals(true, awaitItem().discardChangesDialogVisible)
+
+            viewModel.onEvent(AboutEditorEvent.OnDiscardConfirmed)
             assertEquals(false, awaitItem().discardChangesDialogVisible)
         }
     }


### PR DESCRIPTION


### Description

This PR adds an alert dialog that is shown when the user tries to close the QuickEditor with unsaved changes in the About editor. 

The copy is not final yet, but because we aren't merging to `trunk`, the strings won't be uploaded to GlotPress.

https://github.com/user-attachments/assets/a0e09af3-df0d-410f-954e-6a0906e1c861

### Testing Steps

1. Launch the QE with About scope
2. Tap Done
3. Confirm the QE was closed
4. Open the QE again
5. Change some fields 
6. Tap Done
7. Confirm you see the alert dialog
8. Tap Exit
9. Confirm the QE was closed
10. Open the QE again
5. Change some fields 
6. Tap Done
7. Confirm you see the alert dialog
8. Tap keep editing 
9. Save changes
10. Tap Done
11. Confirm the QE was closed
