### PR TITLE
Set navigation bar padding on the content, not the sheet container

### DIFF
--- a/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
+++ b/gravatar-quickeditor/src/main/java/com/gravatar/quickeditor/ui/editor/bottomsheet/GravatarQuickEditorBottomSheet.kt
@@ -275,17 +275,12 @@ private fun GravatarModalBottomSheet(
                                 },
                             ),
                     ) {
-                        val paddingValues = WindowInsets.navigationBars
-                            .only(WindowInsetsSides.Vertical)
-                            .asPaddingValues()
                         Sheet(
                             modifier = Modifier
                                 .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
                                 .background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
                                 .widthIn(max = 640.dp)
-                                .fillMaxWidth()
-                                .padding(paddingValues)
-                                .consumeWindowInsets(paddingValues),
+                                .fillMaxWidth(),
                         ) {
                             val window = LocalModalWindow.current
                             val isDarkTheme = isSystemInDarkTheme()
@@ -294,12 +289,19 @@ private fun GravatarModalBottomSheet(
                                 WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
                                     !isDarkTheme
                             }
+
                             Surface(
                                 modifier = Modifier
                                     .fillMaxWidth(),
                             ) {
+                                val paddingValues = WindowInsets.navigationBars
+                                    .only(WindowInsetsSides.Vertical)
+                                    .asPaddingValues()
                                 Column(
                                     horizontalAlignment = Alignment.CenterHorizontally,
+                                    modifier = Modifier
+                                        .padding(paddingValues)
+                                        .consumeWindowInsets(paddingValues),
                                 ) {
                                     content()
                                 }


### PR DESCRIPTION


### Description

I've noticed that the background at the bottom of the sheet has a different color. This was introduced with the removal of the `tonalElevation` in one of the recent PRs.

To fix this, I moved the `statusBar` padding to the content so that the sheet container has the same background all the way down. 

| Before | After |
|---|---|
| ![Screenshot_20250611_091729](https://github.com/user-attachments/assets/a9723ac1-4aea-4a10-a648-97eb446a86b6) | ![Screenshot_20250611_091312](https://github.com/user-attachments/assets/62c5e487-0efa-4c1c-8225-ee7f87e57db0) |

### Testing Steps

1. Launch the QE.
2. Confirm the sheet container has the same background from top to bottom.