### PR TITLE
Upadte the default height for the loading section

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/abouteditor/AboutEditor.kt
@@ -42,6 +42,7 @@ import com.gravatar.quickeditor.ui.avatarpicker.titleRes
 import com.gravatar.quickeditor.ui.components.CtaSection
 import com.gravatar.quickeditor.ui.components.QEButton
 import com.gravatar.quickeditor.ui.editor.AboutInputField
+import com.gravatar.quickeditor.ui.editor.bottomsheet.DEFAULT_PAGE_HEIGHT
 import com.gravatar.quickeditor.ui.editor.bottomsheet.positionAwareImePadding
 import com.gravatar.quickeditor.ui.extensions.QESnackbarHost
 import com.gravatar.quickeditor.ui.extensions.SnackbarType
@@ -175,7 +176,7 @@ internal fun AboutEditor(uiState: AboutEditorUiState, onEvent: (AboutEditorEvent
                     uiState.isLoading -> {
                         Box(
                             modifier = Modifier
-                                .height(300.dp)
+                                .height(DEFAULT_PAGE_HEIGHT)
                                 .fillMaxWidth(),
                         ) {
                             CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -406,4 +406,4 @@ internal data class ModalDetents(
     val detents: List<SheetDetent>,
 )
 
-internal val DEFAULT_PAGE_HEIGHT = 250.dp
+internal val DEFAULT_PAGE_HEIGHT = 300.dp


### PR DESCRIPTION
### Description

With the AvatarAndAbout scope selected and horizontal scrolling, the sheet defaults to Peek detent instead of FullyExpanded. 

Tbh, I don't know the exact reason, but a quick fix here is to increase the height of the loading component. This should do for now, and I will try to investigate later.

| Before | After |
|---|---|
| ![peek_before](https://github.com/user-attachments/assets/05ce371d-bdc6-4910-9067-c0b612c006bb) | ![no_peek_after](https://github.com/user-attachments/assets/18c3260b-84e3-4971-a18e-58054b664710) |

### Testing Steps

1. Select AvatarAndAbout
2. Open the QE
3. Confirm it's fully expanded
