### PR TITLE
Bump the publish plugin to 0.32.0

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-dsl`
-    kotlin("jvm") version "2.0.21"
     alias(libs.plugins.ktlint)
     alias(libs.plugins.detekt)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ startup = "1.1.1"
 testCoreKtx = "1.6.1"
 turbine = "1.1.0"
 ucrop = "2.2.11"
-mavenPublish = "0.31.0"
+mavenPublish = "0.32.0"
 kotlinCompilerExtension = "1.5.15"
 
 [libraries]


### PR DESCRIPTION


### Description

Bumping the `gradle-maven-publish-plugin` to 0.32.0 with fixed Kotlin 1.9 compatibility. 

### Testing Steps

Green CI