### PR TITLE
Introduce UpdateHandler with QuickEditorUpdateType to handle different payloads in updates

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -26,8 +26,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
@@ -48,19 +50,25 @@ import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.demoapp.ui.components.GravatarPasswordInput
 import com.gravatar.quickeditor.GravatarQuickEditor
 import com.gravatar.quickeditor.ui.editor.AboutEditorConfiguration
+import com.gravatar.quickeditor.ui.editor.AboutEditorResult
 import com.gravatar.quickeditor.ui.editor.AboutInputField
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.AvatarPickerAndAboutEditorConfiguration
 import com.gravatar.quickeditor.ui.editor.AvatarPickerConfiguration
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
+import com.gravatar.quickeditor.ui.editor.AvatarPickerResult
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.editor.GravatarUiMode
 import com.gravatar.quickeditor.ui.editor.QuickEditorScopeOption
 import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
 import com.gravatar.quickeditor.ui.oauth.OAuthParams
+import com.gravatar.restapi.models.Profile
+import com.gravatar.services.GravatarResult
+import com.gravatar.services.ProfileService
 import com.gravatar.types.Email
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.LocalGravatarTheme
+import com.gravatar.ui.components.ComponentState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -95,6 +103,25 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
 
     val keyboardController = LocalSoftwareKeyboardController.current
 
+    val profileService = ProfileService()
+
+    var profileState: ComponentState<Profile> by remember { mutableStateOf(ComponentState.Loading, neverEqualPolicy()) }
+
+    LaunchedEffect(userEmail) {
+        profileState = ComponentState.Loading
+        when (val result = profileService.retrieveCatching(Email(userEmail))) {
+            is GravatarResult.Success -> {
+                result.value.let {
+                    profileState = ComponentState.Loaded(it)
+                }
+            }
+
+            is GravatarResult.Failure -> {
+                profileState = ComponentState.Empty
+            }
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -109,6 +136,7 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
         ) {
             DemoProfileSummaryCard(
                 email = userEmail,
+                profileState = profileState,
                 avatarCache = cacheBuster,
                 modifier = Modifier.padding(bottom = 16.dp),
             )
@@ -242,9 +270,15 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                     }
                 },
                 authenticationMethod = authenticationMethod,
-                onAvatarSelected = remember {
-                    {
-                        cacheBuster = System.currentTimeMillis().toString()
+                updateHandler = { result ->
+                    when (result) {
+                        is AvatarPickerResult -> {
+                            cacheBuster = System.currentTimeMillis().toString()
+                        }
+
+                        is AboutEditorResult -> {
+                            profileState = ComponentState.Loaded(result.profile)
+                        }
                     }
                 },
                 onDismiss = remember {

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoProfileSummaryCard.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/DemoProfileSummaryCard.kt
@@ -7,19 +7,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.neverEqualPolicy
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gravatar.restapi.models.Profile
-import com.gravatar.services.GravatarResult
-import com.gravatar.services.ProfileService
 import com.gravatar.types.Email
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.components.ComponentState
@@ -27,26 +19,12 @@ import com.gravatar.ui.components.ProfileSummary
 import com.gravatar.ui.components.atomic.Avatar
 
 @Composable
-fun DemoProfileSummaryCard(email: String, avatarCache: String? = null, modifier: Modifier = Modifier) {
-    val profileService = ProfileService()
-
-    var profileState: ComponentState<Profile> by remember { mutableStateOf(ComponentState.Loading, neverEqualPolicy()) }
-
-    LaunchedEffect(email) {
-        profileState = ComponentState.Loading
-        when (val result = profileService.retrieveCatching(Email(email))) {
-            is GravatarResult.Success -> {
-                result.value.let {
-                    profileState = ComponentState.Loaded(it)
-                }
-            }
-
-            is GravatarResult.Failure -> {
-                profileState = ComponentState.Empty
-            }
-        }
-    }
-
+fun DemoProfileSummaryCard(
+    email: String,
+    profileState: ComponentState<Profile> = ComponentState.Loading,
+    avatarCache: String? = null,
+    modifier: Modifier = Modifier,
+) {
     Card(
         modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),

--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/activity/QuickEditorTestActivity.kt
@@ -88,7 +88,7 @@ class QuickEditorTestActivity : AppCompatActivity() {
                     },
                 ),
                 onAvatarSelected = {
-                    Toast.makeText(this, it.toString(), Toast.LENGTH_SHORT).show()
+                    profileChanges++
                 },
                 onDismiss = {
                     Toast.makeText(this, it.toString(), Toast.LENGTH_SHORT).show()

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -4,10 +4,16 @@ public final class com/gravatar/quickeditor/GravatarQuickEditor {
 	public final fun logout (Lcom/gravatar/types/Email;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun show (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;)V
 	public static final fun show (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public static final fun show (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function1;)V
+	public static final fun show (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static final fun show (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;)V
 	public static final fun show (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public static final fun show (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function1;)V
+	public static final fun show (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun show$default (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun show$default (Landroid/app/Activity;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun show$default (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun show$default (Landroidx/fragment/app/Fragment;Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class com/gravatar/quickeditor/ui/GetQuickEditorResult : androidx/activity/result/contract/ActivityResultContract {
@@ -329,6 +335,15 @@ public final class com/gravatar/quickeditor/ui/editor/AboutEditorConfiguration$C
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/gravatar/quickeditor/ui/editor/AboutEditorResult : com/gravatar/quickeditor/ui/editor/QuickEditorUpdateType {
+	public static final field $stable I
+	public fun <init> (Lcom/gravatar/restapi/models/Profile;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProfile ()Lcom/gravatar/restapi/models/Profile;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/quickeditor/ui/editor/AboutInputField : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/gravatar/quickeditor/ui/editor/AboutInputField$Companion;
@@ -542,6 +557,14 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/gravatar/quickeditor/ui/editor/AvatarPickerResult : com/gravatar/quickeditor/ui/editor/QuickEditorUpdateType {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/editor/AvatarPickerResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/gravatar/quickeditor/ui/editor/ComposableSingletons$QuickEditorKt {
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/editor/ComposableSingletons$QuickEditorKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
@@ -687,8 +710,12 @@ public final class com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption$Sco
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public abstract interface class com/gravatar/quickeditor/ui/editor/QuickEditorUpdateType {
+}
+
 public final class com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheetKt {
 	public static final fun GravatarQuickEditorBottomSheet (Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun GravatarQuickEditorBottomSheet (Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/gravatar/quickeditor/ui/extensions/ComposableSingletons$QESnackbarKt {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/GravatarQuickEditor.kt
@@ -4,8 +4,10 @@ import android.app.Activity
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
+import com.gravatar.quickeditor.ui.editor.AvatarPickerResult
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
+import com.gravatar.quickeditor.ui.editor.UpdateHandler
 import com.gravatar.quickeditor.ui.editor.extensions.addQuickEditorToView
 import com.gravatar.types.Email
 
@@ -19,7 +21,7 @@ public object GravatarQuickEditor {
      * @param activity The activity to launch the Gravatar Quick Editor from.
      * @param gravatarQuickEditorParams The parameters to configure the Quick Editor.
      * @param authenticationMethod The method used for authentication with the Gravatar REST API.
-     * @param onAvatarSelected The callback for the avatar update.
+     * @param updateHandler The callback for the Quick Editor updates.
      *                       Can be invoked multiple times while the Quick Editor is open.
      * @param onDismiss The callback for the dismiss action containing [GravatarQuickEditorDismissReason]
      */
@@ -29,11 +31,84 @@ public object GravatarQuickEditor {
         activity: Activity,
         gravatarQuickEditorParams: GravatarQuickEditorParams,
         authenticationMethod: AuthenticationMethod,
+        updateHandler: UpdateHandler,
+        onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
+    ) {
+        val viewGroup: ViewGroup = activity.findViewById(android.R.id.content)
+        addQuickEditorToView(
+            viewGroup = viewGroup,
+            gravatarQuickEditorParams = gravatarQuickEditorParams,
+            authenticationMethod = authenticationMethod,
+            updateHandler = updateHandler,
+            onDismiss = onDismiss,
+        )
+    }
+
+    /**
+     * Helper function to launch the Gravatar Quick Editor from the fragment. Internally it uses
+     *      * `Activity.requireActivity()` to get the activity.
+     *
+     * @param fragment The fragment to launch the Gravatar Quick Editor from.
+     * @param gravatarQuickEditorParams The parameters to configure the Quick Editor.
+     * @param authenticationMethod The method used for authentication with the Gravatar REST API.
+     * @param updateHandler The callback for the Quick Editor updates.
+     *                       Can be invoked multiple times while the Quick Editor is open.
+     * @param onDismiss The callback for the dismiss action containing [GravatarQuickEditorDismissReason]
+     */
+    @JvmStatic
+    @JvmOverloads
+    public fun show(
+        fragment: Fragment,
+        gravatarQuickEditorParams: GravatarQuickEditorParams,
+        authenticationMethod: AuthenticationMethod,
+        updateHandler: UpdateHandler,
+        onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
+    ) {
+        val viewGroup: ViewGroup = fragment.requireActivity().findViewById(android.R.id.content)
+        addQuickEditorToView(
+            viewGroup = viewGroup,
+            gravatarQuickEditorParams = gravatarQuickEditorParams,
+            authenticationMethod = authenticationMethod,
+            updateHandler = updateHandler,
+            onDismiss = onDismiss,
+        )
+    }
+
+    /**
+     * Helper function to launch the Gravatar Quick Editor from the activity.
+     *
+     * @param activity The activity to launch the Gravatar Quick Editor from.
+     * @param gravatarQuickEditorParams The parameters to configure the Quick Editor.
+     * @param authenticationMethod The method used for authentication with the Gravatar REST API.
+     * @param onAvatarSelected The callback for the avatar update.
+     *                       Can be invoked multiple times while the Quick Editor is open.
+     * @param onDismiss The callback for the dismiss action containing [GravatarQuickEditorDismissReason]
+     */
+    @JvmStatic
+    @JvmOverloads
+    @Deprecated(
+        message = "This function is deprecated and will be removed in a future release.",
+        replaceWith = ReplaceWith("GravatarQuickEditor.show()"),
+    )
+    public fun show(
+        activity: Activity,
+        gravatarQuickEditorParams: GravatarQuickEditorParams,
+        authenticationMethod: AuthenticationMethod,
         onAvatarSelected: () -> Unit,
         onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
     ) {
         val viewGroup: ViewGroup = activity.findViewById(android.R.id.content)
-        addQuickEditorToView(viewGroup, gravatarQuickEditorParams, authenticationMethod, onAvatarSelected, onDismiss)
+        addQuickEditorToView(
+            viewGroup = viewGroup,
+            gravatarQuickEditorParams = gravatarQuickEditorParams,
+            authenticationMethod = authenticationMethod,
+            updateHandler = {
+                if (it is AvatarPickerResult) {
+                    onAvatarSelected()
+                }
+            },
+            onDismiss = onDismiss,
+        )
     }
 
     /**
@@ -49,6 +124,10 @@ public object GravatarQuickEditor {
      */
     @JvmStatic
     @JvmOverloads
+    @Deprecated(
+        message = "This function is deprecated and will be removed in a future release.",
+        replaceWith = ReplaceWith("GravatarQuickEditor.show()"),
+    )
     public fun show(
         fragment: Fragment,
         gravatarQuickEditorParams: GravatarQuickEditorParams,
@@ -57,7 +136,17 @@ public object GravatarQuickEditor {
         onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
     ) {
         val viewGroup: ViewGroup = fragment.requireActivity().findViewById(android.R.id.content)
-        addQuickEditorToView(viewGroup, gravatarQuickEditorParams, authenticationMethod, onAvatarSelected, onDismiss)
+        addQuickEditorToView(
+            viewGroup = viewGroup,
+            gravatarQuickEditorParams = gravatarQuickEditorParams,
+            authenticationMethod = authenticationMethod,
+            updateHandler = {
+                if (it is AvatarPickerResult) {
+                    onAvatarSelected()
+                }
+            },
+            onDismiss = onDismiss,
+        )
     }
 
     /**

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -28,7 +28,7 @@ import com.gravatar.quickeditor.ui.splash.SplashPage
  *
  * @param gravatarQuickEditorParams The Quick Editor parameters.
  * @param oAuthParams The OAuth parameters.
- * @param onAvatarSelected The callback for the avatar update.
+ * @param updateHandler The callback for the Quick Editor updates.
  *                       Can be invoked multiple times while the Quick Editor is open
  * @param onDoneClicked The callback for the done action.
  * @param onDismiss The callback for the dismiss action.
@@ -38,7 +38,7 @@ import com.gravatar.quickeditor.ui.splash.SplashPage
 internal fun GravatarQuickEditorPage(
     gravatarQuickEditorParams: GravatarQuickEditorParams,
     oAuthParams: OAuthParams,
-    onAvatarSelected: () -> Unit,
+    updateHandler: UpdateHandler,
     onDoneClicked: () -> Unit,
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
 ) {
@@ -77,7 +77,7 @@ internal fun GravatarQuickEditorPage(
             gravatarQuickEditorParams = gravatarQuickEditorParams,
             handleExpiredSession = true,
             navController = navController,
-            onAvatarSelected = onAvatarSelected,
+            updateHandler = updateHandler,
             onSessionExpired = {
                 navController.navigateAndPopupTo(QuickEditorPage.OAUTH.name, QuickEditorPage.EDITOR.name)
             },
@@ -92,7 +92,7 @@ internal fun GravatarQuickEditorPage(
  *
  * @param gravatarQuickEditorParams The Quick Editor parameters.
  * @param authToken The authentication token.
- * @param onAvatarSelected The callback for the avatar update.
+ * @param updateHandler The callback for the Quick Editor updates.
  *                       Can be invoked multiple times while the Quick Editor is open
  * @param onDoneClicked The callback for the done action.
  * @param onDismiss The callback for the dismiss action.
@@ -102,7 +102,7 @@ internal fun GravatarQuickEditorPage(
 internal fun GravatarQuickEditorPage(
     gravatarQuickEditorParams: GravatarQuickEditorParams,
     authToken: String,
-    onAvatarSelected: () -> Unit,
+    updateHandler: UpdateHandler,
     onDoneClicked: () -> Unit,
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
 ) {
@@ -127,7 +127,7 @@ internal fun GravatarQuickEditorPage(
             gravatarQuickEditorParams = gravatarQuickEditorParams,
             handleExpiredSession = false,
             navController = navController,
-            onAvatarSelected = onAvatarSelected,
+            updateHandler = updateHandler,
             onSessionExpired = { onDismiss(GravatarQuickEditorDismissReason.InvalidToken) },
             onDoneClicked = onDoneClicked,
         )
@@ -139,7 +139,7 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
     navController: NavHostController,
     gravatarQuickEditorParams: GravatarQuickEditorParams,
     handleExpiredSession: Boolean,
-    onAvatarSelected: () -> Unit,
+    updateHandler: UpdateHandler,
     onSessionExpired: () -> Unit,
     onDoneClicked: () -> Unit,
 ) {
@@ -158,7 +158,7 @@ private fun NavGraphBuilder.addAvatarPickerGraph(
             QuickEditor(
                 gravatarQuickEditorParams = gravatarQuickEditorParams,
                 handleExpiredSession = handleExpiredSession,
-                onAvatarSelected = onAvatarSelected,
+                updateHandler = updateHandler,
                 onSessionExpired = onSessionExpired,
                 onAltTextTapped = { email, avatarId ->
                     navController.navigate(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditor.kt
@@ -29,7 +29,7 @@ import com.gravatar.ui.GravatarTheme
 internal fun QuickEditor(
     gravatarQuickEditorParams: GravatarQuickEditorParams,
     handleExpiredSession: Boolean,
-    onAvatarSelected: () -> Unit,
+    updateHandler: UpdateHandler,
     onSessionExpired: () -> Unit,
     onDoneClicked: () -> Unit,
     onAltTextTapped: (email: String, avatarId: String) -> Unit,
@@ -66,7 +66,7 @@ internal fun QuickEditor(
                         gravatarQuickEditorParams = gravatarQuickEditorParams,
                         handleExpiredSession = handleExpiredSession,
                         onAvatarSelected = {
-                            onAvatarSelected()
+                            updateHandler(AvatarPickerResult)
                             viewModel.onEvent(QuickEditorEvent.UpdateAvatarCache)
                         },
                         onSessionExpired = onSessionExpired,
@@ -80,8 +80,9 @@ internal fun QuickEditor(
                 QuickEditorPage.AboutEditor -> {
                     AboutEditor(
                         quickEditorParams = gravatarQuickEditorParams,
-                        onProfileUpdated = {
-                            viewModel.onEvent(QuickEditorEvent.OnProfileUpdated(it))
+                        onProfileUpdated = { profile ->
+                            updateHandler(AboutEditorResult(profile))
+                            viewModel.onEvent(QuickEditorEvent.OnProfileUpdated(profile))
                         },
                         onClose = onDoneClicked,
                         viewModel = aboutEditorViewModel,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/UpdateHandler.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/UpdateHandler.kt
@@ -1,0 +1,34 @@
+package com.gravatar.quickeditor.ui.editor
+
+import com.gravatar.restapi.models.Profile
+import java.util.Objects
+
+/**
+ * Callback to handle updates from the Quick Editor.
+ */
+public typealias UpdateHandler = (QuickEditorUpdateType) -> Unit
+
+/**
+ * The interface for all Quick Editor result types.
+ */
+public interface QuickEditorUpdateType
+
+/**
+ * AvatarPicker result.
+ */
+public data object AvatarPickerResult : QuickEditorUpdateType
+
+/**
+ * AboutEditor result with the updated Profile in the payload.
+ *
+ * @property profile The updated Profile.
+ */
+public class AboutEditorResult(
+    public val profile: Profile,
+) : QuickEditorUpdateType {
+    override fun toString(): String = "AboutPayload(profile=$profile)"
+
+    override fun equals(other: Any?): Boolean = other is AboutEditorResult && other.profile == profile
+
+    override fun hashCode(): Int = Objects.hash(profile)
+}

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/UpdateHandler.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/UpdateHandler.kt
@@ -4,7 +4,25 @@ import com.gravatar.restapi.models.Profile
 import java.util.Objects
 
 /**
- * Callback to handle updates from the Quick Editor.
+ * This callback is invoked whenever the Quick Editor produces a result. The result is represented
+ * by a `QuickEditorUpdateType` instance, which can be one of several variants. Developers should
+ * implement this callback to handle the specific result types appropriately.
+ *
+ * Expected use cases:
+ * - `AvatarPickerResult`: Indicates that the user has updated their avatar. This result does not
+ *   carry any additional data and serves as a signal to refresh the avatar display.
+ * - `AboutEditorResult`: Contains an updated `Profile` object after the user edits their "About Me"
+ *   section. This result should be used to update the user's profile information in the application.
+ *
+ * Example usage:
+ * ```
+ * val updateHandler: UpdateHandler = { result ->
+ *     when (result) {
+ *         is AvatarPickerResult -> refreshAvatar()
+ *         is AboutEditorResult -> updateProfile(result.profile)
+ *     }
+ * }
+ * ```
  */
 public typealias UpdateHandler = (QuickEditorUpdateType) -> Unit
 
@@ -15,13 +33,19 @@ public interface QuickEditorUpdateType
 
 /**
  * AvatarPicker result.
+ *
+ * This result type is used when the user updates their avatar. It does not contain any additional
+ * data but serves as a signal to refresh the avatar display in the application.
  */
 public data object AvatarPickerResult : QuickEditorUpdateType
 
 /**
  * AboutEditor result with the updated Profile in the payload.
  *
- * @property profile The updated Profile.
+ * This result type is used when the user edits their "About Me" section. It contains the updated
+ * `Profile` object, which should be used to update the user's profile information in the application.
+ *
+ * @property profile The updated Profile object.
  */
 public class AboutEditorResult(
     public val profile: Profile,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -47,14 +47,46 @@ import com.gravatar.quickeditor.QuickEditorContainer
 import com.gravatar.quickeditor.ui.components.QEDragHandle
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
+import com.gravatar.quickeditor.ui.editor.AvatarPickerResult
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorPage
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.editor.GravatarUiMode
+import com.gravatar.quickeditor.ui.editor.UpdateHandler
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.LocalGravatarTheme
 import com.gravatar.ui.mainGravatarTheme
 import kotlinx.coroutines.launch
+
+/**
+ * ModalBottomSheet component for the Gravatar Quick Editor that enables the user to
+ * modify their Avatar.
+ *
+ * The bottom sheet is configured to take 70% of the screen height and skips the partially expanded state.
+ *
+ * @param gravatarQuickEditorParams The Quick Editor parameters.
+ * @param authenticationMethod The method used for authentication with the Gravatar REST API.
+ * @param updateHandler The callback for the Quick Editor updates.
+ *                       Can be invoked multiple times while the Quick Editor is open.
+ * @param onDismiss The callback for the dismiss action containing [GravatarQuickEditorDismissReason]
+ */
+@Composable
+public fun GravatarQuickEditorBottomSheet(
+    gravatarQuickEditorParams: GravatarQuickEditorParams,
+    authenticationMethod: AuthenticationMethod,
+    updateHandler: UpdateHandler,
+    onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
+) {
+    GravatarQuickEditorBottomSheet(
+        gravatarQuickEditorParams = gravatarQuickEditorParams,
+        authenticationMethod = authenticationMethod,
+        updateHandler = updateHandler,
+        onDismiss = onDismiss,
+        modalBottomSheetState = rememberGravatarModalBottomSheetState(
+            avatarPickerContentLayout = gravatarQuickEditorParams.scopeOption.avatarPickerContentLayout,
+        ),
+    )
+}
 
 /**
  * ModalBottomSheet component for the Gravatar Quick Editor that enables the user to
@@ -78,7 +110,11 @@ public fun GravatarQuickEditorBottomSheet(
     GravatarQuickEditorBottomSheet(
         gravatarQuickEditorParams = gravatarQuickEditorParams,
         authenticationMethod = authenticationMethod,
-        onAvatarSelected = onAvatarSelected,
+        updateHandler = { quickEditorUpdateType ->
+            if (quickEditorUpdateType is AvatarPickerResult) {
+                onAvatarSelected()
+            }
+        },
         onDismiss = onDismiss,
         modalBottomSheetState = rememberGravatarModalBottomSheetState(
             avatarPickerContentLayout = gravatarQuickEditorParams.scopeOption.avatarPickerContentLayout,
@@ -90,7 +126,7 @@ public fun GravatarQuickEditorBottomSheet(
 internal fun GravatarQuickEditorBottomSheet(
     gravatarQuickEditorParams: GravatarQuickEditorParams,
     authenticationMethod: AuthenticationMethod,
-    onAvatarSelected: () -> Unit,
+    updateHandler: UpdateHandler,
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
     modalBottomSheetState: ModalBottomSheetState,
 ) {
@@ -124,7 +160,7 @@ internal fun GravatarQuickEditorBottomSheet(
                         gravatarQuickEditorParams = gravatarQuickEditorParams,
                         authToken = authenticationMethod.token,
                         onDismiss = onDismiss,
-                        onAvatarSelected = onAvatarSelected,
+                        updateHandler = updateHandler,
                         onDoneClicked = onDoneClicked,
                     )
                 }
@@ -134,7 +170,7 @@ internal fun GravatarQuickEditorBottomSheet(
                         gravatarQuickEditorParams = gravatarQuickEditorParams,
                         oAuthParams = authenticationMethod.oAuthParams,
                         onDismiss = onDismiss,
-                        onAvatarSelected = onAvatarSelected,
+                        updateHandler = updateHandler,
                         onDoneClicked = onDoneClicked,
                     )
                 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -100,6 +100,10 @@ public fun GravatarQuickEditorBottomSheet(
  *                       Can be invoked multiple times while the Quick Editor is open.
  * @param onDismiss The callback for the dismiss action containing [GravatarQuickEditorDismissReason]
  */
+@Deprecated(
+    message = "Use the new GravatarQuickEditorBottomSheet with UpdateHandler param instead.",
+    replaceWith = ReplaceWith(expression = "GravatarQuickEditorBottomSheet()"),
+)
 @Composable
 public fun GravatarQuickEditorBottomSheet(
     gravatarQuickEditorParams: GravatarQuickEditorParams,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
@@ -10,6 +10,7 @@ import com.composables.core.SheetDetent.Companion.Hidden
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
+import com.gravatar.quickeditor.ui.editor.UpdateHandler
 import com.gravatar.quickeditor.ui.editor.bottomsheet.GravatarQuickEditorBottomSheet
 import com.gravatar.quickeditor.ui.editor.bottomsheet.rememberGravatarModalBottomSheetState
 import kotlinx.coroutines.launch
@@ -18,7 +19,7 @@ internal fun addQuickEditorToView(
     viewGroup: ViewGroup,
     gravatarQuickEditorParams: GravatarQuickEditorParams,
     authenticationMethod: AuthenticationMethod,
-    onAvatarUpdate: () -> Unit,
+    updateHandler: UpdateHandler,
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
 ) {
     viewGroup.addView(
@@ -29,7 +30,7 @@ internal fun addQuickEditorToView(
                     composeView = this,
                     gravatarQuickEditorParams = gravatarQuickEditorParams,
                     authenticationMethod = authenticationMethod,
-                    onAvatarUpdate = onAvatarUpdate,
+                    updateHandler = updateHandler,
                     onDismiss = onDismiss,
                 )
             }
@@ -43,7 +44,7 @@ private fun GravatarQuickEditorBottomSheetWrapper(
     composeView: ComposeView,
     gravatarQuickEditorParams: GravatarQuickEditorParams,
     authenticationMethod: AuthenticationMethod,
-    onAvatarUpdate: () -> Unit,
+    updateHandler: UpdateHandler,
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -55,7 +56,7 @@ private fun GravatarQuickEditorBottomSheetWrapper(
     GravatarQuickEditorBottomSheet(
         gravatarQuickEditorParams = gravatarQuickEditorParams,
         authenticationMethod = authenticationMethod,
-        onAvatarSelected = onAvatarUpdate,
+        updateHandler = updateHandler,
         onDismiss = onDismiss,
         modalBottomSheetState = modalBottomSheetState,
     )


### PR DESCRIPTION
### Description

Second PR with new public API. This one introduced an `UpdateHandler` - a callback that will replace the `onAvatarSelected` callback. 

```kotlin
typealias UpdateHandler = (QuickEditorUpdateType) -> Unit
```

`QuickEditorUpdateType` is an interface, and each new result should extend from it. I've used an interface to follow the same requirement of not breaking the compilation when the new scope is added in the future. 

### Testing Steps

1. Launch the demo app
2. Open the AvatarPicker
3. Update the avatar 
4. Confirm the avatar was updated in the demo app
5. Open AboutEditor
6. Update the display name
7. Confirm the profile card data was updated in the demo app
