### PR TITLE
Update outdated GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
           ref: 'docs'
           path: 'docs'
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   dangermattic:
     if: ${{ (github.event.pull_request.draft == false) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.1.2
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1
     with:
       org-slug: "automattic"
       pipeline-slug: "gravatar-sdk-android"

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/actions/dependency-submission@v3
+        uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
Fixes AINFRA-2297

## Summary
- Upgrade `actions/setup-java` from v3 to v4
- Upgrade `gradle/actions/dependency-submission` from v3 to v4
- Update dangermattic reusable workflows to `@v1`

## Test plan
- [ ] Verify docs generation workflow runs on next tag push
- [ ] Verify dependency submission workflow runs on next push to trunk
- [ ] Verify Danger workflow runs on next PR

🤖 Generated with [Claude Code](https://claude.ai/code)