### PR TITLE
Show session expired when receiving 401 after saving the profile

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModel.kt
@@ -5,12 +5,15 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.gravatar.quickeditor.QuickEditorContainer
+import com.gravatar.quickeditor.data.models.QuickEditorError
 import com.gravatar.quickeditor.data.repository.ProfileRepository
+import com.gravatar.quickeditor.ui.avatarpicker.SectionError
 import com.gravatar.quickeditor.ui.avatarpicker.asSectionError
 import com.gravatar.quickeditor.ui.editor.AboutInputField
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.restapi.models.Profile
 import com.gravatar.restapi.models.UpdateProfileRequest
+import com.gravatar.services.ErrorType
 import com.gravatar.services.GravatarResult
 import com.gravatar.types.Email
 import kotlinx.coroutines.channels.Channel
@@ -112,12 +115,18 @@ internal class AboutEditorViewModel(
                 }
 
                 is GravatarResult.Failure -> {
+                    var sectionError: SectionError? = null
+                    if ((result.error as? QuickEditorError.Request)?.type is ErrorType.Unauthorized) {
+                        sectionError = SectionError.InvalidToken(showLogin = handleExpiredSession)
+                    } else {
+                        _actions.send(AboutEditorAction.ProfileUpdateFailed)
+                    }
                     _uiState.update { currentState ->
                         currentState.copy(
                             savingProfile = false,
+                            error = sectionError,
                         )
                     }
-                    _actions.send(AboutEditorAction.ProfileUpdateFailed)
                 }
             }
         }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModelTest.kt
@@ -198,6 +198,51 @@ class AboutEditorViewModelTest {
     }
 
     @Test
+    fun `given updated about field when save clicked and update fails with 401 then uiState is updated`() = runTest {
+        coEvery {
+            profileRepository.updateProfile(email, updateProfileRequest)
+        } returns GravatarResult.Failure(QuickEditorError.Request(ErrorType.Unauthorized))
+
+        viewModel = initViewModel()
+        viewModel.onEvent(
+            AboutEditorEvent.OnAboutFieldUpdated(
+                AboutEditorField(
+                    type = AboutInputField.DisplayName,
+                    value = "Updated Name",
+                ),
+            ),
+        )
+
+        advanceUntilIdle()
+
+        viewModel.onEvent(AboutEditorEvent.OnSaveClicked)
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals(
+                AboutEditorUiState(
+                    savingProfile = true,
+                    aboutFields = updatedProfile.aboutFields(visibleAboutFields),
+                ),
+                awaitItem(),
+            )
+            assertEquals(
+                AboutEditorUiState(
+                    savingProfile = false,
+                    aboutFields = updatedProfile.aboutFields(visibleAboutFields),
+                    error = SectionError.InvalidToken(
+                        showLogin = true,
+                    ),
+                ),
+                awaitItem(),
+            )
+        }
+        viewModel.actions.test {
+            expectNoEvents()
+        }
+    }
+
+    @Test
     fun `given no changes when done clicked then editor is closed`() = runTest {
         viewModel = initViewModel()
 


### PR DESCRIPTION

### Description

About editor will now show the `session expired` error when we receive 401 while saving the profile. [This aligns Android with iOS](https://github.com/Automattic/Gravatar-SDK-Android/pull/634#issuecomment-2893228644).

Originally, I wanted to add a global session listener to automatically show OAuth flow, but I'm putting this aside for now to speed up the work. 

| OAuth | Provided Token |
|---|---|
| <img width="352" alt="Screenshot 2025-05-26 at 14 35 56" src="https://github.com/user-attachments/assets/511d934a-c541-4602-8e0c-030cff768fea" /> | <img width="348" alt="Screenshot 2025-05-26 at 14 35 37" src="https://github.com/user-attachments/assets/0379da33-179d-414f-93a5-a32bf2fcff41" /> |

### Testing Steps

1. Launch the About editor with the OAuth flow
2. Make sure to mock the network response to 401
3. Tap save profile
4. Confirm you can see the error message with `Log in` button
5. Launch the QE again but now use the option to provide your own token in the demo app
6. Make sure to mock the network response to 401
3. Tap save profile
4. Confirm you can see the error message with `Close` button
