### PR TITLE
QuickEditor height adjustments for the new Scopes

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
@@ -1,5 +1,6 @@
 package com.gravatar.quickeditor.ui.abouteditor
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -105,7 +106,10 @@ internal fun AboutEditor(
     }
 
     Surface {
-        Box(modifier = Modifier.wrapContentSize()) {
+        Box(modifier = Modifier
+            .wrapContentSize()
+            .animateContentSize()
+        ) {
             AboutEditor(
                 uiState = uiState,
                 onEvent = { event ->

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
@@ -106,9 +106,10 @@ internal fun AboutEditor(
     }
 
     Surface {
-        Box(modifier = Modifier
-            .wrapContentSize()
-            .animateContentSize()
+        Box(
+            modifier = Modifier
+                .wrapContentSize()
+                .animateContentSize(),
         ) {
             AboutEditor(
                 uiState = uiState,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption.kt
@@ -47,6 +47,13 @@ public class QuickEditorScopeOption private constructor(
             is Scope.AvatarPicker -> AboutInputField.all
         }
 
+    internal val initialPage: QuickEditorPage
+        get() = when (scope) {
+            is Scope.AvatarPicker -> QuickEditorPage.AvatarPicker
+            is Scope.AboutEditor -> QuickEditorPage.AboutEditor
+            is Scope.AvatarPickerAndAboutEditor -> scope.config.initialPage.internalType
+        }
+
     public companion object {
         internal val default = QuickEditorScopeOption(
             scope = Scope.AvatarPicker(AvatarPickerConfiguration.default),

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorViewModel.kt
@@ -121,14 +121,7 @@ internal class QuickEditorViewModelFactory(
     }
 }
 
-private val QuickEditorScopeOption.initialPage: QuickEditorPage
-    get() = when (scope) {
-        is Scope.AvatarPicker -> QuickEditorPage.AvatarPicker
-        is Scope.AboutEditor -> QuickEditorPage.AboutEditor
-        is Scope.AvatarPickerAndAboutEditor -> scope.config.initialPage.internalType
-    }
-
-private val AvatarPickerAndAboutEditorConfiguration.Page.internalType: QuickEditorPage
+internal val AvatarPickerAndAboutEditorConfiguration.Page.internalType: QuickEditorPage
     get() = when (this) {
         AvatarPicker -> QuickEditorPage.AvatarPicker
         AboutEditor -> QuickEditorPage.AboutEditor

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -4,7 +4,9 @@ import android.content.res.Configuration
 import android.graphics.Color
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
@@ -13,6 +15,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -261,36 +264,49 @@ private fun GravatarModalBottomSheet(
                     Scrim(
                         scrimColor = MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f),
                     )
-                    Sheet(
+                    Box(
                         modifier = Modifier
-                            .imePadding()
-                            .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
-                            .background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
-                            .widthIn(max = 640.dp)
-                            .fillMaxWidth()
                             .padding(
-                                WindowInsets.navigationBars
-                                    .only(WindowInsetsSides.Vertical)
-                                    .asPaddingValues(),
+                                paddingValues = if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                                    PaddingValues(0.dp)
+                                } else {
+                                    WindowInsets.statusBars
+                                        .only(WindowInsetsSides.Top)
+                                        .asPaddingValues()
+                                },
                             ),
                     ) {
-                        val window = LocalModalWindow.current
-                        val isDarkTheme = isSystemInDarkTheme()
-                        LaunchedEffect(Unit) {
-                            window.navigationBarColor = Color.TRANSPARENT
-                            WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
-                                !isDarkTheme
-                        }
-                        Surface(
+                        Sheet(
                             modifier = Modifier
-                                .fillMaxWidth(),
-                            tonalElevation = 1.dp,
+                                .imePadding()
+                                .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+                                .background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
+                                .widthIn(max = 640.dp)
+                                .fillMaxWidth()
+                                .padding(
+                                    WindowInsets.navigationBars
+                                        .only(WindowInsetsSides.Vertical)
+                                        .asPaddingValues(),
+                                ),
                         ) {
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
+                            val window = LocalModalWindow.current
+                            val isDarkTheme = isSystemInDarkTheme()
+                            LaunchedEffect(Unit) {
+                                window.navigationBarColor = Color.TRANSPARENT
+                                WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
+                                    !isDarkTheme
+                            }
+                            Surface(
+                                modifier = Modifier
+                                    .fillMaxWidth(),
+                                tonalElevation = 1.dp,
                             ) {
-                                QEDragHandle()
-                                content()
+                                Column(
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                ) {
+                                    QEDragHandle()
+                                    content()
+                                }
                             }
                         }
                     }
@@ -300,12 +316,11 @@ private fun GravatarModalBottomSheet(
     }
 }
 
-internal val peek = SheetDetent(identifier = "peek") { containerHeight, _ ->
-    containerHeight * 0.6f
-}
-
 @Composable
 internal fun AvatarPickerContentLayout.modalDetents(): ModalDetents {
+    val peek = SheetDetent(identifier = "peek") { containerHeight, sheetHeight ->
+        containerHeight * 0.6f
+    }
     val windowHeightSizeClass = currentWindowAdaptiveInfo().windowSizeClass.windowHeightSizeClass
     val initialDetent = if (windowHeightSizeClass == WindowHeightSizeClass.COMPACT) {
         FullyExpanded

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -57,6 +57,8 @@ import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorPage
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.editor.GravatarUiMode
+import com.gravatar.quickeditor.ui.editor.QuickEditorPage
+import com.gravatar.quickeditor.ui.editor.QuickEditorScopeOption
 import com.gravatar.quickeditor.ui.editor.UpdateHandler
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.LocalGravatarTheme
@@ -87,7 +89,7 @@ public fun GravatarQuickEditorBottomSheet(
         authenticationMethod = authenticationMethod,
         updateHandler = updateHandler,
         onDismiss = onDismiss,
-        modalDetents = gravatarQuickEditorParams.scopeOption.avatarPickerContentLayout.modalDetents(),
+        modalDetents = gravatarQuickEditorParams.scopeOption.modalDetents(),
     )
 }
 
@@ -123,7 +125,7 @@ public fun GravatarQuickEditorBottomSheet(
             }
         },
         onDismiss = onDismiss,
-        modalDetents = gravatarQuickEditorParams.scopeOption.avatarPickerContentLayout.modalDetents(),
+        modalDetents = gravatarQuickEditorParams.scopeOption.modalDetents(),
     )
 }
 
@@ -316,34 +318,63 @@ private fun GravatarModalBottomSheet(
     }
 }
 
-@Composable
-internal fun AvatarPickerContentLayout.modalDetents(): ModalDetents {
-    val peek = SheetDetent(identifier = "peek") { containerHeight, sheetHeight ->
-        containerHeight * 0.6f
-    }
-    val windowHeightSizeClass = currentWindowAdaptiveInfo().windowSizeClass.windowHeightSizeClass
-    val initialDetent = if (windowHeightSizeClass == WindowHeightSizeClass.COMPACT) {
-        FullyExpanded
-    } else {
-        when (this) {
-            AvatarPickerContentLayout.Horizontal -> FullyExpanded
-            AvatarPickerContentLayout.Vertical -> peek
-        }
-    }
+private val peek = SheetDetent(identifier = "peek") { containerHeight, _ ->
+    containerHeight * 0.6f
+}
 
-    val detents = buildList {
-        add(Hidden)
-        if (this@modalDetents == AvatarPickerContentLayout.Horizontal) {
-            add(FullyExpanded)
-        } else {
+@Composable
+internal fun QuickEditorScopeOption.modalDetents(): ModalDetents {
+    val windowHeightSizeClass = currentWindowAdaptiveInfo().windowSizeClass.windowHeightSizeClass
+
+    val detents = buildDetentsList()
+    val initialDetent = initialDetent(windowHeightSizeClass)
+
+    return ModalDetents(
+        initialDetent = if (detents.contains(initialDetent)) initialDetent else detents.last(),
+        detents = detents,
+    )
+}
+
+private fun QuickEditorScopeOption.buildDetentsList(): List<SheetDetent> {
+    return when (this.scope) {
+        is QuickEditorScopeOption.Scope.AvatarPickerAndAboutEditor,
+        is QuickEditorScopeOption.Scope.AboutEditor,
+        -> buildList {
+            add(Hidden)
             add(peek)
             add(FullyExpanded)
         }
+
+        is QuickEditorScopeOption.Scope.AvatarPicker -> buildList {
+            add(Hidden)
+            if (avatarPickerContentLayout == AvatarPickerContentLayout.Vertical) {
+                add(peek)
+            }
+            add(FullyExpanded)
+        }
     }
-    return ModalDetents(
-        initialDetent = initialDetent,
-        detents = detents,
-    )
+}
+
+private fun QuickEditorScopeOption.initialDetent(windowHeightSizeClass: WindowHeightSizeClass): SheetDetent {
+    return if (windowHeightSizeClass == WindowHeightSizeClass.COMPACT) {
+        FullyExpanded
+    } else {
+        when (this.scope) {
+            is QuickEditorScopeOption.Scope.AboutEditor -> peek
+            is QuickEditorScopeOption.Scope.AvatarPickerAndAboutEditor,
+            is QuickEditorScopeOption.Scope.AvatarPicker,
+            -> {
+                if (
+                    this.avatarPickerContentLayout == AvatarPickerContentLayout.Horizontal &&
+                    this.initialPage == QuickEditorPage.AvatarPicker
+                ) {
+                    FullyExpanded
+                } else {
+                    peek
+                }
+            }
+        }
+    }
 }
 
 internal data class ModalDetents(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
@@ -25,7 +25,7 @@ internal fun addQuickEditorToView(
                     authenticationMethod = authenticationMethod,
                     updateHandler = updateHandler,
                     onDismiss = onDismiss,
-                    modalDetents = gravatarQuickEditorParams.scopeOption.avatarPickerContentLayout.modalDetents(),
+                    modalDetents = gravatarQuickEditorParams.scopeOption.modalDetents(),
                     onCurrentDetentChanged = {
                         if (it == Hidden) {
                             viewGroup.removeView(this)


### PR DESCRIPTION


### Description

This PR adjusts various aspect of the QE height in the new scopes:
- https://github.com/Automattic/Gravatar-SDK-Android/commit/e4c227cdb26cf76f885509cffdd50c9a6b374fc2 Limits the total height to make sure QE won't be drawn behind the status bar.
- https://github.com/Automattic/Gravatar-SDK-Android/commit/ddd5f6b9d7f7d612503896420f9190ca230627ef Add the `animateContentHeight` modifier to animated About editor height changes (this applies to any content change but in general when switching from loading to loaded or error state).
- https://github.com/Automattic/Gravatar-SDK-Android/commit/dacb12789584e8f3598306803f78ce97eb96bdd4 Updated the possible Detens and the initial detent based on scope (and other factors) for the QE.

| Max height | Content animation | Initial peek detent for About editor |
|---|---|---|
| <img width="366" alt="Screenshot 2025-05-20 at 12 12 34" src="https://github.com/user-attachments/assets/37e0fad4-06cf-4b38-857a-b32b29a1bf41" /> | ![animate_height](https://github.com/user-attachments/assets/af8b8731-70e5-476b-b063-aa703ce34ab5) | <img width="375" alt="Screenshot 2025-05-20 at 12 17 00" src="https://github.com/user-attachments/assets/4b4b19c8-0ad9-4bd1-a5e7-fa7b22fd8a9d" /> |

Note: I've noticed a weird behavior in the AvatarAndAbout scope. With scrolling set to horizontal and the initial page to Avatar picker, the sheet reverts to Peek detent instead of FullyExpanded. I have a feeling this is rather related to the AvatarPicker UI hierarchy so I would like to work on it separately (GRA-103).

### Testing Steps

1. Max height is easy - just launch the About editor with all the fields and expand it fully. Same for the avatar picker in the vertical scrolling mode (with enough images).
2. The content animation is a bit tricky now that we have the peek detent as initial, but you can play around with it to see.
3. Sheet detents - Launch the About editor and confirm the sheet is not fully expanded. Rotate the phone to landscape and repeat - this QE should be fully extended as it doesn't make sense to use peek detent when we have very little screen height to work with. 