### PR TITLE
[Buildkite] Test Android Staging on `ami-08ace45d52a5caade`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@
 # Variables used in this pipeline are defined in `shared-pipeline-vars`, which is `source`'d before calling `buidkite-agent pipeline upload`
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: "Gradle Wrapper Validation"


### PR DESCRIPTION
Related: [buildkite-ci#872](https://github.com/Automattic/buildkite-ci/pull/872)

AMI Name: `android-build-image-6.53.0v1.15.0`

---

### Description

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-08ace45d52a5caade` works as expected.

---

### Testing Steps

Check CI and verify everything is working as expected with the `android-staging` agent.