### PR TITLE
Don't apply -SNAPSHOT to dokka version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,18 +46,18 @@ apiValidation {
 
 val isTagBuild: Boolean = System.getenv("BUILDKITE_TAG")?.isNotEmpty() == true
 
-val sdkVersion = providers.exec {
+val rawSdkVersion = providers.exec {
     commandLine("git", "describe", "--tags")
-}.standardOutput.asText.get().trim() + if (isTagBuild) "" else "-SNAPSHOT" // Add -SNAPSHOT suffix once 0.31.0 version is released
+}.standardOutput.asText.get().trim()
 
-extra["sdkVersion"] = sdkVersion
+extra["sdkVersion"] = rawSdkVersion + if (isTagBuild) "" else "-SNAPSHOT" // Add -SNAPSHOT suffix once 0.31.0 version is released
 
 tasks.dokkaHtmlMultiModule {
     notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/2231")
     val mainDir = projectDir.resolve("docs/dokka/") // docs/dokka/
     val historyDir = mainDir.resolve("history/") // docs/dokka/history/ - all versions
     val currentDir = mainDir.resolve("current/") // docs/dokka/current/ - what we'll serve in github pages
-    val newVersionDir = historyDir.resolve(sdkVersion) // docs/dokka/history/x.x.x/ - new version
+    val newVersionDir = historyDir.resolve(rawSdkVersion) // docs/dokka/history/x.x.x/ - new version
 
     moduleName.set("Gravatar Android SDK")
     outputDirectory.set(newVersionDir)
@@ -68,7 +68,7 @@ tasks.dokkaHtmlMultiModule {
     }
 
     pluginConfiguration<VersioningPlugin, VersioningConfiguration> {
-        version = sdkVersion
+        version = rawSdkVersion
         olderVersionsDir = historyDir
     }
 


### PR DESCRIPTION
### Description

I've noticed that both 2.4.0 and 2.4.1 versions had a `-SNAPSHOT` suffix in the API docs. I have manually [fixed those previous versions](https://github.com/Automattic/Gravatar-SDK-Android/commit/657b554b9f7b5d0bbe50ee4d0e35f1a510ef1f78), and this change should fix all the future ones. 

The Dokka plugin now uses the raw version from the `git describe --tags` command without the suffix.

### Testing Steps
No testing steps, really, we will test it when publishing rc2.