### PR TITLE
Set up `a8c-secrets` (identities only)

### DIFF
--- a/.a8c-secrets/keys.pub
+++ b/.a8c-secrets/keys.pub
@@ -1,0 +1,4 @@
+# dev
+age1pnyg4apd3peekxmu6lkgd9up4j9q02c9stt5da8ml629t5zcgqusxttahe
+# ci
+age1mzs8svvsf5npsdyetcrqclphudedgx8asfw78636nlxj8q4xqpvqq6txwx

--- a/.a8c-secrets/repo-id
+++ b/.a8c-secrets/repo-id
@@ -1,0 +1,1 @@
+gravatar-sdk-android@github.com@automattic

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@ Gemfile*       @Automattic/apps-infra-tooling
 .ruby-version  @Automattic/apps-infra-tooling
 .bundle/       @Automattic/apps-infra-tooling
 .rubocop*.yml  @Automattic/apps-infra-tooling
+.a8c-secrets/  @Automattic/apps-infra-tooling


### PR DESCRIPTION
Won't be used just yet. Just getting ahead with the work... See https://linear.app/a8c/issue/AINFRA-2688