### PR TITLE
Move animateContentSize modifier to a different component

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
@@ -108,8 +108,7 @@ internal fun AboutEditor(
     Surface {
         Box(
             modifier = Modifier
-                .wrapContentSize()
-                .animateContentSize(),
+                .wrapContentSize(),
         ) {
             AboutEditor(
                 uiState = uiState,
@@ -151,7 +150,8 @@ internal fun AboutEditor(uiState: AboutEditorUiState, onEvent: (AboutEditorEvent
                         shape = RoundedCornerShape(8.dp),
                     )
                     .weight(1f, fill = false)
-                    .verticalScroll(rememberScrollState()),
+                    .verticalScroll(rememberScrollState())
+                    .animateContentSize(),
             ) {
                 when {
                     uiState.isLoading -> {


### PR DESCRIPTION

### Description

There was a weird behavior when hiding the keyboard in the About editor. The whole sheet would look like it's going to close for a second. 

I'm not exactly sure why, but I narrowed it down to the `animateContentSize` modifier, and moving it to a component that enables scrolling in the About editor fixes the issue. 

| Before | After |
|---|---|
| ![back_bug](https://github.com/user-attachments/assets/585df781-0e35-4143-a392-53fac14d34b0) | ![back_fixed](https://github.com/user-attachments/assets/62c8cddf-05a3-4644-ae3d-306d788dbf26) |

### Testing Steps

1. Launch the About editor
2. Fully expand it
3. Tap on the input field to show the keyboard
4. Use back button or gesture to close the keyboard / Saving changes also works
5. Confirm there's no weird bounce in the sheet
