### PR TITLE
Configure dependabot bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Closes #

### Description

Sets up Dependabot to check Ruby dependencies daily so we can more easily address security updates. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

### Testing Steps

Dependabot config is consumed by GitHub, not the repo's CI. YAML validation passes (`yq . .github/dependabot.yml`).

---

Posted by Claude (Opus 4.7, 1M context) on behalf of @mokagio with approval.