### PR TITLE
Change tonal elevation to deafult (0.dp) of the bottom sheet

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -317,7 +317,6 @@ private fun GravatarModalBottomSheet(
                                         hasFocus = state.hasFocus
                                     }
                                     .fillMaxWidth(),
-                                tonalElevation = 1.dp,
                             ) {
                                 Column(
                                     horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION

### Description

As suggested by Shaun, I'm removing the tonal elevation that adds a blueish tint to the background. 

| Before | After |
|---|---|
| ![Screenshot_20250609_103333](https://github.com/user-attachments/assets/79e23366-e983-4fc2-9f95-29aa8c4db6f6) | ![Screenshot_20250609_103246](https://github.com/user-attachments/assets/5b0a2db2-a90b-453b-8d06-3e6cba234af5) |
| ![Screenshot_20250609_103327](https://github.com/user-attachments/assets/16cad171-0257-4ed3-bc65-f07b3bd4c168) | ![Screenshot_20250609_103258](https://github.com/user-attachments/assets/a2fbe932-d84d-4a07-9c29-0aeae392da09) |

### Testing Steps

Launch the QE in both color themes and confirm the background color.