### PR TITLE
Only enable the Save button when unsaved changes are present

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorUiState.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorUiState.kt
@@ -8,8 +8,11 @@ internal data class AboutEditorUiState(
     val savingProfile: Boolean = false,
     val discardChangesDialogVisible: Boolean = false,
     val error: SectionError? = null,
+    val savedAboutFields: Set<AboutEditorField> = emptySet(),
 ) {
     val formEnabled: Boolean = !savingProfile
 
-    val saveEnabled: Boolean = !isLoading
+    val unsavedChanges: Boolean = aboutFields != savedAboutFields
+
+    val saveEnabled: Boolean = !isLoading && unsavedChanges
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModel.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModel.kt
@@ -36,8 +36,6 @@ internal class AboutEditorViewModel(
     private val _actions = Channel<AboutEditorAction>(Channel.BUFFERED)
     val actions = _actions.receiveAsFlow()
 
-    private var savedProfile: Profile? = null
-
     init {
         fetchProfile()
     }
@@ -79,9 +77,7 @@ internal class AboutEditorViewModel(
 
     private fun checkForUnsavedChanges() {
         viewModelScope.launch {
-            val currentProfile = uiState.value.aboutFields
-            val savedProfile = savedProfile?.aboutFields(visibleAboutFields)
-            if (savedProfile != null && currentProfile != savedProfile) {
+            if (uiState.value.unsavedChanges) {
                 _uiState.update { currentState ->
                     currentState.copy(
                         discardChangesDialogVisible = true,
@@ -102,11 +98,12 @@ internal class AboutEditorViewModel(
             when (val result = profileRepository.updateProfile(email, updateProfileRequest)) {
                 is GravatarResult.Success -> {
                     val profile = result.value
-                    savedProfile = profile
+                    val aboutFields = profile.aboutFields(visibleAboutFields)
                     _uiState.update { currentState ->
                         currentState.copy(
                             savingProfile = false,
-                            aboutFields = profile.aboutFields(visibleAboutFields),
+                            aboutFields = aboutFields,
+                            savedAboutFields = aboutFields,
                         )
                     }
                     _actions.send(
@@ -159,11 +156,12 @@ internal class AboutEditorViewModel(
                 is GravatarResult.Success -> {
                     _uiState.update {
                         val profile = result.value
-                        savedProfile = profile
+                        val aboutFields = profile.aboutFields(visibleAboutFields)
                         it.copy(
                             isLoading = false,
-                            aboutFields = profile.aboutFields(visibleAboutFields),
+                            aboutFields = aboutFields,
                             error = null,
+                            savedAboutFields = aboutFields,
                         )
                     }
                 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModelTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditorViewModelTest.kt
@@ -60,10 +60,12 @@ class AboutEditorViewModelTest {
         viewModel.uiState.test {
             assertEquals(AboutEditorUiState(isLoading = false), awaitItem())
             assertEquals(AboutEditorUiState(isLoading = true), awaitItem())
+            val aboutFields = profile.aboutFields(visibleAboutFields)
             assertEquals(
                 AboutEditorUiState(
                     isLoading = false,
-                    aboutFields = profile.aboutFields(visibleAboutFields),
+                    aboutFields = aboutFields,
+                    savedAboutFields = aboutFields,
                 ),
                 awaitItem(),
             )
@@ -135,17 +137,20 @@ class AboutEditorViewModelTest {
 
         viewModel.uiState.test {
             expectMostRecentItem()
+            val aboutFields = updatedProfile.aboutFields(visibleAboutFields)
             assertEquals(
                 AboutEditorUiState(
                     savingProfile = true,
-                    aboutFields = updatedProfile.aboutFields(visibleAboutFields),
+                    aboutFields = aboutFields,
+                    savedAboutFields = profile.aboutFields(visibleAboutFields),
                 ),
                 awaitItem(),
             )
             assertEquals(
                 AboutEditorUiState(
                     savingProfile = false,
-                    aboutFields = updatedProfile.aboutFields(visibleAboutFields),
+                    aboutFields = aboutFields,
+                    savedAboutFields = aboutFields,
                 ),
                 awaitItem(),
             )
@@ -177,17 +182,20 @@ class AboutEditorViewModelTest {
 
         viewModel.uiState.test {
             expectMostRecentItem()
+            val aboutFields = updatedProfile.aboutFields(visibleAboutFields)
             assertEquals(
                 AboutEditorUiState(
                     savingProfile = true,
-                    aboutFields = updatedProfile.aboutFields(visibleAboutFields),
+                    aboutFields = aboutFields,
+                    savedAboutFields = profile.aboutFields(visibleAboutFields),
                 ),
                 awaitItem(),
             )
             assertEquals(
                 AboutEditorUiState(
                     savingProfile = false,
-                    aboutFields = updatedProfile.aboutFields(visibleAboutFields),
+                    aboutFields = aboutFields,
+                    savedAboutFields = profile.aboutFields(visibleAboutFields),
                 ),
                 awaitItem(),
             )
@@ -218,18 +226,22 @@ class AboutEditorViewModelTest {
         viewModel.onEvent(AboutEditorEvent.OnSaveClicked)
 
         viewModel.uiState.test {
+            val aboutFields = updatedProfile.aboutFields(visibleAboutFields)
             expectMostRecentItem()
+            val savedAboutFields = profile.aboutFields(visibleAboutFields)
             assertEquals(
                 AboutEditorUiState(
                     savingProfile = true,
-                    aboutFields = updatedProfile.aboutFields(visibleAboutFields),
+                    aboutFields = aboutFields,
+                    savedAboutFields = savedAboutFields,
                 ),
                 awaitItem(),
             )
             assertEquals(
                 AboutEditorUiState(
                     savingProfile = false,
-                    aboutFields = updatedProfile.aboutFields(visibleAboutFields),
+                    aboutFields = aboutFields,
+                    savedAboutFields = savedAboutFields,
                     error = SectionError.InvalidToken(
                         showLogin = true,
                     ),
@@ -365,6 +377,37 @@ class AboutEditorViewModelTest {
                 ),
                 awaitItem().aboutFields,
             )
+        }
+    }
+
+    @Test
+    fun `given no changes when state update then save button is disabled`() = runTest {
+        viewModel = initViewModel()
+
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            assertEquals(false, awaitItem().saveEnabled)
+        }
+    }
+
+    @Test
+    fun `given changes when state update then save button is enabled`() = runTest {
+        viewModel = initViewModel()
+
+        viewModel.onEvent(
+            AboutEditorEvent.OnAboutFieldUpdated(
+                AboutEditorField(
+                    type = AboutInputField.DisplayName,
+                    value = "New Display Name",
+                ),
+            ),
+        )
+
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            assertEquals(true, awaitItem().saveEnabled)
         }
     }
 


### PR DESCRIPTION


### Description

The `Save` button is enabled even when no changes to the profile when made. This PR fixes that and the button will only be enabled when there's something to save.

<img width="344" alt="Screenshot 2025-05-26 at 15 24 28" src="https://github.com/user-attachments/assets/fe8e5228-4221-4fca-8a5e-c3e32aafcc09" />


### Testing Steps

1. Launch the About Editor
2. Confirm the button is disabled
3. Make some changes
4. Confirm the button is enabled
5. Revert the changes - the button should get disabled again
6. Make some changes again
7. Save
8. Confirm the button is disabled
9. Feel free to test error scenarios when saving the profile as well 
