### PR TITLE
Remove Peek detent from the QuickEditor bottom sheet

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowInsetsControllerCompat
@@ -237,17 +236,6 @@ private fun GravatarModalBottomSheet(
     modalBottomSheetState: ModalBottomSheetState,
     content: @Composable () -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
-    var hasFocus by remember { mutableStateOf(false) }
-
-    LaunchedEffect(hasFocus) {
-        scope.launch {
-            if (hasFocus) {
-                modalBottomSheetState.animateTo(FullyExpanded)
-            }
-        }
-    }
-
     val configuration = Configuration(LocalConfiguration.current).apply {
         uiMode = when (colorScheme) {
             GravatarUiMode.LIGHT -> Configuration.UI_MODE_NIGHT_NO
@@ -308,9 +296,6 @@ private fun GravatarModalBottomSheet(
                             }
                             Surface(
                                 modifier = Modifier
-                                    .onFocusChanged { state ->
-                                        hasFocus = state.hasFocus
-                                    }
                                     .fillMaxWidth(),
                             ) {
                                 Column(

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -38,7 +37,6 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.window.core.layout.WindowHeightSizeClass
 import com.composables.core.ModalBottomSheet
 import com.composables.core.ModalBottomSheetState
 import com.composables.core.ModalSheetProperties
@@ -51,14 +49,11 @@ import com.composables.core.rememberModalBottomSheetState
 import com.composeunstyled.LocalModalWindow
 import com.gravatar.quickeditor.QuickEditorContainer
 import com.gravatar.quickeditor.ui.editor.AuthenticationMethod
-import com.gravatar.quickeditor.ui.editor.AvatarPickerContentLayout
 import com.gravatar.quickeditor.ui.editor.AvatarPickerResult
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorDismissReason
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorPage
 import com.gravatar.quickeditor.ui.editor.GravatarQuickEditorParams
 import com.gravatar.quickeditor.ui.editor.GravatarUiMode
-import com.gravatar.quickeditor.ui.editor.QuickEditorPage
-import com.gravatar.quickeditor.ui.editor.QuickEditorScopeOption
 import com.gravatar.quickeditor.ui.editor.UpdateHandler
 import com.gravatar.ui.GravatarTheme
 import com.gravatar.ui.LocalGravatarTheme
@@ -89,7 +84,7 @@ public fun GravatarQuickEditorBottomSheet(
         authenticationMethod = authenticationMethod,
         updateHandler = updateHandler,
         onDismiss = onDismiss,
-        modalDetents = gravatarQuickEditorParams.scopeOption.modalDetents(),
+        modalDetents = modalDetents(),
     )
 }
 
@@ -125,7 +120,7 @@ public fun GravatarQuickEditorBottomSheet(
             }
         },
         onDismiss = onDismiss,
-        modalDetents = gravatarQuickEditorParams.scopeOption.modalDetents(),
+        modalDetents = modalDetents(),
     )
 }
 
@@ -332,64 +327,14 @@ private fun GravatarModalBottomSheet(
     }
 }
 
-private val peek = SheetDetent(identifier = "peek") { containerHeight, _ ->
-    containerHeight * 0.6f
-}
-
 @Composable
-internal fun QuickEditorScopeOption.modalDetents(): ModalDetents {
-    val windowHeightSizeClass = currentWindowAdaptiveInfo().windowSizeClass.windowHeightSizeClass
-
-    val detents = buildDetentsList()
-    val initialDetent = initialDetent(windowHeightSizeClass)
-
-    return ModalDetents(
-        initialDetent = if (detents.contains(initialDetent)) initialDetent else detents.last(),
-        detents = detents,
-    )
-}
-
-private fun QuickEditorScopeOption.buildDetentsList(): List<SheetDetent> {
-    return when (this.scope) {
-        is QuickEditorScopeOption.Scope.AvatarPickerAndAboutEditor,
-        is QuickEditorScopeOption.Scope.AboutEditor,
-        -> buildList {
-            add(Hidden)
-            add(peek)
-            add(FullyExpanded)
-        }
-
-        is QuickEditorScopeOption.Scope.AvatarPicker -> buildList {
-            add(Hidden)
-            if (avatarPickerContentLayout == AvatarPickerContentLayout.Vertical) {
-                add(peek)
-            }
-            add(FullyExpanded)
-        }
-    }
-}
-
-private fun QuickEditorScopeOption.initialDetent(windowHeightSizeClass: WindowHeightSizeClass): SheetDetent {
-    return if (windowHeightSizeClass == WindowHeightSizeClass.COMPACT) {
-        FullyExpanded
-    } else {
-        when (this.scope) {
-            is QuickEditorScopeOption.Scope.AboutEditor -> peek
-            is QuickEditorScopeOption.Scope.AvatarPickerAndAboutEditor,
-            is QuickEditorScopeOption.Scope.AvatarPicker,
-            -> {
-                if (
-                    this.avatarPickerContentLayout == AvatarPickerContentLayout.Horizontal &&
-                    this.initialPage == QuickEditorPage.AvatarPicker
-                ) {
-                    FullyExpanded
-                } else {
-                    peek
-                }
-            }
-        }
-    }
-}
+internal fun modalDetents(): ModalDetents = ModalDetents(
+    initialDetent = FullyExpanded,
+    detents = buildList {
+        add(Hidden)
+        add(FullyExpanded)
+    },
+)
 
 internal data class ModalDetents(
     val initialDetent: SheetDetent,

--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/extensions/QuickEditorExtensions.kt
@@ -25,7 +25,7 @@ internal fun addQuickEditorToView(
                     authenticationMethod = authenticationMethod,
                     updateHandler = updateHandler,
                     onDismiss = onDismiss,
-                    modalDetents = gravatarQuickEditorParams.scopeOption.modalDetents(),
+                    modalDetents = modalDetents(),
                     onCurrentDetentChanged = {
                         if (it == Hidden) {
                             viewGroup.removeView(this)


### PR DESCRIPTION


### Description

The Peek detent doesn't have much sense in the About Editor, and to stay consistent with behavior in the combined scope and the Avatar only, we are removing the Peek detent completely. This might come back later as a configurable option. 

### Testing Steps
1. Launch QE in different modes and confirm that it always goes to FullyExpanded detent.


cc @pinarol 