### PR TITLE
Pin nokogiri >= 1.19.3 (GHSA-c4rq-3m3g-8wgx)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,8 @@ gem 'rubocop', '~> 1.65'
 # Security: https://github.com/lostisland/faraday/pull/1665
 # Faraday 2.0 is not compatible with Fastlane
 gem 'faraday', '~> 1.10', '>= 1.10.5'
+
+# Pinned to pull in the fix for GHSA-c4rq-3m3g-8wgx (CSS selector ReDoS).
+# Drop once `fastlane-plugin-wpmreleasetoolkit` moves to >= 14.4.1, whose
+# gemspec carries this floor transitively.
+gem 'nokogiri', '>= 1.19.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
     nap (1.1.0)
     naturally (2.3.0)
     nkf (0.2.0)
-    nokogiri (1.19.1)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (6.1.1)
@@ -357,6 +357,7 @@ DEPENDENCIES
   faraday (~> 1.10, >= 1.10.5)
   fastlane (~> 2.222)
   fastlane-plugin-wpmreleasetoolkit (~> 13.0)
+  nokogiri (>= 1.19.3)
   rubocop (~> 1.65)
 
 BUNDLED WITH


### PR DESCRIPTION
<!-- blue -->
> [!NOTE]  
> Closed in favor of #683 

## Summary

Adds `gem 'nokogiri', '>= 1.19.3'` to `Gemfile` to pull in the fix for [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) — high-severity ReDoS in Nokogiri's CSS selector tokenizer (vulnerable `< 1.19.3`).

This repo is on `fastlane-plugin-wpmreleasetoolkit ~> 13.0`, which predates the toolkit's own `nokogiri >= 1.19.3` floor (added in 14.4.1). The explicit pin closes the gap without requiring a release-toolkit major bump.

Generated as part of the [nokogiri 1.19.3 Orchard campaign](https://github.a8c.com/mokagio/swiftlint-adoption-orchard-campaign/tree/main/nokogiri-1.19.3-campaign).

## Testing

`bundle install`. `Gemfile.lock` resolves `nokogiri` to `1.19.3`.

---

*Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval.*