### PR TITLE
Expand the sheet fully on focus

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
@@ -250,6 +251,17 @@ private fun GravatarModalBottomSheet(
     modalBottomSheetState: ModalBottomSheetState,
     content: @Composable () -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
+    var hasFocus by remember { mutableStateOf(false) }
+
+    LaunchedEffect(hasFocus) {
+        scope.launch {
+            if (hasFocus) {
+                modalBottomSheetState.animateTo(FullyExpanded)
+            }
+        }
+    }
+
     val configuration = Configuration(LocalConfiguration.current).apply {
         uiMode = when (colorScheme) {
             GravatarUiMode.LIGHT -> Configuration.UI_MODE_NIGHT_NO
@@ -310,6 +322,9 @@ private fun GravatarModalBottomSheet(
                             }
                             Surface(
                                 modifier = Modifier
+                                    .onFocusChanged { state ->
+                                        hasFocus = state.hasFocus
+                                    }
                                     .fillMaxWidth(),
                                 tonalElevation = 1.dp,
                             ) {


### PR DESCRIPTION

### Description

There's an issue when you tap on an input field and the keyboard shows up. In the Peek detent, the sheet won't be moved up above the keyboard, so the UI is essentially covered. In order to fix this, the sheet will now fully expand when it has the focus. 

| Before | After |
|---|---|
| ![keyboard_bug](https://github.com/user-attachments/assets/b3acb5d3-23a2-4695-adf2-17dcc6f95201) | ![keyboard_fix](https://github.com/user-attachments/assets/8ebe5944-7df2-4969-abdc-8a4cae3e2861) |

### Testing Steps

1. Open the About editor
2. Without expanding, tap on any of the visible input fields
3. Confirm the keyboard shows up and the sheet is expanded
