### PR TITLE
Add DSL like API for the QuickEditorScopeOption

### DIFF
--- a/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
+++ b/demo-app/src/main/java/com/gravatar/demoapp/ui/AvatarUpdateTab.kt
@@ -53,12 +53,10 @@ import com.gravatar.demoapp.ui.components.GravatarEmailInput
 import com.gravatar.demoapp.ui.components.GravatarPasswordInput
 import com.gravatar.demoapp.ui.components.translatedValue
 import com.gravatar.quickeditor.GravatarQuickEditor
-import com.gravatar.quickeditor.ui.editor.AboutEditorConfiguration
 import com.gravatar.quickeditor.ui.editor.AboutEditorResult
 import com.gravatar.quickeditor.ui.editor.AboutInputField
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
 import com.gravatar.quickeditor.ui.editor.AvatarPickerAndAboutEditorConfiguration
-import com.gravatar.quickeditor.ui.editor.AvatarPickerConfiguration
 import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.quickeditor.ui.editor.AvatarPickerResult
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
@@ -281,25 +279,19 @@ fun AvatarUpdateTab(modifier: Modifier = Modifier) {
                     email = Email(userEmail)
                     uiMode = pickerUiMode
                     scopeOption = when (editorScope) {
-                        QuickEditorScope.Avatar -> QuickEditorScopeOption.avatarPicker(
-                            config = AvatarPickerConfiguration(
-                                contentLayout = pickerContentLayout,
-                            ),
-                        )
+                        QuickEditorScope.Avatar -> QuickEditorScopeOption.avatarPicker {
+                            contentLayout = pickerContentLayout
+                        }
 
-                        QuickEditorScope.About -> QuickEditorScopeOption.aboutEditor(
-                            config = AboutEditorConfiguration(
-                                fields = aboutFields,
-                            ),
-                        )
+                        QuickEditorScope.About -> QuickEditorScopeOption.aboutEditor {
+                            fields = aboutFields
+                        }
 
-                        QuickEditorScope.AvatarAndAbout -> QuickEditorScopeOption.avatarAndAbout(
-                            config = AvatarPickerAndAboutEditorConfiguration(
-                                contentLayout = pickerContentLayout,
-                                initialPage = editorInitialPage,
-                                fields = aboutFields,
-                            ),
-                        )
+                        QuickEditorScope.AvatarAndAbout -> QuickEditorScopeOption.avatarAndAbout {
+                            contentLayout = pickerContentLayout
+                            initialPage = editorInitialPage
+                            fields = aboutFields
+                        }
                     }
                 },
                 authenticationMethod = authenticationMethod,

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -331,6 +331,15 @@ public final class com/gravatar/quickeditor/ui/editor/AboutEditorConfiguration :
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class com/gravatar/quickeditor/ui/editor/AboutEditorConfiguration$Builder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun build ()Lcom/gravatar/quickeditor/ui/editor/AboutEditorConfiguration;
+	public final fun getFields ()Ljava/util/Set;
+	public final fun setFields (Ljava/util/Set;)Lcom/gravatar/quickeditor/ui/editor/AboutEditorConfiguration$Builder;
+	public final synthetic fun setFields (Ljava/util/Set;)V
+}
+
 public final class com/gravatar/quickeditor/ui/editor/AboutEditorConfiguration$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/editor/AboutEditorConfiguration;
@@ -463,6 +472,21 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditor
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class com/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Builder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun build ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration;
+	public final fun getContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
+	public final fun getFields ()Ljava/util/Set;
+	public final fun getInitialPage-Fs-4V8w ()Ljava/lang/String;
+	public final fun setContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Builder;
+	public final synthetic fun setContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)V
+	public final fun setFields (Ljava/util/Set;)Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Builder;
+	public final synthetic fun setFields (Ljava/util/Set;)V
+	public final fun setInitialPage-FkoExek (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Builder;
+	public final synthetic fun setInitialPage-FkoExek (Ljava/lang/String;)V
+}
+
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration;
@@ -515,6 +539,15 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration 
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration$Builder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun build ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration;
+	public final fun getContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
+	public final fun setContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)Lcom/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration$Builder;
+	public final synthetic fun setContentLayout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration$Creator : android/os/Parcelable$Creator {
@@ -681,10 +714,13 @@ public final class com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption : a
 
 public final class com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption$Companion {
 	public final fun aboutEditor (Lcom/gravatar/quickeditor/ui/editor/AboutEditorConfiguration;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
+	public final synthetic fun aboutEditor (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 	public static synthetic fun aboutEditor$default (Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption$Companion;Lcom/gravatar/quickeditor/ui/editor/AboutEditorConfiguration;ILjava/lang/Object;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 	public final fun avatarAndAbout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
+	public final synthetic fun avatarAndAbout (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 	public static synthetic fun avatarAndAbout$default (Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption$Companion;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration;ILjava/lang/Object;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 	public final fun avatarPicker (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
+	public final synthetic fun avatarPicker (Lkotlin/jvm/functions/Function1;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 	public static synthetic fun avatarPicker$default (Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption$Companion;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration;ILjava/lang/Object;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 }
 

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeConfiguration.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeConfiguration.kt
@@ -20,6 +20,32 @@ public class AvatarPickerConfiguration(
     override fun equals(other: Any?): Boolean = other is AvatarPickerConfiguration &&
         contentLayout == other.contentLayout
 
+    /**
+     * Builder class for AvatarPickerConfiguration.
+     */
+    public class Builder {
+        /**
+         * The layout direction of the Avatar picker in the Quick Editor.
+         */
+        @set:JvmSynthetic // Hide 'void' setter from Java
+        public var contentLayout: AvatarPickerContentLayout = default.contentLayout
+
+        /**
+         * Sets the layout direction of the Avatar picker in the Quick Editor.
+         *
+         * @param contentLayout The layout direction
+         * @return This Builder instance
+         */
+        public fun setContentLayout(contentLayout: AvatarPickerContentLayout): Builder = apply {
+            this.contentLayout = contentLayout
+        }
+
+        /**
+         * Builds the AvatarPickerConfiguration.
+         */
+        public fun build(): AvatarPickerConfiguration = AvatarPickerConfiguration(contentLayout)
+    }
+
     internal companion object {
         val default = AvatarPickerConfiguration(
             contentLayout = AvatarPickerContentLayout.Horizontal,
@@ -42,6 +68,32 @@ public class AboutEditorConfiguration(
 
     override fun equals(other: Any?): Boolean = other is AboutEditorConfiguration &&
         fields == other.fields
+
+    /**
+     * Builder class for AboutEditorConfiguration.
+     */
+    public class Builder {
+        /**
+         * The input fields to be shown in the about editor.
+         */
+        @set:JvmSynthetic // Hide 'void' setter from Java
+        public var fields: Set<AboutInputField> = default.fields
+
+        /**
+         * Sets the input fields to be shown in the about editor.
+         *
+         * @param fields The input fields
+         * @return This Builder instance
+         */
+        public fun setFields(fields: Set<AboutInputField>): Builder = apply {
+            this.fields = fields
+        }
+
+        /**
+         * Builds the AboutEditorConfiguration.
+         */
+        public fun build(): AboutEditorConfiguration = AboutEditorConfiguration(fields)
+    }
 
     internal companion object {
         val default = AboutEditorConfiguration(
@@ -75,6 +127,68 @@ public class AvatarPickerAndAboutEditorConfiguration(
         contentLayout == other.contentLayout &&
         fields == other.fields &&
         initialPage == other.initialPage
+
+    /**
+     * Builder class for AvatarPickerAndAboutEditorConfiguration.
+     */
+    public class Builder {
+        /**
+         * The layout direction of the Avatar picker in the Quick Editor.
+         */
+        @set:JvmSynthetic // Hide 'void' setter from Java
+        public var contentLayout: AvatarPickerContentLayout = default.contentLayout
+
+        /**
+         * The input fields to be shown in the about editor.
+         */
+        @set:JvmSynthetic // Hide 'void' setter from Java
+        public var fields: Set<AboutInputField> = default.fields
+
+        /**
+         * The initial page to be shown in the Quick Editor.
+         */
+        @set:JvmSynthetic // Hide 'void' setter from Java
+        public var initialPage: Page = default.initialPage
+
+        /**
+         * Sets the layout direction of the Avatar picker in the Quick Editor.
+         *
+         * @param contentLayout The layout direction
+         * @return This Builder instance
+         */
+        public fun setContentLayout(contentLayout: AvatarPickerContentLayout): Builder = apply {
+            this.contentLayout = contentLayout
+        }
+
+        /**
+         * Sets the input fields to be shown in the about editor.
+         *
+         * @param fields The input fields
+         * @return This Builder instance
+         */
+        public fun setFields(fields: Set<AboutInputField>): Builder = apply {
+            this.fields = fields
+        }
+
+        /**
+         * Sets the initial page to be shown in the Quick Editor.
+         *
+         * @param initialPage The initial page
+         * @return This Builder instance
+         */
+        public fun setInitialPage(initialPage: Page): Builder = apply {
+            this.initialPage = initialPage
+        }
+
+        /**
+         * Builds the AvatarPickerAndAboutEditorConfiguration.
+         */
+        public fun build(): AvatarPickerAndAboutEditorConfiguration = AvatarPickerAndAboutEditorConfiguration(
+            contentLayout,
+            fields,
+            initialPage,
+        )
+    }
 
     /**
      * The page of the AvatarPickerAndAboutEditor scope.

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption.kt
@@ -103,5 +103,45 @@ public class QuickEditorScopeOption private constructor(
                 scope = Scope.AvatarPickerAndAboutEditor(config),
             )
         }
+
+        /**
+         * Creates a `QuickEditorScopeOption` configured for the avatar picker scope using a DSL-style builder.
+         *
+         * @param initializer Function literal with AvatarPickerConfiguration.Builder as the receiver
+         * @return A configured instance of `QuickEditorScopeOption` for the avatar picker scope
+         */
+        @JvmSynthetic // Hide from Java callers who should use the static method.
+        public fun avatarPicker(
+            initializer: AvatarPickerConfiguration.Builder.() -> Unit,
+        ): QuickEditorScopeOption {
+            return avatarPicker(AvatarPickerConfiguration.Builder().apply(initializer).build())
+        }
+
+        /**
+         * Creates a `QuickEditorScopeOption` configured for the about editor scope using a DSL-style builder.
+         *
+         * @param initializer Function literal with AboutEditorConfiguration.Builder as the receiver
+         * @return A configured instance of `QuickEditorScopeOption` for the about editor scope
+         */
+        @JvmSynthetic // Hide from Java callers who should use the static method.
+        public fun aboutEditor(
+            initializer: AboutEditorConfiguration.Builder.() -> Unit,
+        ): QuickEditorScopeOption {
+            return aboutEditor(AboutEditorConfiguration.Builder().apply(initializer).build())
+        }
+
+        /**
+         * Creates a `QuickEditorScopeOption` configured for the avatar and about editor scope
+         * using a DSL-style builder.
+         *
+         * @param initializer Function literal with AvatarPickerAndAboutEditorConfiguration.Builder as the receiver
+         * @return A configured instance of `QuickEditorScopeOption` for the avatar and about editor scope
+         */
+        @JvmSynthetic // Hide from Java callers who should use the static method.
+        public fun avatarAndAbout(
+            initializer: AvatarPickerAndAboutEditorConfiguration.Builder.() -> Unit,
+        ): QuickEditorScopeOption {
+            return avatarAndAbout(AvatarPickerAndAboutEditorConfiguration.Builder().apply(initializer).build())
+        }
     }
 }

--- a/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeOptionTest.kt
+++ b/gravatar-quickeditor/src/test/java/com/gravatar/quickeditor/ui/editor/QuickEditorScopeOptionTest.kt
@@ -1,0 +1,90 @@
+package com.gravatar.quickeditor.ui.editor
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QuickEditorScopeOptionTest {
+    @Test
+    fun `avatarPicker DSL creates same result as static method`() {
+        // Using static method
+        val staticResult = QuickEditorScopeOption.avatarPicker(
+            AvatarPickerConfiguration(AvatarPickerContentLayout.Vertical),
+        )
+
+        // Using DSL
+        val dslResult = QuickEditorScopeOption.avatarPicker {
+            contentLayout = AvatarPickerContentLayout.Vertical
+        }
+
+        assertEquals(staticResult, dslResult)
+    }
+
+    @Test
+    fun `aboutEditor DSL creates same result as static method`() {
+        // Using static method
+        val staticResult = QuickEditorScopeOption.aboutEditor(
+            AboutEditorConfiguration(setOf(AboutInputField.DisplayName, AboutInputField.FirstName)),
+        )
+
+        // Using DSL
+        val dslResult = QuickEditorScopeOption.aboutEditor {
+            fields = setOf(AboutInputField.DisplayName, AboutInputField.FirstName)
+        }
+
+        assertEquals(staticResult, dslResult)
+    }
+
+    @Test
+    fun `avatarAndAbout DSL creates same result as static method`() {
+        // Using static method
+        val staticResult = QuickEditorScopeOption.avatarAndAbout(
+            AvatarPickerAndAboutEditorConfiguration(
+                contentLayout = AvatarPickerContentLayout.Vertical,
+                fields = setOf(AboutInputField.DisplayName, AboutInputField.FirstName),
+                initialPage = AvatarPickerAndAboutEditorConfiguration.Page.AboutEditor,
+            ),
+        )
+
+        // Using DSL
+        val dslResult = QuickEditorScopeOption.avatarAndAbout {
+            contentLayout = AvatarPickerContentLayout.Vertical
+            fields = setOf(AboutInputField.DisplayName, AboutInputField.FirstName)
+            initialPage = AvatarPickerAndAboutEditorConfiguration.Page.AboutEditor
+        }
+
+        assertEquals(staticResult, dslResult)
+    }
+
+    @Test
+    fun `avatarPicker DSL with default values creates same result as static method with default values`() {
+        // Using static method with default values
+        val staticResult = QuickEditorScopeOption.avatarPicker()
+
+        // Using DSL with default values
+        val dslResult = QuickEditorScopeOption.avatarPicker {}
+
+        assertEquals(staticResult, dslResult)
+    }
+
+    @Test
+    fun `aboutEditor DSL with default values creates same result as static method with default values`() {
+        // Using static method with default values
+        val staticResult = QuickEditorScopeOption.aboutEditor()
+
+        // Using DSL with default values
+        val dslResult = QuickEditorScopeOption.aboutEditor {}
+
+        assertEquals(staticResult, dslResult)
+    }
+
+    @Test
+    fun `avatarAndAbout DSL with default values creates same result as static method with default values`() {
+        // Using static method with default values
+        val staticResult = QuickEditorScopeOption.avatarAndAbout()
+
+        // Using DSL with default values
+        val dslResult = QuickEditorScopeOption.avatarAndAbout {}
+
+        assertEquals(staticResult, dslResult)
+    }
+}


### PR DESCRIPTION


### Description

This is mostly an API sugar for Kotlin, but also to stay consistent with other classes. With this PR you can now do this:
```kotlin
                    scopeOption = QuickEditorScopeOption.avatarAndAbout {
                            contentLayout = pickerContentLayout
                            initialPage = editorInitialPage
                            fields = aboutFields
                    }
```

instead of 

```kotlin
                     scopeOption = QuickEditorScopeOption.avatarAndAbout(
                            config = AvatarPickerAndAboutEditorConfiguration(
                                contentLayout = pickerContentLayout,
                                initialPage = editorInitialPage,
                                fields = aboutFields,
                            ),
                      )
```


### Testing Steps

Tests were added, so code review should be enough.
