### PR TITLE
Rename leftover scopConfig with scopeOption

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -280,7 +280,7 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                 gravatarQuickEditorParams = GravatarQuickEditorParams {
                     email = Email(userEmail)
                     uiMode = pickerUiMode
-                    scopeConfig = when (editorScope) {
+                    scopeOption = when (editorScope) {
                         QuickEditorScope.Avatar -> QuickEditorScopeOption.avatarPicker(
                             config = AvatarPickerConfiguration(
                                 contentLayout = pickerContentLayout,

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -631,14 +631,14 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$
 	public final fun build ()Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
-	public final fun getScopeConfig ()Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
+	public final fun getScopeOption ()Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 	public final fun getUiMode ()Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
 	public final fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setAvatarPickerContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)V
 	public final fun setEmail (Lcom/gravatar/types/Email;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setEmail (Lcom/gravatar/types/Email;)V
-	public final fun setScopeConfig (Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
-	public final synthetic fun setScopeConfig (Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;)V
+	public final fun setScopeOption (Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
+	public final synthetic fun setScopeOption (Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;)V
 	public final fun setUiMode (Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;)Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder;
 	public final synthetic fun setUiMode (Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;)V
 }

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams.kt
@@ -50,7 +50,7 @@ public class GravatarQuickEditorParams private constructor(
         /**
          * The content layout direction used in the Avatar Picker
          */
-        @Deprecated(message = "AvatarPickerContentLayout was moved to ScopeConfig")
+        @Deprecated(message = "AvatarPickerContentLayout was moved to QuickEditorScopeOption")
         @set:JvmSynthetic // Hide 'void' setter from Java
         public var avatarPickerContentLayout: AvatarPickerContentLayout = AvatarPickerContentLayout.Horizontal
 
@@ -64,14 +64,14 @@ public class GravatarQuickEditorParams private constructor(
          * The scope option for the Quick Editor
          */
         @set:JvmSynthetic // Hide 'void' setter from Java
-        public var scopeConfig: QuickEditorScopeOption = QuickEditorScopeOption.default
+        public var scopeOption: QuickEditorScopeOption = QuickEditorScopeOption.default
 
         /**
          * Sets the content layout direction used in the Avatar Picker
          */
         @Deprecated(
-            message = "AvatarPickerContentLayout was moved to ScopeConfig",
-            replaceWith = ReplaceWith("setScopeConfig(scopeConfig)"),
+            message = "AvatarPickerContentLayout was moved to QuickEditorScopeOption",
+            replaceWith = ReplaceWith("setScopeOption(scopeOption)"),
         )
         public fun setAvatarPickerContentLayout(avatarPickerContentLayout: AvatarPickerContentLayout): Builder =
             apply { this.avatarPickerContentLayout = avatarPickerContentLayout }
@@ -89,8 +89,8 @@ public class GravatarQuickEditorParams private constructor(
         /**
          * Sets the scope of the Quick Editor
          */
-        public fun setScopeConfig(scopeConfig: QuickEditorScopeOption): Builder =
-            apply { this.scopeConfig = scopeConfig }
+        public fun setScopeOption(scopeOption: QuickEditorScopeOption): Builder =
+            apply { this.scopeOption = scopeOption }
 
         /**
          * Builds the GravatarQuickEditorParams object
@@ -99,7 +99,7 @@ public class GravatarQuickEditorParams private constructor(
             email!!,
             avatarPickerContentLayout,
             uiMode,
-            scopeConfig.withContentLayout(avatarPickerContentLayout),
+            scopeOption.withContentLayout(avatarPickerContentLayout),
         )
 
         private fun QuickEditorScopeOption.withContentLayout(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption.kt
@@ -24,7 +24,7 @@ public class QuickEditorScopeOption private constructor(
         data class AvatarPickerAndAboutEditor(val config: AvatarPickerAndAboutEditorConfiguration) : Scope()
     }
 
-    override fun toString(): String = "ScopeConfig(scope=$scope)"
+    override fun toString(): String = "QuickEditorScopeOption(scope=$scope)"
 
     override fun hashCode(): Int = Objects.hash(scope)
 


### PR DESCRIPTION


### Description

I missed some names when changing the public API structure and left `scopeConfig` instead of `scopeOption`. This PR aligns all the names. 

### Testing Steps

Green CI should be good. 