### PR TITLE
Use rememberSaveable for userEmail to preserve the value during config changes

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -62,7 +62,7 @@ import kotlinx.coroutines.withContext
 
 @Composable
 fun AvatarUpdateTab(modifier: Modifier = Modifier) {
-    var userEmail by remember { mutableStateOf(BuildConfig.DEMO_EMAIL) }
+    var userEmail by rememberSaveable { mutableStateOf(BuildConfig.DEMO_EMAIL) }
     var userToken by remember { mutableStateOf(BuildConfig.DEMO_BEARER_TOKEN) }
     var useToken by rememberSaveable { mutableStateOf(false) }
     var tokenVisible by remember { mutableStateOf(false) }


### PR DESCRIPTION


### Description

As reported: 

>In short, I'm logged in with an email, then I try to log in with a different email, but when I finish the OAuth process, the app goes back to the previous email, and shows that previous account instead of the new one.

This happens with the `Don't keep activities` setting ON.

The fix is to use `rememberSaveable` instead of `remember`. The former preserves the value between config changes.

### Testing Steps

1. Enable "Don't keep activities"
2. Launch the QE and login with account nr 1
3. Close the QE
4. Type in email for account nr 2
5. Open the QE
6. Make sure to use correct email in the oauth screen
7. Finish oauth
8. Confirm you are logged in as account nr 2 
