### PR TITLE
Handle back press in the QE manually

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/QEPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/components/QEPage.kt
@@ -1,11 +1,16 @@
 package com.gravatar.quickeditor.ui.components
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
 internal fun QEPageDefault(onDoneClicked: () -> Unit, content: @Composable () -> Unit, modifier: Modifier = Modifier) {
+    BackHandler {
+        onDoneClicked()
+    }
+
     QEPage(
         topBar = {
             QETopBar({

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -47,6 +48,12 @@ internal fun GravatarQuickEditorPage(
     onDismiss: (dismissReason: GravatarQuickEditorDismissReason) -> Unit = {},
 ) {
     val navController = rememberNavController()
+
+    LaunchedEffect(confirmDismissal) {
+        if (confirmDismissal && navController.currentDestination?.route != EditorNavDestinations.QUICK_EDITOR.name) {
+            onDoneClicked()
+        }
+    }
 
     NavHost(
         navController,
@@ -159,10 +166,10 @@ private fun NavGraphBuilder.addEditorGraph(
 ) {
     navigation(
         route = QuickEditorPage.EDITOR.name,
-        startDestination = EditorNavDestinations.AVATAR_SELECTION.name,
+        startDestination = EditorNavDestinations.QUICK_EDITOR.name,
     ) {
         composable(
-            route = EditorNavDestinations.AVATAR_SELECTION.name,
+            route = EditorNavDestinations.QUICK_EDITOR.name,
             enterTransition = { fadeIn() },
             popEnterTransition = { fadeIn() + expandVertically() },
             exitTransition = {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -249,7 +249,7 @@ private fun GravatarModalBottomSheet(
             ModalBottomSheet(
                 state = modalBottomSheetState,
                 properties = ModalSheetProperties(
-                    dismissOnBackPress = true,
+                    dismissOnBackPress = false,
                     dismissOnClickOutside = true,
                 ),
             ) {

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/navigation/EditorNavDestinations.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/navigation/EditorNavDestinations.kt
@@ -1,6 +1,6 @@
 package com.gravatar.quickeditor.ui.navigation
 
 internal enum class EditorNavDestinations {
-    AVATAR_SELECTION,
+    QUICK_EDITOR,
     ALT_TEXT,
 }


### PR DESCRIPTION


### Description

This PR fixes a bug that must have been introduced with the `confirmDetentChange` callback. I've reverted the behavior and I'm again manually handling the Back press in the QE rather than using the Sheet's behavior. 

| Before | After |
|---|---|
| ![back_press_bug](https://github.com/user-attachments/assets/a3e8c50f-70dd-4bbb-b9e8-961836249498) | ![back_press_fixe](https://github.com/user-attachments/assets/b2e02b77-3219-477f-b815-74598bd88c83) |

### Testing Steps

1. Open the QE with Avatar Picker
2. Go to Alt page
3. Focus the input field to show the keyboard
4. Use the system back button to hide the keyboard
5. Use the system back button to close the AltPage
6. Confirm the QE was not dismissed
7. Ideally, run some regression tests to make sure the `Unsaved changes` dialog behavior was not affected and that the system back button works on the "Into login" screen as well (before the OAuth).
