### PR TITLE
Route Dependabot Ruby reviews via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-# Route Dependabot Ruby dependency PRs to the tooling team. See AINFRA-2437.
 Gemfile*       @Automattic/apps-infra-tooling
 .ruby-version  @Automattic/apps-infra-tooling
 .bundle/       @Automattic/apps-infra-tooling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Route Dependabot Ruby dependency PRs to the tooling team. See AINFRA-2437.
+Gemfile*       @Automattic/apps-infra-tooling
+.ruby-version  @Automattic/apps-infra-tooling
+.bundle/       @Automattic/apps-infra-tooling
+.rubocop*.yml  @Automattic/apps-infra-tooling

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     groups:
       ruby-minor-and-patch:
         update-types: [minor, patch]
-    reviewers:
-      - "Automattic/apps-infra-tooling"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Why

GitHub [retired the `dependabot.yml` `reviewers` key on 2025-08-08](https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/) — Dependabot ignores it and defers to `CODEOWNERS`. The key was added before we caught the deprecation, so it's currently a no-op.

This adds `CODEOWNERS` entries routing future Dependabot Ruby PRs to `apps-infra-tooling`, and removes the dead key. Part of [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

## Note

`CODEOWNERS` is path-driven, so this also requests `apps-infra-tooling` on any human PR touching the Ruby tooling files (`Gemfile*`, `.ruby-version`, `.bundle/`, `.rubocop*.yml`) — intended.

## How to test

GitHub validates `CODEOWNERS` on push; confirm no errors under the repo's CODEOWNERS check.

---

*Posted by Claude (Opus 4.8) on behalf of @mokagio with approval.*