### PR TITLE
Bump Kotlin to 2.0.21

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,5 +1,4 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     `kotlin-dsl`
     alias(libs.plugins.ktlint)
@@ -12,15 +11,16 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 
 dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.compose.compiler.gradlePlugin)
     compileOnly(libs.vanniktech.maven.publishPlugin)
     compileOnly(libs.detekt.gradlePlugin)
     compileOnly(libs.openapi.generator.gradlePlugin)

--- a/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
@@ -1,25 +1,22 @@
 import com.android.build.gradle.LibraryExtension
-import com.gravatar.libs
 import io.github.takahirom.roborazzi.RoborazziPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradleSubplugin
 
 class GravatarComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply<RoborazziPlugin>()
+            apply<ComposeCompilerGradleSubplugin>()
 
             extensions.configure<LibraryExtension> {
                 buildFeatures {
                     compose = true
-                }
-                composeOptions {
-                    kotlinCompilerExtensionVersion =
-                        libs.findVersion("kotlinCompilerExtension").get().toString()
                 }
                 testOptions {
                     unitTests {
@@ -38,23 +35,13 @@ class GravatarComposeConventionPlugin : Plugin<Project> {
                         }
                     }
                 }
-                tasks.withType<KotlinCompile>().configureEach {
-                    kotlinOptions {
-                        val composeReportsDir = "reports/compose"
-                        val prefix = "plugin:androidx.compose.compiler.plugins.kotlin"
+            }
 
-                        freeCompilerArgs += listOf(
-                            "-P",
-                            "$prefix:stabilityConfigurationPath=${project.rootDir}/compose_compiler_config.conf",
-                            "-P",
-                            "$prefix:metricsDestination=${project.layout.buildDirectory.get().dir(composeReportsDir)
-                                .asFile.absolutePath}",
-                            "-P",
-                            "$prefix:reportsDestination=${project.layout.buildDirectory.get().dir(composeReportsDir)
-                                .asFile.absolutePath}",
-                        )
-                    }
-                }
+            extensions.configure<ComposeCompilerGradlePluginExtension> {
+                val composeReportsDir = "reports/compose"
+                reportsDestination = project.layout.buildDirectory.get().dir(composeReportsDir).asFile
+                metricsDestination = project.layout.buildDirectory.get().dir(composeReportsDir).asFile
+                stabilityConfigurationFile = project.file("${project.rootDir}/compose_compiler_config.conf")
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GravatarComposeConventionPlugin.kt
@@ -3,7 +3,6 @@ import io.github.takahirom.roborazzi.RoborazziPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradleSubplugin
@@ -39,9 +38,9 @@ class GravatarComposeConventionPlugin : Plugin<Project> {
 
             extensions.configure<ComposeCompilerGradlePluginExtension> {
                 val composeReportsDir = "reports/compose"
-                reportsDestination = project.layout.buildDirectory.get().dir(composeReportsDir).asFile
-                metricsDestination = project.layout.buildDirectory.get().dir(composeReportsDir).asFile
-                stabilityConfigurationFile = project.file("${project.rootDir}/compose_compiler_config.conf")
+                reportsDestination.set(project.layout.buildDirectory.get().dir(composeReportsDir).asFile)
+                metricsDestination.set(project.layout.buildDirectory.get().dir(composeReportsDir).asFile)
+                stabilityConfigurationFile.set(project.file("${project.rootDir}/compose_compiler_config.conf"))
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
@@ -5,7 +5,6 @@ import MIN_SDK
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
@@ -34,7 +33,7 @@ internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, 
 internal fun Project.configureKotlin() {
     extensions.configure<KotlinAndroidProjectExtension> {
         compilerOptions {
-            jvmTarget = JvmTarget.JVM_1_8
+            jvmTarget.set(JvmTarget.JVM_1_8)
         }
     }
     extensions.configure<KotlinProjectExtension> {

--- a/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/gravatar/KotlinAndroid.kt
@@ -5,10 +5,11 @@ import MIN_SDK
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, *, *, *, *, *>) {
     commonExtension.apply {
@@ -31,9 +32,9 @@ internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, 
  * Configure base Kotlin options for JVM (non-Android)
  */
 internal fun Project.configureKotlin() {
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_1_8.toString()
+    extensions.configure<KotlinAndroidProjectExtension> {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_1_8
         }
     }
     extensions.configure<KotlinProjectExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
     alias(libs.plugins.binary.compatibility.validator)
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.vanniktech.maven.publish) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }
 
 buildscript {

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -4,6 +4,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
     // Ktlint
     alias(libs.plugins.ktlint)
     // Detekt
@@ -83,9 +84,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
     }
     detekt {
         config.setFrom("${project.rootDir}/config/detekt/detekt.yml")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,9 @@ dataStore = "1.1.1-beta03"
 detekt = "1.23.4"
 dokka = "1.9.20"
 junit = "4.13.2"
-kotlin = "1.9.25"
+kotlin = "2.0.21"
 kotlinCoroutines = "1.7.3"
-ksp = "1.9.25-1.0.20"
+ksp = "2.0.21-1.0.27"
 ktlint = "12.1.0"
 ktx = "1.13.1"
 material = "1.12.0"
@@ -35,7 +35,6 @@ testCoreKtx = "1.6.1"
 turbine = "1.1.0"
 ucrop = "2.2.11"
 mavenPublish = "0.32.0"
-kotlinCompilerExtension = "1.5.15"
 
 [libraries]
 android-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
@@ -83,6 +82,7 @@ ucrop = { group = "com.automattic", name = "ucrop", version.ref = "ucrop" }
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+compose-compiler-gradlePlugin = { group = "org.jetbrains.kotlin.plugin.compose", name = "org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
 vanniktech-maven-publishPlugin = { group = "com.vanniktech.maven.publish", name = "com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublish" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "io.gitlab.arturbosch.detekt.gradle.plugin", version.ref = "detekt" }
 openapi-generator-gradlePlugin = { group = "org.openapitools", name = "openapi-generator-gradle-plugin", version.ref = "openapi" }
@@ -102,6 +102,7 @@ openapi-generator = { id = "org.openapi.generator", version.ref = "openapi" }
 parcelize = { id = "kotlin-parcelize" }
 roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
 vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 # Plugins defined by this project
 gravatar-maven-publish = { id = "gravatar.maven.publish" }

--- a/gravatar-quickeditor/api/gravatar-quickeditor.api
+++ b/gravatar-quickeditor/api/gravatar-quickeditor.api
@@ -39,10 +39,10 @@ public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity$Grava
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public final fun getAuthenticationMethod ()Lcom/gravatar/quickeditor/ui/editor/AuthenticationMethod;
 	public final fun getGravatarQuickEditorParams ()Lcom/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/GravatarQuickEditorActivity$GravatarEditorActivityArguments$Creator : android/os/Parcelable$Creator {
@@ -323,12 +323,12 @@ public final class com/gravatar/quickeditor/ui/editor/AboutEditorConfiguration :
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/util/Set;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFields ()Ljava/util/Set;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AboutEditorConfiguration$Builder {
@@ -362,8 +362,8 @@ public final class com/gravatar/quickeditor/ui/editor/AboutInputField : android/
 	public static final field Companion Lcom/gravatar/quickeditor/ui/editor/AboutInputField$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/editor/AboutInputField;
 	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
-	public fun describeContents ()I
-	public static fun describeContents-impl (Ljava/lang/String;)I
+	public final fun describeContents ()I
+	public static final fun describeContents-impl (Ljava/lang/String;)I
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -386,8 +386,8 @@ public final class com/gravatar/quickeditor/ui/editor/AboutInputField : android/
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-	public static fun writeToParcel-impl (Ljava/lang/String;Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+	public static final fun writeToParcel-impl (Ljava/lang/String;Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AboutInputField$Companion {
@@ -422,12 +422,12 @@ public final class com/gravatar/quickeditor/ui/editor/AuthenticationMethod$Beare
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getToken ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AuthenticationMethod$Bearer$Creator : android/os/Parcelable$Creator {
@@ -442,12 +442,12 @@ public final class com/gravatar/quickeditor/ui/editor/AuthenticationMethod$OAuth
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOAuthParams ()Lcom/gravatar/quickeditor/ui/oauth/OAuthParams;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AuthenticationMethod$OAuth$Creator : android/os/Parcelable$Creator {
@@ -462,14 +462,14 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditor
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public synthetic fun <init> (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Ljava/util/Set;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
 	public final fun getFields ()Ljava/util/Set;
 	public final fun getInitialPage-Fs-4V8w ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Builder {
@@ -499,8 +499,8 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditor
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Page$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Page;
-	public fun describeContents ()I
-	public static fun describeContents-impl (Ljava/lang/String;)I
+	public final fun describeContents ()I
+	public static final fun describeContents-impl (Ljava/lang/String;)I
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -512,8 +512,8 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditor
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-	public static fun writeToParcel-impl (Ljava/lang/String;Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+	public static final fun writeToParcel-impl (Ljava/lang/String;Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration$Page$Companion {
@@ -533,12 +533,12 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration 
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration$Builder {
@@ -566,11 +566,11 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Horizontal;
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Horizontal$Creator : android/os/Parcelable$Creator {
@@ -585,11 +585,11 @@ public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Vertical;
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout$Vertical$Creator : android/os/Parcelable$Creator {
@@ -647,7 +647,7 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams 
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public synthetic fun <init> (Lcom/gravatar/types/Email;Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarPickerContentLayout ()Lcom/gravatar/quickeditor/ui/editor/AvatarPickerContentLayout;
 	public final fun getEmail ()Lcom/gravatar/types/Email;
@@ -655,7 +655,7 @@ public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams 
 	public final fun getUiMode ()Lcom/gravatar/quickeditor/ui/editor/GravatarUiMode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/GravatarQuickEditorParams$Builder {
@@ -705,11 +705,11 @@ public final class com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption : a
 	public static final fun aboutEditor (Lcom/gravatar/quickeditor/ui/editor/AboutEditorConfiguration;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 	public static final fun avatarAndAbout (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerAndAboutEditorConfiguration;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
 	public static final fun avatarPicker (Lcom/gravatar/quickeditor/ui/editor/AvatarPickerConfiguration;)Lcom/gravatar/quickeditor/ui/editor/QuickEditorScopeOption;
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/editor/QuickEditorScopeOption$Companion {
@@ -789,13 +789,13 @@ public final class com/gravatar/quickeditor/ui/oauth/OAuthParams : android/os/Pa
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClientId ()Ljava/lang/String;
 	public final fun getRedirectUri ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/quickeditor/ui/oauth/OAuthParams$Builder {

--- a/gravatar/api/gravatar.api
+++ b/gravatar/api/gravatar.api
@@ -1019,10 +1019,10 @@ public final class com/gravatar/services/ProfileService {
 public final class com/gravatar/types/Email : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public fun describeContents ()I
+	public final fun describeContents ()I
 	public final fun hash ()Lcom/gravatar/types/Hash;
 	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/gravatar/types/Email$Creator : android/os/Parcelable$Creator {

--- a/uitestutils/build.gradle.kts
+++ b/uitestutils/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 
     // Ktlint
     alias(libs.plugins.ktlint)
@@ -28,9 +29,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
     }
     kotlinOptions {
         jvmTarget = "1.8"


### PR DESCRIPTION

### Description

Kotlin bump to 2.0.21, along with an update to the Compose compiler setup, as it changed after Kotlin 2.0. 
`kotlinOptions {` is also deprecated now, so I replaced it with `kotlin { compilerOptions`.

It also looks like the implementation for Parcelize plugin was changed and it now generates final functions - this can be seen in the updated `.api` files. 

### Testing Steps

1. Build the project and perform a smoke test on the demo app.
2. Review