### PR TITLE
Move sheet to hidden detent internally when dismissing

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -186,6 +186,14 @@ internal fun GravatarQuickEditorBottomSheet(
         }
     }
 
+    val internalOnDismiss: (GravatarQuickEditorDismissReason) -> Unit = { dismissReason ->
+        dismissState = DismissConfirmationState.Confirm
+        coroutineScope.launch {
+            modalBottomSheetState.animateTo(Hidden)
+            onDismiss(dismissReason)
+        }
+    }
+
     LaunchedEffect(modalBottomSheetState.currentDetent) {
         onCurrentDetentChanged(modalBottomSheetState.currentDetent)
     }
@@ -211,7 +219,7 @@ internal fun GravatarQuickEditorBottomSheet(
                     GravatarQuickEditorPage(
                         gravatarQuickEditorParams = gravatarQuickEditorParams,
                         authToken = authenticationMethod.token,
-                        onDismiss = onDismiss,
+                        onDismiss = internalOnDismiss,
                         updateHandler = updateHandler,
                         confirmDismissal = dismissState == DismissConfirmationState.Delegated,
                         onDismissIgnored = onDismissIgnored,
@@ -223,7 +231,7 @@ internal fun GravatarQuickEditorBottomSheet(
                     GravatarQuickEditorPage(
                         gravatarQuickEditorParams = gravatarQuickEditorParams,
                         oAuthParams = authenticationMethod.oAuthParams,
-                        onDismiss = onDismiss,
+                        onDismiss = internalOnDismiss,
                         updateHandler = updateHandler,
                         confirmDismissal = dismissState == DismissConfirmationState.Delegated,
                         onDismissIgnored = onDismissIgnored,
@@ -242,12 +250,6 @@ private fun GravatarModalBottomSheet(
     modalBottomSheetState: ModalBottomSheetState,
     content: @Composable () -> Unit,
 ) {
-    LaunchedEffect(modalBottomSheetState.currentDetent) {
-        if (modalBottomSheetState.currentDetent == Hidden) {
-            onDismiss(GravatarQuickEditorDismissReason.Finished)
-        }
-    }
-
     val configuration = Configuration(LocalConfiguration.current).apply {
         uiMode = when (colorScheme) {
             GravatarUiMode.LIGHT -> Configuration.UI_MODE_NIGHT_NO
@@ -261,6 +263,7 @@ private fun GravatarModalBottomSheet(
         GravatarTheme {
             ModalBottomSheet(
                 state = modalBottomSheetState,
+                onDismiss = { onDismiss(GravatarQuickEditorDismissReason.Finished) },
                 properties = ModalSheetProperties(
                     dismissOnBackPress = false,
                     dismissOnClickOutside = true,


### PR DESCRIPTION

### Description

Normally, the sheet animates when being closed. There are a few scenarios related to the authorization where we wouldn't do that, but the sheet would be simply hidden by the consuming app (demo app in our case) on the `dismiss` callback. 

This is now fixed, and we are animating the sheet to a hidden state internally when the `onDismiss` is invoked.

| Before | After |
|---|---|
| ![close_before](https://github.com/user-attachments/assets/eb109d13-215b-48b3-8ee9-3ad7a49fb0f6) | ![close_after](https://github.com/user-attachments/assets/053fb8ee-bfe1-4f45-841c-37e9e3f38f81) |

### Testing Steps

1. Open the Editor with the provided random auth token
2. Tap Close
3. Confirm the sliding animation is present